### PR TITLE
Fix typo in Errors chapter

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -106,7 +106,7 @@ Errors
 
 pq may return errors of type *pq.Error which can be interrogated for error details:
 
-        if err, ok := err.(*pq.Error), ok {
+        if err, ok := err.(*pq.Error); ok {
             fmt.Println("pq error:", err.Code.Name())
         }
 


### PR DESCRIPTION
Hi,

This commit fix a little typo in the documentation in Errors chapter. There is a comma instead of a semicolon in the if statement and believe me, as a beginner gopher it's difficult to figure out :)
