### PR TITLE
Create a parser for Arrays, and wire up decode to use it for 1d arrays.

### DIFF
--- a/arrays/decode.go
+++ b/arrays/decode.go
@@ -1,0 +1,632 @@
+// Parses PG Arrays into Go arrays
+
+package arrays
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+var byteSliceType = reflect.TypeOf([]byte(nil))
+
+// Unmarshal parses the PG Array data and stores the result
+// in the value pointed to by v.
+//
+// Heavily lifted from the Go JSON decoder. Main difference is
+// PG Arrays can contain unquoted strings if they're string arrays
+// and the strings don't have whitespace or special characters.
+func Unmarshal(data []byte, v interface{}) error {
+	var d decodeState
+	d.init(data)
+	return d.unmarshal(v)
+}
+
+// An UnmarshalTypeError describes a value that was
+// not appropriate for a value of a specific Go type.
+type UnmarshalTypeError struct {
+	Value string       // description of value - "bool", "array", "number -5"
+	Type  reflect.Type // type of Go value it could not be assigned to
+}
+
+func (e *UnmarshalTypeError) Error() string {
+	return "cannot unmarshal " + e.Value + " into Go value of type " + e.Type.String()
+}
+
+// An InvalidUnmarshalError describes an invalid argument passed to Unmarshal.
+// (The argument to Unmarshal must be a non-nil pointer.)
+type InvalidUnmarshalError struct {
+	Type reflect.Type
+}
+
+func (e *InvalidUnmarshalError) Error() string {
+	if e.Type == nil {
+		return "Unmarshal(nil)"
+	}
+
+	if e.Type.Kind() != reflect.Ptr {
+		return "Unmarshal(non-pointer " + e.Type.String() + ")"
+	}
+	return "Unmarshal(nil " + e.Type.String() + ")"
+}
+
+func (d *decodeState) unmarshal(v interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(runtime.Error); ok {
+				panic(r)
+			}
+			err = r.(error)
+		}
+	}()
+
+	rv := reflect.ValueOf(v)
+	if (rv.Kind() != reflect.Ptr) || rv.IsNil() {
+		return &InvalidUnmarshalError{reflect.TypeOf(v)}
+	}
+
+	d.scan.reset()
+	// We decode rv not rv.Elem because the Unmarshaler interface
+	// test must be applied at the top level of the value.
+	d.value(rv)
+	return d.savedError
+}
+
+// decodeState represents the state while decoding an array value.
+type decodeState struct {
+	data       []byte
+	off        int // read offset in data
+	scan       scanner
+	nextscan   scanner // for calls to nextValue
+	savedError error
+	tempstr    string // scratch space to avoid some allocations
+}
+
+// errPhase is used for errors that should not happen unless
+// there is a bug in the decoder or something is editing
+// the data slice while the decoder executes.
+var errPhase = errors.New("decoder out of sync - data changing underfoot?")
+
+func (d *decodeState) init(data []byte) *decodeState {
+	d.data = data
+	d.off = 0
+	d.savedError = nil
+	return d
+}
+
+// error aborts the decoding by panicking with err.
+func (d *decodeState) error(err error) {
+	panic(err)
+}
+
+// saveError saves the first err it is called with,
+// for reporting at the end of the unmarshal.
+func (d *decodeState) saveError(err error) {
+	if d.savedError == nil {
+		d.savedError = err
+	}
+}
+
+// next cuts off and returns the next full value in d.data[d.off:].
+// The next value is known to be an object or array, not a literal.
+func (d *decodeState) next() []byte {
+	// c := d.data[d.off]
+	item, rest, err := nextValue(d.data[d.off:], &d.nextscan)
+	if err != nil {
+		d.error(err)
+	}
+	d.off = len(d.data) - len(rest)
+
+	return item
+}
+
+// scanWhile processes bytes in d.data[d.off:] until it
+// receives a scan code not equal to op.
+// It updates d.off and returns the new scan code.
+func (d *decodeState) scanWhile(op opcode) opcode {
+	var newOp opcode
+	for {
+		if d.off >= len(d.data) {
+			newOp = d.scan.eof()
+			d.off = len(d.data) + 1 // mark processed EOF with len+1
+		} else {
+			c := int(d.data[d.off])
+			d.off++
+			newOp = d.scan.step(&d.scan, c)
+		}
+		if newOp != op {
+			break
+		}
+	}
+	return newOp
+}
+
+// value decodes a value from d.data[d.off:] into the value.
+// it updates d.off to point past the decoded value.
+func (d *decodeState) value(v reflect.Value) {
+	switch op := d.scanWhile(scanSkipSpace); op {
+	default:
+		d.error(errPhase)
+
+	case scanBeginArray:
+		d.array(v)
+
+	case scanBeginLiteral:
+		d.literal(v)
+	}
+}
+
+// indirect walks down v allocating pointers as needed,
+// until it gets to a non-pointer.
+// if decodingNull is true, indirect stops at the last pointer so it can be set to nil.
+func (d *decodeState) indirect(v reflect.Value, decodingNull bool) reflect.Value {
+	// If v is a named type and is addressable,
+	// start with its address, so that if the type has pointer methods,
+	// we find them.
+	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+		v = v.Addr()
+	}
+	for {
+		// Load value from interface, but only if the result will be
+		// usefully addressable.
+		if v.Kind() == reflect.Interface && !v.IsNil() {
+			e := v.Elem()
+			if e.Kind() == reflect.Ptr && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Ptr) {
+				v = e
+				continue
+			}
+		}
+
+		if v.Kind() != reflect.Ptr {
+			break
+		}
+
+		if v.Elem().Kind() != reflect.Ptr && decodingNull && v.CanSet() {
+			break
+		}
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		v = v.Elem()
+	}
+	return v
+}
+
+// array consumes an array from d.data[d.off-1:], decoding into the value v.
+// the first byte of the array ('{') has been read already.
+func (d *decodeState) array(v reflect.Value) {
+	v = d.indirect(v, false)
+
+	// Check type of target.
+	switch v.Kind() {
+	case reflect.Interface:
+		if v.NumMethod() == 0 {
+			// Decoding into nil interface?  Switch to non-reflect code.
+			v.Set(reflect.ValueOf(d.arrayInterface()))
+			return
+		}
+		// Otherwise it's invalid.
+		fallthrough
+	default:
+		d.saveError(&UnmarshalTypeError{"array", v.Type()})
+		d.off--
+		d.next()
+		return
+	case reflect.Array:
+	case reflect.Slice:
+		break
+	}
+
+	i := 0
+	for {
+		// Look ahead for } - can only happen on first iteration.
+		op := d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+
+		// Back up so d.value can have the byte we just read.
+		d.off--
+		d.scan.undo(op)
+
+		// Get element of array, growing if necessary.
+		if v.Kind() == reflect.Slice {
+			// Grow slice if necessary
+			if i >= v.Cap() {
+				newcap := v.Cap() + v.Cap()/2
+				if newcap < 4 {
+					newcap = 4
+				}
+				newv := reflect.MakeSlice(v.Type(), v.Len(), newcap)
+				reflect.Copy(newv, v)
+				v.Set(newv)
+			}
+			if i >= v.Len() {
+				v.SetLen(i + 1)
+			}
+		}
+
+		if i < v.Len() {
+			// Decode into element.
+			d.value(v.Index(i))
+		} else {
+			// Ran out of fixed array: skip.
+			d.value(reflect.Value{})
+		}
+		i++
+
+		// Next token must be , or }.
+		op = d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+		if op != scanArrayValue {
+			d.error(errPhase)
+		}
+	}
+
+	if i < v.Len() {
+		if v.Kind() == reflect.Array {
+			// Array.  Zero the rest.
+			z := reflect.Zero(v.Type().Elem())
+			for ; i < v.Len(); i++ {
+				v.Index(i).Set(z)
+			}
+		} else {
+			v.SetLen(i)
+		}
+	}
+	if i == 0 && v.Kind() == reflect.Slice {
+		v.Set(reflect.MakeSlice(v.Type(), 0, 0))
+	}
+}
+
+// literal consumes a literal from d.data[d.off-1:], decoding into the value v.
+// The first byte of the literal has been read already
+// (that's how the caller knows it's a literal).
+func (d *decodeState) literal(v reflect.Value) {
+	// All bytes inside literal return scanContinue op code.
+	start := d.off - 1
+	op := d.scanWhile(scanContinue)
+
+	// Scan read one byte too far; back up.
+	d.off--
+	d.scan.undo(op)
+
+	d.literalStore(d.data[start:d.off], v, false)
+}
+
+// convertNumber converts the number literal s to a float64
+func (d *decodeState) convertNumber(s string) (interface{}, error) {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil, &UnmarshalTypeError{"number " + s, reflect.TypeOf(0.0)}
+	}
+	return f, nil
+}
+
+// literalStore decodes a literal stored in item into v.
+//
+// fromQuoted indicates whether this literal came from unwrapping a
+// string from the ",string" struct tag option. this is used only to
+// produce more helpful error messages.
+func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool) {
+	// Check for unmarshaler.
+	if len(item) == 0 {
+		//Empty string given
+		d.saveError(fmt.Errorf("invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+		return
+	}
+	wantptr := item[0] == 'N' // null
+	v = d.indirect(v, wantptr)
+
+	switch c := item[0]; c {
+	case 'N': // null
+		switch v.Kind() {
+		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+			v.Set(reflect.Zero(v.Type()))
+			// otherwise, ignore null for primitives/string
+		}
+	case 't', 'f': // true, false
+		value := c == 't'
+		switch v.Kind() {
+		default:
+			if fromQuoted {
+				d.saveError(fmt.Errorf("invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+			} else {
+				d.saveError(&UnmarshalTypeError{"bool", v.Type()})
+			}
+		case reflect.Bool:
+			v.SetBool(value)
+		case reflect.String:
+			v.SetString(string(c))
+		case reflect.Interface:
+			if v.NumMethod() == 0 {
+				v.Set(reflect.ValueOf(value))
+			} else {
+				d.saveError(&UnmarshalTypeError{"bool", v.Type()})
+			}
+		}
+
+	case '"': // string
+		s, ok := unquoteBytes(item)
+		if !ok {
+			if fromQuoted {
+				d.error(fmt.Errorf("invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+			} else {
+				d.error(errPhase)
+			}
+		}
+		switch v.Kind() {
+		default:
+			d.saveError(&UnmarshalTypeError{"string", v.Type()})
+		case reflect.Slice:
+			if v.Type() != byteSliceType {
+				d.saveError(&UnmarshalTypeError{"string", v.Type()})
+				break
+			}
+			b := make([]byte, base64.StdEncoding.DecodedLen(len(s)))
+			n, err := base64.StdEncoding.Decode(b, s)
+			if err != nil {
+				d.saveError(err)
+				break
+			}
+			v.Set(reflect.ValueOf(b[0:n]))
+		case reflect.String:
+			v.SetString(string(s))
+		case reflect.Interface:
+			if v.NumMethod() == 0 {
+				v.Set(reflect.ValueOf(string(s)))
+			} else {
+				d.saveError(&UnmarshalTypeError{"string", v.Type()})
+			}
+		}
+
+	default: // number or unquoted string
+		s := string(item)
+		switch v.Kind() {
+		default:
+			d.error(&UnmarshalTypeError{s, v.Type()})
+
+		case reflect.String:
+			v.SetString(string(s))
+
+		case reflect.Interface:
+			n, err := d.convertNumber(s)
+			if err != nil {
+				d.saveError(err)
+				break
+			}
+			if v.NumMethod() != 0 {
+				d.saveError(&UnmarshalTypeError{"number", v.Type()})
+				break
+			}
+			v.Set(reflect.ValueOf(n))
+
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			n, err := strconv.ParseInt(s, 10, 64)
+			if err != nil || v.OverflowInt(n) {
+				d.saveError(&UnmarshalTypeError{"number " + s, v.Type()})
+				break
+			}
+			v.SetInt(n)
+
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			n, err := strconv.ParseUint(s, 10, 64)
+			if err != nil || v.OverflowUint(n) {
+				d.saveError(&UnmarshalTypeError{"number " + s, v.Type()})
+				break
+			}
+			v.SetUint(n)
+
+		case reflect.Float32, reflect.Float64:
+			n, err := strconv.ParseFloat(s, v.Type().Bits())
+			if err != nil || v.OverflowFloat(n) {
+				d.saveError(&UnmarshalTypeError{"number " + s, v.Type()})
+				break
+			}
+			v.SetFloat(n)
+		}
+	}
+}
+
+// The xxxInterface routines build up a value to be stored
+// in an empty interface.  They are not strictly necessary,
+// but they avoid the weight of reflection in this common case.
+
+// valueInterface is like value but returns interface{}
+func (d *decodeState) valueInterface() interface{} {
+	switch d.scanWhile(scanSkipSpace) {
+	default:
+		d.error(errPhase)
+		panic("unreachable")
+	case scanBeginArray:
+		return d.arrayInterface()
+	case scanBeginLiteral:
+		return d.literalInterface()
+	}
+}
+
+// arrayInterface is like array but returns []interface{}.
+func (d *decodeState) arrayInterface() []interface{} {
+	var v = make([]interface{}, 0)
+	for {
+		// Look ahead for ] - can only happen on first iteration.
+		op := d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+
+		// Back up so d.value can have the byte we just read.
+		d.off--
+		d.scan.undo(op)
+
+		v = append(v, d.valueInterface())
+
+		// Next token must be , or ].
+		op = d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+		if op != scanArrayValue {
+			d.error(errPhase)
+		}
+	}
+	return v
+}
+
+// literalInterface is like literal but returns an interface value.
+func (d *decodeState) literalInterface() interface{} {
+	// All bytes inside literal return scanContinue op code.
+	start := d.off - 1
+	op := d.scanWhile(scanContinue)
+
+	// Scan read one byte too far; back up.
+	d.off--
+	d.scan.undo(op)
+	item := d.data[start:d.off]
+
+	switch c := item[0]; c {
+	case 'N': // null
+		return nil
+
+	case 't', 'f': // true, false
+		return c == 't'
+
+	case '"': // string
+		s, ok := unquote(item)
+		if !ok {
+			d.error(errPhase)
+		}
+		return s
+
+	default: // number
+		if c != '-' && (c < '0' || c > '9') {
+			d.error(errPhase)
+		}
+		n, err := d.convertNumber(string(item))
+		if err != nil {
+			d.saveError(err)
+		}
+		return n
+	}
+}
+
+// getu4 decodes \uXXXX from the beginning of s, returning the hex value,
+// or it returns -1.
+func getu4(s []byte) rune {
+	if len(s) < 6 || s[0] != '\\' || s[1] != 'u' {
+		return -1
+	}
+	r, err := strconv.ParseUint(string(s[2:6]), 16, 64)
+	if err != nil {
+		return -1
+	}
+	return rune(r)
+}
+
+// unquote converts a quoted string literal s into an actual string t.
+// The rules are different than for Go, so cannot use strconv.Unquote.
+func unquote(s []byte) (t string, ok bool) {
+	s, ok = unquoteBytes(s)
+	t = string(s)
+	return
+}
+
+func unquoteBytes(s []byte) (t []byte, ok bool) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return
+	}
+	s = s[1 : len(s)-1]
+
+	// Check for unusual characters. If there are none,
+	// then no unquoting is needed, so return a slice of the
+	// original bytes.
+	r := 0
+	for r < len(s) {
+		c := s[r]
+		if c == '\\' || c == '"' || c < ' ' {
+			break
+		}
+		if c < utf8.RuneSelf {
+			r++
+			continue
+		}
+		rr, size := utf8.DecodeRune(s[r:])
+		if rr == utf8.RuneError && size == 1 {
+			break
+		}
+		r += size
+	}
+	if r == len(s) {
+		return s, true
+	}
+
+	b := make([]byte, len(s)+2*utf8.UTFMax)
+	w := copy(b, s[0:r])
+	for r < len(s) {
+		// Out of room?  Can only happen if s is full of
+		// malformed UTF-8 and we're replacing each
+		// byte with RuneError.
+		if w >= len(b)-2*utf8.UTFMax {
+			nb := make([]byte, (len(b)+utf8.UTFMax)*2)
+			copy(nb, b[0:w])
+			b = nb
+		}
+		switch c := s[r]; {
+		case c == '\\':
+			r++
+			if r >= len(s) {
+				return
+			}
+			switch s[r] {
+			default:
+				b[w] = s[r]
+				r++
+				w++
+			case 'u':
+				r--
+				rr := getu4(s[r:])
+				if rr < 0 {
+					return
+				}
+				r += 6
+				if utf16.IsSurrogate(rr) {
+					rr1 := getu4(s[r:])
+					if dec := utf16.DecodeRune(rr, rr1); dec != unicode.ReplacementChar {
+						// A valid pair; consume.
+						r += 6
+						w += utf8.EncodeRune(b[w:], dec)
+						break
+					}
+					// Invalid surrogate; fall back to replacement rune.
+					rr = unicode.ReplacementChar
+				}
+				w += utf8.EncodeRune(b[w:], rr)
+			}
+
+		// Quote, control characters are invalid.
+		case c == '"', c < ' ':
+			return
+
+		// ASCII
+		case c < utf8.RuneSelf:
+			b[w] = c
+			r++
+			w++
+
+		// Coerce to well-formed UTF-8.
+		default:
+			rr, size := utf8.DecodeRune(s[r:])
+			r += size
+			w += utf8.EncodeRune(b[w:], rr)
+		}
+	}
+	return b[0:w], true
+}

--- a/arrays/decode_test.go
+++ b/arrays/decode_test.go
@@ -157,20 +157,24 @@ func TestArrayNumbersAsStrings(t *testing.T) {
 func TestArrayNullsAsStrings(t *testing.T) {
 	var v []string
 
-	if err := Unmarshal([]byte("{\"null\", NULL}"), &v); err != nil {
+	if err := Unmarshal([]byte("{\"NULL\", NotANull, NULL}"), &v); err != nil {
 		t.Fatalf("Unexpected error, %v", err)
 	}
 
-	if expected := 2; len(v) != expected {
+	if expected := 3; len(v) != expected {
 		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
 	}
 
-	if expected := "null"; v[0] != expected {
+	if expected := "NULL"; v[0] != expected {
 		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
 	}
 
-	if expected := ""; v[1] != expected {
+	if expected := "NotANull"; v[1] != expected {
 		t.Errorf("Expected array[1] to be '%s', got '%s'", expected, v[1])
+	}
+
+	if expected := ""; v[2] != expected {
+		t.Errorf("Expected array[2] to be '%s', got '%s'", expected, v[2])
 	}
 }
 

--- a/arrays/decode_test.go
+++ b/arrays/decode_test.go
@@ -1,0 +1,445 @@
+package arrays
+
+import "testing"
+
+func TestArrayIntOne(t *testing.T) {
+	var v []int
+
+	if err := Unmarshal([]byte("{1}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 1; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := 1; v[0] != expected {
+		t.Errorf("Expected array[0] to be %d, got %d", expected, v[0])
+	}
+}
+
+func TestArrayIntTwo(t *testing.T) {
+	var v []int
+
+	if err := Unmarshal([]byte("{-1,2}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := -1; v[0] != expected {
+		t.Errorf("Expected array[0] to be %d, got %d", expected, v[0])
+	}
+
+	if expected := 2; v[1] != expected {
+		t.Errorf("Expected array[1] to be %d, got %d", expected, v[1])
+	}
+}
+
+func TestArrayIntTwoWhitespace(t *testing.T) {
+	var v []int
+
+	if err := Unmarshal([]byte("{1, 2}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := 1; v[0] != expected {
+		t.Errorf("Expected array[0] to be %d, got %d", expected, v[0])
+	}
+
+	if expected := 2; v[1] != expected {
+		t.Errorf("Expected array[1] to be %d, got %d", expected, v[1])
+	}
+}
+
+func TestArrayIntMultidimension(t *testing.T) {
+	var v [][]int
+
+	if err := Unmarshal([]byte("{{1}, {2}}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := 1; len(v[0]) != expected {
+		t.Errorf("Expected array[0] to have length %d, got %d", expected, len(v[0]))
+	}
+
+	if expected := 1; v[0][0] != expected {
+		t.Errorf("Expected array[0][0] to be %d, got %d", expected, v[0][0])
+	}
+
+	if expected := 1; len(v[1]) != expected {
+		t.Errorf("Expected array[1] to have length %d, got %d", expected, len(v[0]))
+	}
+
+	if expected := 2; v[1][0] != expected {
+		t.Errorf("Expected array[1][0] to be %d, got %d", expected, v[1][0])
+	}
+}
+
+func TestArrayStringOne(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{\"hello\"}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 1; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "hello"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+}
+
+func TestArrayUnquotedString(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{hello}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 1; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "hello"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+}
+
+func TestArrayMixedQuotingStrings(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{hello,\"there world\"}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "hello"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+
+	if expected := "there world"; v[1] != expected {
+		t.Errorf("Expected array[1] to be '%s', got '%s'", expected, v[1])
+	}
+}
+
+func TestArrayNumbersAsStrings(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{123}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 1; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "123"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+}
+
+func TestArrayNullsAsStrings(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{\"null\", NULL}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "null"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+
+	if expected := ""; v[1] != expected {
+		t.Errorf("Expected array[1] to be '%s', got '%s'", expected, v[1])
+	}
+}
+
+func TestArrayStringTwo(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{\"hello\",\"world\"}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "hello"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+
+	if expected := "world"; v[1] != expected {
+		t.Errorf("Expected array[1] to be '%s', got '%s'", expected, v[1])
+	}
+}
+
+func TestArrayStringTwoWhitespace(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{\"hello\", \"world\"}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "hello"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+
+	if expected := "world"; v[1] != expected {
+		t.Errorf("Expected array[1] to be '%s', got '%s'", expected, v[1])
+	}
+}
+
+func TestArrayStringMultidimension(t *testing.T) {
+	var v [][]string
+
+	if err := Unmarshal([]byte("{{\"hello\"}, {\"world\"}}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := 1; len(v[0]) != expected {
+		t.Errorf("Expected array[0] to have length %d, got %d", expected, len(v[0]))
+	}
+
+	if expected := "hello"; v[0][0] != expected {
+		t.Errorf("Expected array[0][0] to be '%s', got '%s'", expected, v[0][0])
+	}
+
+	if expected := 1; len(v[1]) != expected {
+		t.Errorf("Expected array[1] to have length %d, got %d", expected, len(v[0]))
+	}
+
+	if expected := "world"; v[1][0] != expected {
+		t.Errorf("Expected array[1][0] to be '%s', got '%s'", expected, v[1][0])
+	}
+}
+
+func TestArrayFloat(t *testing.T) {
+	var v []float64
+
+	if err := Unmarshal([]byte("{-1.2, 0.2, 4.54356}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 3; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := -1.2; v[0] != expected {
+		t.Errorf("Expected array[0] to be %f, got %f", expected, v[0])
+	}
+
+	if expected := 0.2; v[1] != expected {
+		t.Errorf("Expected array[1] to be %f, got %f", expected, v[1])
+	}
+
+	if expected := 4.54356; v[2] != expected {
+		t.Errorf("Expected array[2] to be %f, got %f", expected, v[2])
+	}
+}
+
+func TestArrayBool(t *testing.T) {
+	var v []bool
+
+	if err := Unmarshal([]byte("{t, f}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := true; v[0] != expected {
+		t.Errorf("Expected array[0] to be %t, got %t", expected, v[0])
+	}
+
+	if expected := false; v[1] != expected {
+		t.Errorf("Expected array[1] to be %t, got %t", expected, v[1])
+	}
+}
+
+func TestArrayBoolWithNulls(t *testing.T) {
+	var v []bool
+
+	if err := Unmarshal([]byte("{t, NULL}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := true; v[0] != expected {
+		t.Errorf("Expected array[0] to be %t, got %t", expected, v[0])
+	}
+
+	if expected := false; v[1] != expected {
+		t.Errorf("Expected array[1] to be %t, got %t", expected, v[1])
+	}
+}
+
+func TestArrayBoolAsStrings(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{t, f}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "t"; v[0] != expected {
+		t.Errorf("Expected array[0] to be %t, got %t", expected, v[0])
+	}
+
+	if expected := "f"; v[1] != expected {
+		t.Errorf("Expected array[1] to be %t, got %t", expected, v[1])
+	}
+}
+
+func TestArrayBoolWithNullsIntoInterfaceArray(t *testing.T) {
+	var v []interface{}
+
+	if err := Unmarshal([]byte("{t, NULL}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 2; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := true; v[0] != expected {
+		t.Errorf("Expected array[0] to be %t, got %t", expected, v[0])
+	}
+
+	if v[1] != nil {
+		t.Errorf("Expected array[1] to be nil, got %t", v[1])
+	}
+}
+
+func TestArrayEscapedSlash(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{\"hello\\\\world\"}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 1; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "hello\\world"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+}
+
+func TestArrayEscapedOpenArray(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{\"hello\\{world\"}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 1; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "hello{world"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+}
+
+func TestArrayEscapedCloseArray(t *testing.T) {
+	var v []string
+
+	if err := Unmarshal([]byte("{\"hello\\}world\"}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 1; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := "hello}world"; v[0] != expected {
+		t.Errorf("Expected array[0] to be '%s', got '%s'", expected, v[0])
+	}
+}
+
+type testObj struct {
+	id int
+}
+
+func TestArrayDecodeIntoObject(t *testing.T) {
+	v := testObj{}
+
+	if err := Unmarshal([]byte("{\"hello\\}world\"}"), &v); err == nil {
+		t.Fatal("Expected error, didn't get one")
+	}
+
+	v2 := &testObj{}
+
+	if err := Unmarshal([]byte("{\"hello\\}world\"}"), &v2); err == nil {
+		t.Fatal("Expected error, didn't get one")
+	}
+}
+
+func TestArrayDecodeIntoPreallocatedSlice(t *testing.T) {
+	v := make([]int, 0, 10)
+
+	if err := Unmarshal([]byte("{1}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 1; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := 1; v[0] != expected {
+		t.Errorf("Expected array[0] to be %d, got %d", expected, v[0])
+	}
+}
+
+func TestArrayDecodeIntoArray(t *testing.T) {
+	v := [10]int{}
+
+	if err := Unmarshal([]byte("{1}"), &v); err != nil {
+		t.Fatalf("Unexpected error, %v", err)
+	}
+
+	if expected := 10; len(v) != expected {
+		t.Errorf("Expected array to have length %d, got %d", expected, len(v))
+	}
+
+	if expected := 1; v[0] != expected {
+		t.Errorf("Expected array[0] to be %d, got %d", expected, v[0])
+	}
+}

--- a/arrays/scanner.go
+++ b/arrays/scanner.go
@@ -174,9 +174,6 @@ func stateBeginValue(s *scanner, c int) opcode {
 		s.step = stateBeginValueOrEmpty
 		s.pushParseState(parseArrayValue)
 		return scanBeginArray
-	case 'N': // beginning of null
-		s.step = stateN
-		return scanBeginLiteral
 	}
 	return s.error(c, "looking for beginning of value")
 }
@@ -248,33 +245,6 @@ func stateInUnquotedString(s *scanner, c int) opcode {
 func stateInStringEsc(s *scanner, c int) opcode {
 	s.step = stateInString
 	return scanContinue
-}
-
-// stateN is the state after reading `N`.
-func stateN(s *scanner, c int) opcode {
-	if c == 'U' {
-		s.step = stateNu
-		return scanContinue
-	}
-	return s.error(c, "in literal null (expecting 'U')")
-}
-
-// stateNu is the state after reading `NU`.
-func stateNu(s *scanner, c int) opcode {
-	if c == 'L' {
-		s.step = stateNul
-		return scanContinue
-	}
-	return s.error(c, "in literal null (expecting 'L')")
-}
-
-// stateNul is the state after reading `NUL`.
-func stateNul(s *scanner, c int) opcode {
-	if c == 'L' {
-		s.step = stateEndValue
-		return scanContinue
-	}
-	return s.error(c, "in literal null (expecting 'L')")
 }
 
 // stateError is the state after reaching a syntax error,

--- a/arrays/scanner.go
+++ b/arrays/scanner.go
@@ -1,0 +1,310 @@
+// PostgreSQL Array value parser state machine.
+// Heavily lifted from the Go JSON decoder, with modifications for
+// PGs inconsistent array format.
+
+package arrays
+
+// nextValue splits data after the next whole value,
+// returning that value and the bytes that follow it as separate slices.
+// scan is passed in for use by nextValue to avoid an allocation.
+func nextValue(data []byte, scan *scanner) (value, rest []byte, err error) {
+	scan.reset()
+	for i, c := range data {
+		v := scan.step(scan, int(c))
+		if v >= scanEnd {
+			switch v {
+			case scanError:
+				return nil, nil, scan.err
+			case scanEnd:
+				return data[0:i], data[i:], nil
+			}
+		}
+	}
+	if scan.eof() == scanError {
+		return nil, nil, scan.err
+	}
+	return data, nil, nil
+}
+
+// A SyntaxError is a description of a syntax error.
+type SyntaxError struct {
+	msg    string // description of error
+	Offset int64  // error occurred after reading Offset bytes
+}
+
+func (e *SyntaxError) Error() string { return e.msg }
+
+// A scanner is a PostgreSQL Array scanning state machine.
+// Callers call scan.reset() and then pass bytes in one at a time
+// by calling scan.step(&scan, c) for each byte.
+// The return value, referred to as an opcode, tells the
+// caller about significant parsing events like beginning
+// and ending literals and arrays, so that the caller can follow
+// along if it wishes.
+// The return value scanEnd indicates that a single top-level
+// array has been completed, *before* the byte that just got passed
+// in.  (The indication must be delayed in order to recognize the
+// end of numbers: is 123 a whole value or the beginning of 12345e+6?).
+type scanner struct {
+	// The step is a func to be called to execute the next transition.
+	// Also tried using an integer constant and a single func
+	// with a switch, but using the func directly was 10% faster
+	// on a 64-bit Mac Mini, and it's nicer to read.
+	step func(*scanner, int) opcode
+
+	// Reached end of top-level value.
+	endTop bool
+
+	// Stack of what we're in the middle of - array values, object keys, object values.
+	parseState []parsecode
+
+	// Error that happened, if any.
+	err error
+
+	// 1-byte redo (see undo method)
+	redo      bool
+	redoCode  opcode
+	redoState func(*scanner, int) opcode
+
+	// total bytes consumed, updated by decoder.Decode
+	bytes int64
+}
+
+// An opcode is returned by the state transition functions. They
+// give details about the current state of the scan that callers
+// may be interested to know about.
+type opcode int
+
+const (
+	// Continue.
+	scanContinue     opcode = iota // uninteresting byte
+	scanBeginLiteral               // end implied by next result != scanContinue
+	scanBeginArray                 // begin array
+	scanArrayValue                 // just finished array value
+	scanEndArray                   // end array (implies scanArrayValue if possible)
+	scanSkipSpace                  // space byte; can skip; known to be last "continue" result
+
+	// Stop.
+	scanEnd   // top-level value ended *before* this byte; known to be first "stop" result
+	scanError // hit an error, scanner.err.
+)
+
+type parsecode int
+
+// These values are stored in the parseState stack.
+// They give the current state of a composite value
+// being scanned.  If the parser is inside a nested value
+// the parseState describes the nested state, outermost at entry 0.
+const (
+	parseArrayValue parsecode = iota // parsing array value
+)
+
+// reset prepares the scanner for use.
+// It must be called before calling s.step.
+func (s *scanner) reset() {
+	s.step = stateBeginValue
+	s.parseState = s.parseState[0:0]
+	s.err = nil
+	s.redo = false
+	s.endTop = false
+}
+
+// eof tells the scanner that the end of input has been reached.
+// It returns a scan status just as s.step does.
+func (s *scanner) eof() opcode {
+	if s.err != nil {
+		return scanError
+	}
+	if s.endTop {
+		return scanEnd
+	}
+	s.step(s, ' ')
+	if s.endTop {
+		return scanEnd
+	}
+	if s.err == nil {
+		s.err = &SyntaxError{"unexpected end of input", s.bytes}
+	}
+	return scanError
+}
+
+// pushParseState pushes a new parse state p onto the parse stack.
+func (s *scanner) pushParseState(p parsecode) {
+	s.parseState = append(s.parseState, p)
+}
+
+// popParseState pops a parse state (already obtained) off the stack
+// and updates s.step accordingly.
+func (s *scanner) popParseState() {
+	n := len(s.parseState) - 1
+	s.parseState = s.parseState[0:n]
+	s.redo = false
+	if n == 0 {
+		s.step = stateEndTop
+		s.endTop = true
+	} else {
+		s.step = stateEndValue
+	}
+}
+
+// stateBeginValueOrEmpty is the state after reading `{`.
+func stateBeginValueOrEmpty(s *scanner, c int) opcode {
+	if c == ' ' {
+		return scanSkipSpace
+	}
+	if c == '}' {
+		return stateEndValue(s, c)
+	}
+	return stateBeginValue(s, c)
+}
+
+// stateBeginValue is the state at the beginning of the input.
+func stateBeginValue(s *scanner, c int) opcode {
+	if c == ' ' {
+		return scanSkipSpace
+	}
+	switch c {
+	default: // unquoted value (could be a string if we're an array of strings)
+		s.step = stateInUnquotedString
+		return scanBeginLiteral
+	case '"': // beginning of quoted string
+		s.step = stateInString
+		return scanBeginLiteral
+	case '{': // beginning of new array
+		s.step = stateBeginValueOrEmpty
+		s.pushParseState(parseArrayValue)
+		return scanBeginArray
+	case 'N': // beginning of null
+		s.step = stateN
+		return scanBeginLiteral
+	}
+	return s.error(c, "looking for beginning of value")
+}
+
+// stateEndValue is the state after completing a value,
+// such as after reading `{}` or `true` or `["x"`.
+func stateEndValue(s *scanner, c int) opcode {
+	n := len(s.parseState)
+	if n == 0 {
+		// Completed top-level before the current byte.
+		s.step = stateEndTop
+		s.endTop = true
+		return stateEndTop(s, c)
+	}
+	if c == ' ' {
+		s.step = stateEndValue
+		return scanSkipSpace
+	}
+	ps := s.parseState[n-1]
+	switch ps {
+	case parseArrayValue:
+		if c == ',' {
+			s.step = stateBeginValue
+			return scanArrayValue
+		}
+		if c == '}' {
+			s.popParseState()
+			return scanEndArray
+		}
+		return s.error(c, "after array element")
+	}
+	return s.error(c, "")
+}
+
+// stateEndTop is the state after finishing the top-level value,
+// such as after reading `{}`.
+func stateEndTop(s *scanner, c int) opcode {
+	return scanEnd
+}
+
+// stateInString is the state after reading `"`.
+func stateInString(s *scanner, c int) opcode {
+	if c == '"' {
+		s.step = stateEndValue
+		return scanContinue
+	}
+	if c == '\\' {
+		s.step = stateInStringEsc
+		return scanContinue
+	}
+	if c < 0x20 {
+		return s.error(c, "in string literal")
+	}
+	return scanContinue
+}
+
+// stateInUnquotedString is the state for an unquoted string
+func stateInUnquotedString(s *scanner, c int) opcode {
+	if c == ',' || c == '}' {
+		return stateEndValue(s, c)
+	}
+	if c < 0x20 {
+		return s.error(c, "in string literal")
+	}
+	return scanContinue
+}
+
+// stateInStringEsc is the state after reading `"\` during a quoted string.
+func stateInStringEsc(s *scanner, c int) opcode {
+	s.step = stateInString
+	return scanContinue
+}
+
+// stateN is the state after reading `N`.
+func stateN(s *scanner, c int) opcode {
+	if c == 'U' {
+		s.step = stateNu
+		return scanContinue
+	}
+	return s.error(c, "in literal null (expecting 'U')")
+}
+
+// stateNu is the state after reading `NU`.
+func stateNu(s *scanner, c int) opcode {
+	if c == 'L' {
+		s.step = stateNul
+		return scanContinue
+	}
+	return s.error(c, "in literal null (expecting 'L')")
+}
+
+// stateNul is the state after reading `NUL`.
+func stateNul(s *scanner, c int) opcode {
+	if c == 'L' {
+		s.step = stateEndValue
+		return scanContinue
+	}
+	return s.error(c, "in literal null (expecting 'L')")
+}
+
+// stateError is the state after reaching a syntax error,
+// such as after reading `[1}` or `5.1.2`.
+func stateError(s *scanner, c int) opcode {
+	return scanError
+}
+
+// error records an error and switches to the error state.
+func (s *scanner) error(c int, context string) opcode {
+	s.step = stateError
+	s.err = &SyntaxError{"invalid character " + string(c) + " " + context, s.bytes}
+	return scanError
+}
+
+// undo causes the scanner to return scanCode from the next state transition.
+// This gives callers a simple 1-byte undo mechanism.
+func (s *scanner) undo(scanCode opcode) {
+	if s.redo {
+		panic("invalid use of scanner")
+	}
+	s.redoCode = scanCode
+	s.redoState = s.step
+	s.step = stateRedo
+	s.redo = true
+}
+
+// stateRedo helps implement the scanner's 1-byte undo.
+func stateRedo(s *scanner, c int) opcode {
+	s.redo = false
+	s.step = s.redoState
+	return s.redoCode
+}

--- a/conn.go
+++ b/conn.go
@@ -601,6 +601,7 @@ func (rs *rows) Next(dest []driver.Value) (err error) {
 					dest[i] = nil
 					continue
 				}
+
 				dest[i] = decode(r.next(l), rs.st.rowTyps[i])
 			}
 			return

--- a/encode.go
+++ b/encode.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
+	"github.com/lib/pq/arrays"
 	"github.com/lib/pq/oid"
 	"strconv"
 	"time"
@@ -76,6 +77,18 @@ func decode(s []byte, typ oid.Oid) interface{} {
 			errorf("%s", err)
 		}
 		return f
+	case oid.T__int8, oid.T__int4, oid.T__int2:
+		var v []int
+		if err := arrays.Unmarshal(s, &v); err != nil {
+			errorf("%s", err)
+		}
+		return v
+	case oid.T__varchar:
+		var v []string
+		if err := arrays.Unmarshal(s, &v); err != nil {
+			errorf("%s", err)
+		}
+		return v
 	}
 
 	return s

--- a/encode_test.go
+++ b/encode_test.go
@@ -162,3 +162,83 @@ func TestByteToText(t *testing.T) {
 		t.Fatalf("expected %v but got %v", b, result)
 	}
 }
+
+func TestSelectIntArray(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	row := db.QueryRow("SELECT '{1,2,3}'::int[]")
+
+	var result []int
+	err := row.Scan(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result) != 3 {
+		t.Errorf("Expected result to have 3 elements, got %d.\n#v", len(result), result)
+	}
+
+	if result[0] != 1 {
+		t.Errorf("Expected result[0] to equal 1, got %d", result[0])
+	}
+
+	if result[1] != 2 {
+		t.Errorf("Expected result[1] to equal 2, got %d", result[1])
+	}
+
+	if result[2] != 3 {
+		t.Errorf("Expected result[2] to equal 3, got %d", result[2])
+	}
+}
+
+func TestSelectStringArray(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	row := db.QueryRow("SELECT '{\"hello\", \"world\"}'::varchar[]")
+
+	var result []string
+	err := row.Scan(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("Expected result to have 2 elements, got %d.\n#v", len(result), result)
+	}
+
+	if result[0] != "hello" {
+		t.Errorf("Expected result[0] to equal 'hello', got %s", result[0])
+	}
+
+	if result[1] != "world" {
+		t.Errorf("Expected result[1] to equal 'world', got %s", result[1])
+	}
+}
+
+// Not supported yet. Can parse it, but can't get it out of the pq.decoder
+// func TestSelectMultidimensionStringArray(t *testing.T) {
+// 	db := openTestConn(t)
+// 	defer db.Close()
+
+// 	row := db.QueryRow("SELECT '{{\"hello\"}, {\"world\"}}'::varchar[]")
+
+// 	var result [][]string
+// 	err := row.Scan(&result)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	if len(result) != 2 {
+// 		t.Errorf("Expected result to have 2 elements, got %d.\n#v", len(result), result)
+// 	}
+
+// 	if result[0][0] != "hello" {
+// 		t.Errorf("Expected result[0] to equal 'hello', got %s", result[0])
+// 	}
+
+// 	if result[1][0] != "world" {
+// 		t.Errorf("Expected result[1] to equal 'world', got %s", result[1])
+// 	}
+// }


### PR DESCRIPTION
Hello. I've started implementing array support, but it's not complete yet. Consider this pull request to be the start of a conversation, if you're interested.

This PR includes a parser, which is heavily inspired by the Go JSON parser, with various tweaks for the PG array syntax (mainly around unquoted strings). It can handle `string`, `int`, `float`, and `bool` arrays.

The following now works:

    var strings []string
    var ints []int
    db.QueryRow("select {\"a\", \"b\", \"c\"}::varchar[], {1,2,3}::int[]").Scan(&arr)

    // strings = ["a", "b", "c"]
    // ints = [1, 2, 3]

The parser has support for multidimensional arrays, but this feature hasn't been wired up to the decoder yet. To do this may require some further changes to the pq decoder or providing a `PgArray` type for usage similar to `NullString`.

Currently only supports unmarshaling of data. Marshaling/using arrays as input parameters can be worked around by using string formatting.

My questions to you are:

  * Is it desirable to have Array parsing (and I imagine eventually HStore) in PQ core, or provide some kind of extension mechanism to allow 3rd parties to create support?
  * Is it important to have multi-dimensions supported before this feature can be considered complete, or is single dimension support good enough on it's own to start with?
  * How extensive should type support be before considering this for merging?
  * Does it make sense to have reading without writing support?