### PR TITLE
you don't need to implement Execer and Queryer

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -773,13 +773,17 @@ func TestParseComplete(t *testing.T) {
 }
 
 func TestExecerInterface(t *testing.T) {
-	// Gin up a straw man private struct just for the type check
-	cn := &conn{c: nil}
-	var cni interface{} = cn
+	db := openTestConn(t)
+	defer db.Close()
 
-	_, ok := cni.(driver.Execer)
-	if !ok {
-		t.Fatal("Driver doesn't implement Execer")
+	res, err := db.Exec("SELECT 1")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res == nil {
+		t.Fatal("result is nil")
 	}
 }
 


### PR DESCRIPTION
Not sure if this is worth a PR, but you don't need to implement these. They're implemented in database/sql. Effectively, that code in conn.go will never be hit. I tweaked the unit test to check for Execer--it wasn't really testing anything before. 

Exec:
http://golang.org/src/pkg/database/sql/sql.go?s=22844:22913#L836

Query:
http://golang.org/src/pkg/database/sql/sql.go?s=23894:23963#L885

Also, apparently my `go fmt` autorun when exit caught a few things.
