### PR TITLE
Support Postgres versions 9.1, 9.2 & 9.3 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - PGVERSION=9.3
     - PGVERSION=9.2
     - PGVERSION=9.1
+    - PGVERSION=9.0
 
 script:
  - env PGUSER=postgres go test -v ./...


### PR DESCRIPTION
Hi, 

I added the before install block from plv8js to the travis file, which adds Postgres versions 9.1, 9.2 & 9.3 to the travis testing matrix. 

Note that 9.0 fails but I wasn't sure whether that's too old to matter so I just removed it for the time being.

Failing tests on Postgres 9.0:
conn_test.go:249: pq: invalid byte sequence for encoding "UTF8": 0x00
conn_test.go:758: bad value for client_encoding: got UTF-8, want UTF8 with conninfo "client_encoding=UTF-8"
