### PR TITLE
Replace nearly all literal codes with symbols

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -1,0 +1,71 @@
+//
+// FEBE Message type constants
+//
+// All the constants in this file have a special naming convention:
+// "(msg)(NameInManual)(characterCode)".  This results in long and
+// awkward constant names, but also makes it easy to determine what
+// the author's intent is quickly in code (consider that both
+// msgDescribeD and msgDataRowD appear on the wire as 'D') as well as
+// debugging against captured wire protocol traffic (where one will
+// only see 'D', but has a sense what state the protocol is in).
+//
+package pq
+
+type pqMsgType byte
+
+const (
+	// Special sub-message coding for Close and Describe
+	msgIsPortalP    = 'P'
+	msgIsStatementS = 'S'
+
+	// Sub-message character coding that is part of ReadyForQuery
+	msgInIdleI        = 'I'
+	msgInTransactionT = 'T'
+	msgInErrorE       = 'E'
+
+	// Message tags
+	msgAuthenticationOkR                = 'R'
+	msgAuthenticationCleartextPasswordR = 'R'
+	msgAuthenticationMD5PasswordR       = 'R'
+	msgAuthenticationSCMCredentialR     = 'R'
+	msgAuthenticationGSSR               = 'R'
+	msgAuthenticationSSPIR              = 'R'
+	msgAuthenticationGSSContinueR       = 'R'
+	msgBackendKeyDataK                  = 'K'
+	msgBindB                            = 'B'
+	msgBindComplete2                    = '2'
+	// CancelRequest, not seen here, is formatted differently
+	msgCloseC                = 'C'
+	msgCloseComplete3        = '3'
+	msgCommandCompleteC      = 'C'
+	msgCopyDatad             = 'd'
+	msgCopyDonec             = 'c'
+	msgCopyFailf             = 'f'
+	msgCopyInResponseG       = 'G'
+	msgCopyOutResponseH      = 'H'
+	msgCopyBothResponseW     = 'W'
+	msgDataRowD              = 'D'
+	msgDescribeD             = 'D'
+	msgEmptyQueryResponseI   = 'I'
+	msgErrorResponseE        = 'E'
+	msgExecuteE              = 'E'
+	msgFlushH                = 'H'
+	msgFunctionCallF         = 'F'
+	msgFunctionCallResponseV = 'V'
+	msgNoDatan               = 'n'
+	msgNoticeResponseN       = 'N'
+	msgNotificationResponseA = 'A'
+	msgParameterDescriptiont = 't'
+	msgParameterStatusS      = 'S'
+	msgParseP                = 'P'
+	msgParseComplete1        = '1'
+	msgPasswordMessagep      = 'p'
+	msgPortalSuspendeds      = 's'
+	msgQueryQ                = 'Q'
+	msgReadyForQueryZ        = 'Z'
+	msgRowDescriptionT       = 'T'
+	// SSLRequest and StartupMessage are not seen here, and are
+	// formatted differently
+	msgSyncS      = 'S'
+	msgTerminateX = 'X'
+)


### PR DESCRIPTION
To provide better mnemonics and searching for the message in question,
and cross referencing with the "Message Flow" chapter of the
PostgreSQL manual.

This is not a completely mechanical replacement because some message
type characters are reused in various protocol states, and in those
cases the correct code name is to be used.  These names and order of
messages in "messages.go" are copied directly from the PostgreSQL 9.1
manual.

Signed-off-by: Dan Farina drfarina@acm.org
