### PR TITLE
Make tests independent of table "temp"

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -18,7 +18,10 @@ func TestExec(t *testing.T) {
 	}
 	defer db.Close()
 
-	db.Exec("DELETE FROM temp")
+	_, err = db.Exec("CREATE TEMP TABLE temp (a int)")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	r, err := db.Exec("INSERT INTO temp VALUES (1)")
 	if err != nil {


### PR DESCRIPTION
Previously, the test case would just hang.  That's a very interesting
behavior if one neglects to check the error and abort, regardless...

Signed-off-by: Dan Farina drfarina@acm.org
