### PR TITLE
Fixing inconsistent behaviour between SimpleQuery and complex queries.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -289,6 +289,7 @@ func (cn *conn) simpleQuery(q string) (res driver.Rows, err error) {
 			return
 		case 'E':
 			st.lasterr = parseError(r)
+			err = st.lasterr
 			return
 		case 'T':
 			st.cols, st.rowTyps = parseMeta(r)


### PR DESCRIPTION
When doing a query on a non existent table, complex queries actually return errors whereas simple queries do not.

```
_, err = db.Query("SELECT * FROM nonexistenttable WHERE age=$1", 20)
// err is not nil

_, err = db.Query("SELECT * FROM nonexistenttable")
// err is nil
```
