### PR TITLE
Fix TLS/SSL while keeping bufio

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -73,8 +73,9 @@ func Open(name string) (_ driver.Conn, err error) {
 		return nil, err
 	}
 
-	cn := &conn{c: c, buf: bufio.NewReader(c)}
+	cn := &conn{c: c}
 	cn.ssl(o)
+	cn.buf = bufio.NewReader(cn.c)
 	cn.startup(o)
 	return cn, nil
 }


### PR DESCRIPTION
This should restore the performance gains from a6c22b1152ab04b5ecab9eb123c89491bc81183a without breaking completely under SSL. I suspect this also solves #35.

The relevant bit of a6c22b1152ab04b5ecab9eb123c89491bc81183a was this in Open:

``` go
cn := &conn{c: c, buf: bufio.NewReader(c)}
cn.ssl(o)
```

where the underlying net.Conn gets wrapped in a buffered reader. Unfortunately I completely missed that cn.ssl _also_ wrapped the underlying net.Conn in a tls.Client (startup would therefore hang, because it was trying to read from the bufio.Reader which was still operating on the unencrypted net.Conn, whereas Postgres was trying to send data over SSL). The fix is thankfully quite easy; those two lines instead become

``` go
cn := &conn{c: c}
cn.ssl(o)
cn.buf = bufio.NewReader(cn.c)
```

In the non-SSL case, this works exactly like it did before; in the SSL case, cn.buf is now a bufio.Reader wrapping a tls.Client wrapping the net.Conn.
