### PR TITLE
Discard notice messages

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -156,6 +156,8 @@ func (cn *conn) simpleQuery(q string) (res driver.Result, err error) {
 			return
 		case 'E':
 			err = parseError(r)
+		case 'N':
+			// ignore
 		case 'T':
 			// ignore
 		default:


### PR DESCRIPTION
When running a simple query like 'DROP TABLE IF EXISTS foo;', Postgres
will send a warning if "foo" does not exist. This patch makes it ignore
the warning.

It is not well tested, also I am unsure whether or not more data needs
to be consumed. However, instead of putting into this specific issue,
the following needs to be considered (from
<http://www.postgresql.org/docs/9.1/static/protocol-flow.html#PROTOCOL-ASYNC?):

  Note: At present, NotificationResponse can only be sent outside a
  transaction, and thus it will not occur in the middle of a
  command-response series, though it might occur just before
  ReadyForQuery. It is unwise to design frontend logic that assumes
  that, however. Good practice is to be able to accept
  NotificationResponse at any point in the protocol.
