### PR TITLE
Keep pq go-gettable

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -3,7 +3,7 @@ package pq
 import (
 	"bytes"
 	"encoding/binary"
-	"pq/oid"
+	"github.com/lib/pq/oid"
 )
 
 type readBuf []byte

--- a/conn.go
+++ b/conn.go
@@ -9,12 +9,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/lib/pq/oid"
 	"io"
 	"net"
 	"os"
 	"os/user"
 	"path"
-	"pq/oid"
 	"strconv"
 	"strings"
 )

--- a/encode.go
+++ b/encode.go
@@ -4,7 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
-	"pq/oid"
+	"github.com/lib/pq/oid"
 	"strconv"
 	"time"
 )


### PR DESCRIPTION
The commit makes pq go-gettable again by adjusting import from "pq/oid" to "github.com/lib/pq/oid".
