### PR TITLE
Refactoring hstore to a simpler and easier to understand map.

### DIFF
--- a/hstore/hstore_test.go
+++ b/hstore/hstore_test.go
@@ -52,7 +52,7 @@ func TestHstore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hs.Map != nil {
+	if hs != nil {
 		t.Fatalf("expected null map")
 	}
 
@@ -60,7 +60,7 @@ func TestHstore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-query null map failed: %s", err.Error())
 	}
-	if hs.Map != nil {
+	if hs != nil {
 		t.Fatalf("expected null map")
 	}
 
@@ -69,78 +69,72 @@ func TestHstore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hs.Map == nil {
+	if hs == nil {
 		t.Fatalf("expected empty map, got null map")
 	}
-	if len(hs.Map) != 0 {
-		t.Fatalf("expected empty map, got len(map)=%d", len(hs.Map))
+	if len(hs) != 0 {
+		t.Fatalf("expected empty map, got len(map)=%d", len(hs))
 	}
 
 	err = db.QueryRow("SELECT $1::hstore", hs).Scan(&hs)
 	if err != nil {
 		t.Fatalf("re-query empty map failed: %s", err.Error())
 	}
-	if hs.Map == nil {
+	if hs == nil {
 		t.Fatalf("expected empty map, got null map")
 	}
-	if len(hs.Map) != 0 {
-		t.Fatalf("expected empty map, got len(map)=%d", len(hs.Map))
+	if len(hs) != 0 {
+		t.Fatalf("expected empty map, got len(map)=%d", len(hs))
 	}
 
 	// a few example maps to test out
 	hsOnePair := Hstore{
-		Map: map[string]sql.NullString{
-			"key1": sql.NullString{"value1", true},
-		},
+		"key1": sql.NullString{"value1", true},
 	}
 
 	hsThreePairs := Hstore{
-		Map: map[string]sql.NullString{
-			"key1": sql.NullString{"value1", true},
-			"key2": sql.NullString{"value2", true},
-			"key3": sql.NullString{"value3", true},
-		},
+		"key1": sql.NullString{"value1", true},
+		"key2": sql.NullString{"value2", true},
+		"key3": sql.NullString{"value3", true},
 	}
 
 	hsSmorgasbord := Hstore{
-		Map: map[string]sql.NullString{
-			"nullstring":             sql.NullString{"NULL", true},
-			"actuallynull":           sql.NullString{"", false},
-			"NULL":                   sql.NullString{"NULL string key", true},
-			"withbracket":            sql.NullString{"value>42", true},
-			"withequal":              sql.NullString{"value=42", true},
-			`"withquotes1"`:          sql.NullString{`this "should" be fine`, true},
-			`"withquotes"2"`:         sql.NullString{`this "should\" also be fine`, true},
-			"embedded1":              sql.NullString{"value1=>x1", true},
-			"embedded2":              sql.NullString{`"value2"=>x2`, true},
-			"withnewlines":           sql.NullString{"\n\nvalue\t=>2", true},
-			"<<all sorts of crazy>>": sql.NullString{`this, "should,\" also, => be fine`, true},
-		},
+		"nullstring":             sql.NullString{"NULL", true},
+		"actuallynull":           sql.NullString{"", false},
+		"NULL":                   sql.NullString{"NULL string key", true},
+		"withbracket":            sql.NullString{"value>42", true},
+		"withequal":              sql.NullString{"value=42", true},
+		`"withquotes1"`:          sql.NullString{`this "should" be fine`, true},
+		`"withquotes"2"`:         sql.NullString{`this "should\" also be fine`, true},
+		"embedded1":              sql.NullString{"value1=>x1", true},
+		"embedded2":              sql.NullString{`"value2"=>x2`, true},
+		"withnewlines":           sql.NullString{"\n\nvalue\t=>2", true},
+		"<<all sorts of crazy>>": sql.NullString{`this, "should,\" also, => be fine`, true},
 	}
 
 	// test encoding in query params, then decoding during Scan
 	testBidirectional := func(h Hstore) {
 		err = db.QueryRow("SELECT $1::hstore", h).Scan(&hs)
 		if err != nil {
-			t.Fatalf("re-query %d-pair map failed: %s", len(h.Map), err.Error())
+			t.Fatalf("re-query %d-pair map failed: %s", len(h), err.Error())
 		}
-		if hs.Map == nil {
-			t.Fatalf("expected %d-pair map, got null map", len(h.Map))
+		if hs == nil {
+			t.Fatalf("expected %d-pair map, got null map", len(h))
 		}
-		if len(hs.Map) != len(h.Map) {
-			t.Fatalf("expected %d-pair map, got len(map)=%d", len(h.Map), len(hs.Map))
+		if len(hs) != len(h) {
+			t.Fatalf("expected %d-pair map, got len(map)=%d", len(h), len(hs))
 		}
 
-		for key, val := range hs.Map {
-			otherval, found := h.Map[key]
+		for key, val := range hs {
+			otherval, found := h[key]
 			if !found {
-				t.Fatalf("  key '%v' not found in %d-pair map", key, len(h.Map))
+				t.Fatalf("  key '%v' not found in %d-pair map", key, len(h))
 			}
 			if otherval.Valid != val.Valid {
-				t.Fatalf("  value %v <> %v in %d-pair map", otherval, val, len(h.Map))
+				t.Fatalf("  value %v <> %v in %d-pair map", otherval, val, len(h))
 			}
 			if otherval.String != val.String {
-				t.Fatalf("  value '%v' <> '%v' in %d-pair map", otherval.String, val.String, len(h.Map))
+				t.Fatalf("  value '%v' <> '%v' in %d-pair map", otherval.String, val.String, len(h))
 			}
 		}
 	}


### PR DESCRIPTION
The htore type uses a struct, which ads an extra level of complexity and verbosity to the use of the hstore type with no tangible benefit. This pull-request redefines hstore as `type Hstore map[string]sql.NullString` which greatly increases the usability of this API.
