### PR TITLE
Error  "statement expects 0 inputs; got 1" on Prepare() after Tx rollback

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -469,10 +469,9 @@ FROM (VALUES (0::integer, NULL::text), (1, 'test string')) AS t;`)
 // Open transaction, issue INSERT query inside transaction, rollback
 // transaction, issue SELECT query to same db used to create the tx.  No rows
 // should be returned.
-func TestRollback(t *testing.T) {
+func TestRollbackThenQuery(t *testing.T) {
 	db := openTestConn(t)
 	defer db.Close()
-
 	_, err := db.Exec("CREATE TEMP TABLE temp (a int)")
 	if err != nil {
 		t.Fatal(err)
@@ -497,6 +496,45 @@ func TestRollback(t *testing.T) {
 	}
 	// Next() returns false if query returned no rows.
 	if r.Next() {
+		t.Fatal("Transaction rollback failed")
+	}
+}
+
+// Open transaction, issue INSERT query inside transaction, rollback
+// transaction, create prepared statement for SELECT query using same db object
+// used to create the tx.
+func TestRollbackThenPrepare(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+	_, err := db.Exec("CREATE TEMP TABLE temp (a int)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlInsert := "INSERT INTO temp VALUES (1)"
+	sqlSelectLimit := "SELECT * FROM temp LIMIT $1"
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tx.Query(sqlInsert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tx.Rollback()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmt, err := db.Prepare(sqlSelectLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []int{1}
+	rows, err := stmt.Query(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Next() returns false if query returned no rows.
+	if rows.Next() {
 		t.Fatal("Transaction rollback failed")
 	}
 }


### PR DESCRIPTION
Found another error in transaction rollback handling, similar to #89.  The error occurs when one begins a transaction, rolls back the transaction, then tries to create a prepared statement on the same `DB` object.  Regardless of how many arguments a given statement requires, the call to `Prepare()` will fail with an error complaining statement expects zero inputs but got _n_, where _n_ is the number of arguments provided.
# Test Case

This pull request includes a [test case](https://github.com/jmcvetta/pq/pull/new/prep_stmt_input_cnt#L0R503) that reliably reproduces the bug.  
# Impact

This bug is  blocking development of PostgreSQL dialect of the `qbs` ORM: coocood/qbs#11
