### PR TITLE
Expose pg errors on Open()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -39,6 +39,7 @@ type conn struct {
 
 func Open(name string) (_ driver.Conn, err error) {
 	defer errRecover(&err)
+	defer errRecoverWithPGReason(&err)
 
 	o := make(Values)
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -254,7 +254,7 @@ func TestPGError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	if err != driver.ErrBadConn {
+	if err, ok := err.(PGError); !ok {
 		t.Fatalf("expected a PGError, got: %v", err)
 	}
 }

--- a/error.go
+++ b/error.go
@@ -66,6 +66,20 @@ func (err *SimplePGError) Error() string {
 	return "pq: " + err.Get('M')
 }
 
+func errRecoverWithPGReason(err *error) {
+	e := recover()
+	switch v := e.(type) {
+	case nil:
+		// Do nothing
+	case *pgError:
+		// Return a SimplePGError in place
+		*err = &SimplePGError{*v}
+	default:
+		// Otherwise re-panic
+		panic(e)
+	}
+}
+
 func errRecover(err *error) {
 	e := recover()
 	switch v := e.(type) {


### PR DESCRIPTION
Here is a more concise version of my other pull request.

After reading the discussion here at https://codereview.appspot.com/5785043/ I realize this is a slightly more general issue.
That said, these changes provide a straightforward method of exposing at least Open() errors.

In the case of other errors, maybe the conn struct can have a "last error" field?
