### PR TITLE
Use communicationError for network errors

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -412,7 +412,7 @@ func TestBadConn(t *testing.T) {
 
 	func() {
 		defer errRecover(&err)
-		panic(io.EOF)
+		panic(communicationError{io.EOF})
 	}()
 
 	if err != driver.ErrBadConn {

--- a/error.go
+++ b/error.go
@@ -3,8 +3,6 @@ package pq
 import (
 	"database/sql/driver"
 	"fmt"
-	"io"
-	"net"
 	"runtime"
 )
 
@@ -452,14 +450,10 @@ func errRecover(err *error) {
 		} else {
 			*err = v
 		}
-	case *net.OpError:
+	case communicationError:
 		*err = driver.ErrBadConn
 	case error:
-		if v == io.EOF || v.(error).Error() == "remote error: handshake failure" {
-			*err = driver.ErrBadConn
-		} else {
-			*err = v
-		}
+		*err = v
 
 	default:
 		panic(fmt.Sprintf("unknown error: %#v", e))


### PR DESCRIPTION
This seems cleaner than trying to maintain the list of errors which might have originated from operations on the network socket / TLS layer.

Any thoughts?
