### PR TITLE
Ignore ParameterStatus while waiting for RowDescription or BindComplete

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -345,6 +345,8 @@ func (cn *conn) prepareToSimpleStmt(q, stmtName string) (_ *stmt, err error) {
 			}
 		case 'T':
 			st.cols, st.rowTyps = parseMeta(r)
+		case 'S':
+			// ParameterStatus, ignore
 		case 'n':
 			// no data
 		case 'Z':
@@ -675,6 +677,8 @@ func (st *stmt) exec(v []driver.Value) {
 				panic(err)
 			}
 			return
+		case 'S':
+			// ParameterStatus, ignore
 		case 'N':
 			// ignore
 		default:


### PR DESCRIPTION
Steps to reproduce:

1) Spam Query() with at least one parameter (to avoid simpleQuery() fast path)
2) Reload the server, changing the value of one of the parameters which are sent using ParameterStatus (e.g. search_path)
3) Observe a pattern similar to the following:
    pq: unexpected describe rows response: 'S'
    pq: unexpected describe rows response: 'S'
    panic or unexpected bind response

Hitting the one while waiting for BindComplete can be reproduced using a similar method, but it appeared to be slightly harder unless the RowDescription one had been patched.
