### PR TITLE
Check the number of supplied parameters against what the statement expects

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -790,6 +790,10 @@ func (st *stmt) Exec(v []driver.Value) (res driver.Result, err error) {
 }
 
 func (st *stmt) exec(v []driver.Value) {
+	if len(v) != len(st.paramTyps) {
+		errorf("got %d parameters but the statement requires %d", len(v), len(st.paramTyps))
+	}
+
 	w := st.cn.writeBuf('B')
 	w.string("")
 	w.string(st.name)

--- a/conn_test.go
+++ b/conn_test.go
@@ -240,6 +240,32 @@ func TestRowsCloseBeforeDone(t *testing.T) {
 	}
 }
 
+func TestParameterCountMismatch(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	var notused int
+	err := db.QueryRow("SELECT false", 1).Scan(&notused)
+	if err == nil {
+		t.Fatal("expected err")
+	}
+	// make sure we clean up correctly
+	err = db.QueryRow("SELECT 1").Scan(&notused)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.QueryRow("SELECT $1").Scan(&notused)
+	if err == nil {
+		t.Fatal("expected err")
+	}
+	// make sure we clean up correctly
+	err = db.QueryRow("SELECT 1").Scan(&notused)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestEncodeDecode(t *testing.T) {
 	db := openTestConn(t)
 	defer db.Close()


### PR DESCRIPTION
I thought about this earlier and was again reminded by the recent report in #177.  Any thoughts?
