### PR TITLE
Re-export Open

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -56,7 +56,7 @@ var (
 type drv struct{}
 
 func (d *drv) Open(name string) (driver.Conn, error) {
-	return open(name)
+	return Open(name)
 }
 
 func init() {
@@ -76,7 +76,7 @@ func (c *conn) writeBuf(b byte) *writeBuf {
 	return &w
 }
 
-func open(name string) (_ driver.Conn, err error) {
+func Open(name string) (_ driver.Conn, err error) {
 	defer errRecover(&err)
 
 	o := make(values)


### PR DESCRIPTION
In #161 I assumed that nobody was calling `pq.Open` directly. I was wrong, as @fd explained in a [comment](https://github.com/lib/pq/pull/161#commitcomment-4297782) on that pull request.

This pull request fixes that problem.
