### PR TITLE
Try to infer the time zone for timestamptzs from TimeZone

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -282,13 +282,13 @@ func benchPreparedMockQuery(b *testing.B, c *conn, stmt driver.Stmt) {
 
 func BenchmarkEncodeInt64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		encode(nil, int64(1234), oid.T_int8)
+		encode(&parameterStatus{}, int64(1234), oid.T_int8)
 	}
 }
 
 func BenchmarkEncodeFloat64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		encode(nil, 3.14159, oid.T_float8)
+		encode(&parameterStatus{}, 3.14159, oid.T_float8)
 	}
 }
 
@@ -296,13 +296,13 @@ var testByteString = []byte("abcdefghijklmnopqrstuvwxyz")
 
 func BenchmarkEncodeBytea(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		encode(nil, testByteString, oid.T_bytea)
+		encode(&parameterStatus{}, testByteString, oid.T_bytea)
 	}
 }
 
 func BenchmarkEncodeBool(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		encode(nil, true, oid.T_bool)
+		encode(&parameterStatus{}, true, oid.T_bool)
 	}
 }
 
@@ -310,7 +310,7 @@ var testTimestamptz = time.Date(2001, time.January, 1, 0, 0, 0, 0, time.Local)
 
 func BenchmarkEncodeTimestamptz(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		encode(nil, testTimestamptz, oid.T_timestamptz)
+		encode(&parameterStatus{}, testTimestamptz, oid.T_timestamptz)
 	}
 }
 
@@ -318,7 +318,7 @@ var testIntBytes = []byte("1234")
 
 func BenchmarkDecodeInt64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		decode(testIntBytes, oid.T_int8)
+		decode(&parameterStatus{}, testIntBytes, oid.T_int8)
 	}
 }
 
@@ -326,7 +326,7 @@ var testFloatBytes = []byte("3.14159")
 
 func BenchmarkDecodeFloat64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		decode(testFloatBytes, oid.T_float8)
+		decode(&parameterStatus{}, testFloatBytes, oid.T_float8)
 	}
 }
 
@@ -334,7 +334,7 @@ var testBoolBytes = []byte{'t'}
 
 func BenchmarkDecodeBool(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		decode(testBoolBytes, oid.T_bool)
+		decode(&parameterStatus{}, testBoolBytes, oid.T_bool)
 	}
 }
 
@@ -351,7 +351,7 @@ var testTimestamptzBytes = []byte("2013-09-17 22:15:32.360754-07")
 
 func BenchmarkDecodeTimestamptz(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		decode(testTimestamptzBytes, oid.T_timestamptz)
+		decode(&parameterStatus{}, testTimestamptzBytes, oid.T_timestamptz)
 	}
 }
 


### PR DESCRIPTION
Here's a pull request based on the discussion in #202.

There I hinted at the possibility that this might not work properly when the TimeZone value changes mid-session, but I think my concerns were not justified as we only ever deal with one query at a time.  If that changes in the future, we might want to start shoving Locations into `rows` objects.
