### PR TITLE
Ignore data rows for Exec queries

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -159,7 +159,7 @@ func (cn *conn) simpleQuery(q string) (res driver.Result, err error) {
 			return
 		case 'E':
 			err = parseError(r)
-		case 'T', 'N', 'S':
+		case 'T', 'N', 'S', 'D':
 			// ignore
 		default:
 			errorf("unknown response for simple query: %q", t)


### PR DESCRIPTION
The wording in the interface docs ("executes a query without returning
any rows") suggests that rows are ignored, not that the query must not
return any rows. This change supports ignoring data rows.
