### PR TITLE
bug #83

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -93,7 +93,13 @@ func mustParse(f string, typ oid.Oid, s []byte) time.Time {
 	// check for a 30-minute-offset timezone
 	if (typ == oid.T_timestamptz || typ == oid.T_timetz) &&
 		str[len(str)-3] == ':' {
-		f += ":00"
+		f += ":04"
+
+		// check for a timezone before 1895 
+		// eg: (0001-01-01 00:34:08+00:34:08)
+		if len(str) > len(f) {
+			f += ":05"
+		}
 	}
 	t, err := time.Parse(f, str)
 	if err != nil {


### PR DESCRIPTION
In some cases (described in bug #83), PostgreSQL saves time zones with minutes and seconds. These cases was not being handled in the function mustParse.

To reproduce this behavior:
create table time_example (x timestamp with time zone);
insert into time_example (x) VALUES ('0001-01-01 00:00:00');
