### PR TITLE
Return booleans as bool, not as []byte.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -50,6 +50,8 @@ func decode(s []byte, typ int) interface{} {
 		return mustParse("15:04:05-07", s)
 	case t_date:
 		return mustParse("2006-01-02", s)
+	case t_bool:
+		return s[0] == 't';
 	}
 
 	return s


### PR DESCRIPTION
This is helpful in situations where "f" might by interpreted as true, such as in the template package.
