### PR TITLE
Support bytea_output=escape when receiving data

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -1,6 +1,7 @@
 package pq
 
 import (
+	"bytes"
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
@@ -43,13 +44,7 @@ func encode(x interface{}, pgtypOid oid.Oid) []byte {
 func decode(s []byte, typ oid.Oid) interface{} {
 	switch typ {
 	case oid.T_bytea:
-		s = s[2:] // trim off "\\x"
-		d := make([]byte, hex.DecodedLen(len(s)))
-		_, err := hex.Decode(d, s)
-		if err != nil {
-			errorf("%s", err)
-		}
-		return d
+		return parseBytea(s)
 	case oid.T_timestamptz, oid.T_timestamp, oid.T_date:
 		return parseTs(string(s))
 	case oid.T_time:
@@ -193,6 +188,54 @@ func parseTs(str string) (result time.Time) {
 	return time.Date(bcSign*year, time.Month(month), day,
 		hour, minute, second, nanoSec,
 		time.FixedZone("", tzOff))
+}
+
+// Parse a bytea value received from the server.  Both "hex" and the legacy
+// "escape" format are supported.
+func parseBytea(s []byte) (result []byte) {
+	if len(s) >= 2 && bytes.Equal(s[:2], []byte("\\x")) {
+		// bytea_output = hex
+		s = s[2:] // trim off leading "\\x"
+		result = make([]byte, hex.DecodedLen(len(s)))
+		_, err := hex.Decode(result, s)
+		if err != nil {
+			errorf("%s", err)
+		}
+	} else {
+		// bytea_output = escape
+		for len(s) > 0 {
+			if s[0] == '\\' {
+				// escaped \\
+				if len(s) >= 2 && s[1] == '\\' {
+					result = append(result, '\\')
+					s = s[2:]
+					continue
+				}
+
+				// '\\' followed by an octal number
+				if len(s) < 4 {
+					errorf("invalid bytea sequence %v", s)
+				}
+				r, err := strconv.ParseInt(string(s[1:4]), 8, 9)
+				if err != nil {
+					errorf("could not parse bytea value: %s", err.Error())
+				}
+				result = append(result, byte(r))
+				s = s[4:]
+			} else {
+				// unescaped, raw byte
+				i := bytes.IndexByte(s, '\\')
+				if (i == -1) {
+					result = append(result, s...)
+					break
+				}
+				result = append(result, s[:i]...)
+				s = s[i:]
+			}
+		}
+	}
+
+	return result
 }
 
 // NullTime represents a time.Time that may be null. NullTime implements the


### PR DESCRIPTION
Here's a proof-of-concept patch implementing support for bytea_output=escape when reading data from the database.  Supporting both when sending data to the database seems more difficult given what database/sql forces us to work with.

Is this worth supporting?  Do we care?
