### PR TITLE
Use scratch buffer instead of allocating in lots of places

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -48,12 +48,6 @@ func (b *readBuf) byte() byte {
 
 type writeBuf []byte
 
-func newWriteBuf(c byte) *writeBuf {
-	b := make(writeBuf, 5)
-	b[0] = c
-	return &b
-}
-
 func (b *writeBuf) int32(n int) {
 	x := make([]byte, 4)
 	binary.BigEndian.PutUint32(x, uint32(n))

--- a/conn.go
+++ b/conn.go
@@ -35,9 +35,16 @@ func init() {
 }
 
 type conn struct {
-	c     net.Conn
-	buf   *bufio.Reader
-	namei int
+	c       net.Conn
+	buf     *bufio.Reader
+	namei   int
+	scratch [512]byte
+}
+
+func (c *conn) writeBuf(b byte) *writeBuf {
+	c.scratch[0] = b
+	w := writeBuf(c.scratch[:5])
+	return &w
 }
 
 func Open(name string) (_ driver.Conn, err error) {
@@ -148,7 +155,7 @@ func (cn *conn) gname() string {
 func (cn *conn) simpleQuery(q string) (res driver.Result, err error) {
 	defer errRecover(&err)
 
-	b := newWriteBuf('Q')
+	b := cn.writeBuf('Q')
 	b.string(q)
 	cn.send(b)
 
@@ -176,18 +183,18 @@ func (cn *conn) prepareTo(q, stmtName string) (_ driver.Stmt, err error) {
 
 	st := &stmt{cn: cn, name: stmtName, query: q}
 
-	b := newWriteBuf('P')
+	b := cn.writeBuf('P')
 	b.string(st.name)
 	b.string(q)
 	b.int16(0)
 	cn.send(b)
 
-	b = newWriteBuf('D')
+	b = cn.writeBuf('D')
 	b.byte('S')
 	b.string(st.name)
 	cn.send(b)
 
-	cn.send(newWriteBuf('S'))
+	cn.send(cn.writeBuf('S'))
 
 	for {
 		t, r := cn.recv1()
@@ -233,7 +240,7 @@ func (cn *conn) Prepare(q string) (driver.Stmt, error) {
 
 func (cn *conn) Close() (err error) {
 	defer errRecover(&err)
-	cn.send(newWriteBuf('X'))
+	cn.send(cn.writeBuf('X'))
 
 	return cn.c.Close()
 }
@@ -296,20 +303,27 @@ func (cn *conn) recv() (t byte, r *readBuf) {
 }
 
 func (cn *conn) recv1() (byte, *readBuf) {
-	x := make([]byte, 5)
+	x := cn.scratch[:5]
 	_, err := io.ReadFull(cn.buf, x)
 	if err != nil {
 		panic(err)
 	}
+	c := x[0]
 
 	b := readBuf(x[1:])
-	y := make([]byte, b.int32()-4)
+	n := b.int32() - 4
+	var y []byte
+	if n <= len(cn.scratch) {
+		y = cn.scratch[:n]
+	} else {
+		y = make([]byte, n)
+	}
 	_, err = io.ReadFull(cn.buf, y)
 	if err != nil {
 		panic(err)
 	}
 
-	return x[0], (*readBuf)(&y)
+	return c, (*readBuf)(&y)
 }
 
 func (cn *conn) ssl(o Values) {
@@ -325,11 +339,11 @@ func (cn *conn) ssl(o Values) {
 		errorf(`unsupported sslmode %q; only "require" (default), "verify-full", and "disable" supported`, mode)
 	}
 
-	w := newWriteBuf(0)
+	w := cn.writeBuf(0)
 	w.int32(80877103)
 	cn.send(w)
 
-	b := make([]byte, 1)
+	b := cn.scratch[:1]
 	_, err := io.ReadFull(cn.c, b)
 	if err != nil {
 		panic(err)
@@ -343,7 +357,7 @@ func (cn *conn) ssl(o Values) {
 }
 
 func (cn *conn) startup(o Values) {
-	w := newWriteBuf(0)
+	w := cn.writeBuf(0)
 	w.int32(196608)
 	w.string("user")
 	w.string(o.Get("user"))
@@ -371,7 +385,7 @@ func (cn *conn) auth(r *readBuf, o Values) {
 	case 0:
 		// OK
 	case 3:
-		w := newWriteBuf('p')
+		w := cn.writeBuf('p')
 		w.string(o.Get("password"))
 		cn.send(w)
 
@@ -385,7 +399,7 @@ func (cn *conn) auth(r *readBuf, o Values) {
 		}
 	case 5:
 		s := string(r.next(4))
-		w := newWriteBuf('p')
+		w := cn.writeBuf('p')
 		w.string("md5" + md5s(md5s(o.Get("password")+o.Get("user"))+s))
 		cn.send(w)
 
@@ -419,12 +433,12 @@ func (st *stmt) Close() (err error) {
 
 	defer errRecover(&err)
 
-	w := newWriteBuf('C')
+	w := st.cn.writeBuf('C')
 	w.byte('S')
 	w.string(st.name)
 	st.cn.send(w)
 
-	st.cn.send(newWriteBuf('S'))
+	st.cn.send(st.cn.writeBuf('S'))
 
 	t, _ := st.cn.recv()
 	if t != '3' {
@@ -475,7 +489,7 @@ func (st *stmt) Exec(v []driver.Value) (res driver.Result, err error) {
 }
 
 func (st *stmt) exec(v []driver.Value) {
-	w := newWriteBuf('B')
+	w := st.cn.writeBuf('B')
 	w.string("")
 	w.string(st.name)
 	w.int16(0)
@@ -492,12 +506,12 @@ func (st *stmt) exec(v []driver.Value) {
 	w.int16(0)
 	st.cn.send(w)
 
-	w = newWriteBuf('E')
+	w = st.cn.writeBuf('E')
 	w.string("")
 	w.int32(0)
 	st.cn.send(w)
 
-	st.cn.send(newWriteBuf('S'))
+	st.cn.send(st.cn.writeBuf('S'))
 
 	var err error
 	for {


### PR DESCRIPTION
The size of the buffer is fairly arbitrary. I'm open to suggestions for making it larger or smaller.

Improvements:

benchmark                            old ns/op    new ns/op    delta
BenchmarkSelectString                   327049       308282   -5.74%
BenchmarkSelectSeries                   818056       727728  -11.04%
BenchmarkMockSelectString                 8883         5910  -33.47%
BenchmarkMockSelectSeries                67110        49027  -26.95%
BenchmarkPreparedSelectString           113551       116031   +2.18%
BenchmarkPreparedSelectSeries           391017       332082  -15.07%
BenchmarkMockPreparedSelectString         3467         2392  -31.01%
BenchmarkMockPreparedSelectSeries        61802        45087  -27.05%

(The slight regression on BenchmarkPreparedSelectString is probably just noise.)
