### PR TITLE
Set extra_float_digits to max for float fidelity

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -53,6 +53,9 @@ func Open(name string) (_ driver.Conn, err error) {
 	o.Set("host", "localhost")
 	o.Set("port", "5432")
 
+        // Set the "lossless floating point" flag
+        o.Set("extra_float_digits", "3")
+
 	// Default the username, but ignore errors, because a user
 	// passed in via environment variable or connection string
 	// would be okay.  This can result in connections failing


### PR DESCRIPTION
Without this setting, it's easy to lose fidelity when round-tripping some floating point values.

By the way, if you care more about server versions `8.4` and older than about `float4`, a value of 2 will suffice (2 was the max until `9.0`, but it is not enough for some `float4` values). Of course, the right thing to do is to check this based on server version, but that's uglier.

I haven't found a great Postgres discussion of this, but [this message](http://archives.postgresql.org/pgsql-bugs/2009-09/msg00171.php) prompted the bump from 2 to 3 and the JDBC driver [also sets extra_float_digits](https://github.com/pgjdbc/pgjdbc/blob/master/org/postgresql/core/v3/ConnectionFactoryImpl.java#L636).
