### PR TITLE
Fix Go Get

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -3,7 +3,7 @@ package pq
 import (
 	"bytes"
 	"encoding/binary"
-	"pq/oid"
+	"github.com/lib/pq/oid"
 )
 
 type readBuf []byte

--- a/conn.go
+++ b/conn.go
@@ -9,12 +9,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/lib/pq/oid"
 	"io"
 	"net"
 	"os"
 	"os/user"
 	"path"
-	"pq/oid"
 	"strconv"
 	"strings"
 )

--- a/encode.go
+++ b/encode.go
@@ -4,7 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
-	"pq/oid"
+	"github.com/lib/pq/oid"
 	"strconv"
 	"time"
 )


### PR DESCRIPTION
When you pulled out oid into a separate package, it broke go get github.com/lib/pq. The import path should not be pq/oid, but rather github.com/lib/pq following the "Remote import path syntax" ( http://golang.org/cmd/go/ )
