### PR TITLE
Support run-time parameters in connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,25 @@
 
 **Connection String Parameters**
 
-These are a subset of the libpq connection parameters.  In addition, a
-number of the [environment
-variables](http://www.postgresql.org/docs/current/static/libpq-envars.html)
-supported by libpq are also supported.  Just like libpq, these have
-lower precedence than explicitly provided connection parameters.
+Similarly to libpq, when establishing a connection using pq you are expected to
+supply a [connection string](http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)
+containing zero or more parameters.  A subset of the connection parameters
+supported by libpq are also supported by pq.  Additionally, pq also lets you
+specify run-time parameters (such as `search_path` or `work_mem`) directly in
+the connection string.  This is different from libpq, which does not allow
+run-time parameters in the connection string, instead requiring you to supply
+them in the `options` parameter.
+
+Most [environment variables](http://www.postgresql.org/docs/current/static/libpq-envars.html)
+supported by libpq are also supported by pq.  If any of the environment
+variables not supported by pq are set, pq will panic during connection
+establishment.  Environment variables have a lower precedence than explicitly
+provided connection parameters.
 
 See http://www.postgresql.org/docs/current/static/libpq-connect.html.
+
+For compatibility with libpq, the following special connection parameters are
+supported:
 
 * `dbname` - The name of the database to connect to
 * `user` - The user to sign in as
@@ -48,6 +60,11 @@ See http://www.postgresql.org/docs/current/static/libpq-connect.html.
 Use single quotes for values that contain whitespace:
 
     "user=pqgotest password='with spaces'"
+
+In addition to the parameters listed above, any run-time parameter that can be
+set at backend start time can be set in the connection string.  For more
+information, see
+http://www.postgresql.org/docs/current/static/runtime-config.html.
 
 See http://golang.org/pkg/database/sql to learn how to use with `pq` through the `database/sql` package.
 


### PR DESCRIPTION
This should be compatible between libpq, and supports setting some parameters easily in the connection string.

Builds on top of #157.
