### PR TITLE
Fix problems with pq.CopyIn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1031,6 +1031,10 @@ func (rs *rows) Next(dest []driver.Value) (err error) {
 	panic("not reached")
 }
 
+func quoteIdentifier(name string) string {
+	return `"` + strings.Replace(name, `"`, `""`, -1) + `"`;
+}
+
 func md5s(s string) string {
 	h := md5.New()
 	h.Write([]byte(s))


### PR DESCRIPTION
Here's an attempt at fixing the problem described in #214.  The docs could use some more massaging at least, but I think the technical side should be a bit less broken.  There was also a problem with user-issued rogue COPY messages destroying the protocol state, but I'm not sure I got it completely right yet.

I also tried to make the tests look more like the ones in conn_test.go, probably with varying success.

I'll have to take a closer look at this at a different time, but feel free to criticize before that.
