### PR TITLE
Tolerate less messages in prepareToSimpleStmt

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -426,9 +426,6 @@ func (cn *conn) prepareToSimpleStmt(q, stmtName string) (_ *stmt, err error) {
 			return st, err
 		case 'E':
 			err = parseError(r)
-		case 'C':
-			// command complete
-			return st, err
 		default:
 			errorf("unexpected describe rows response: %q", t)
 		}

--- a/conn_test.go
+++ b/conn_test.go
@@ -474,6 +474,23 @@ func TestBindError(t *testing.T) {
 	defer r.Close()
 }
 
+func TestParseErrorInExtendedQuery(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	rows, err := db.Query("PARSE_ERROR $1", 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	rows, err = db.Query("SELECT 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows.Close()
+}
+
+
 // TestReturning tests that an INSERT query using the RETURNING clause returns a row.
 func TestReturning(t *testing.T) {
 	db := openTestConn(t)
@@ -611,41 +628,6 @@ FROM (VALUES (0::integer, NULL::text), (1, 'test string')) AS t;`)
 	defer r.Close()
 
 	for r.Next() {
-	}
-}
-
-// Open transaction, issue INSERT query inside transaction, rollback
-// transaction, issue SELECT query to same db used to create the tx.  No rows
-// should be returned.
-func TestRollback(t *testing.T) {
-	db := openTestConn(t)
-	defer db.Close()
-
-	_, err := db.Exec("CREATE TEMP TABLE temp (a int)")
-	if err != nil {
-		t.Fatal(err)
-	}
-	sqlInsert := "INSERT INTO temp VALUES (1)"
-	sqlSelect := "SELECT * FROM temp"
-	tx, err := db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = tx.Query(sqlInsert)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = tx.Rollback()
-	if err != nil {
-		t.Fatal(err)
-	}
-	r, err := db.Query(sqlSelect)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Next() returns false if query returned no rows.
-	if r.Next() {
-		t.Fatal("Transaction rollback failed")
 	}
 }
 


### PR DESCRIPTION
Here's a PR for the changes I talked about in #89, removing tolerance for a CommandComplete message after Parse + Describe + Sync.  As far as I can tell, this should not break any applications which were not broken already (i.e. experiencing symptoms of the client state not matching the server state).

This PR also includes a separate commit which removes tolerance for BindComplete in the same code path -- if we don't bind there, why do we tolerate such a response from the server?
