### PR TITLE
Add support for connect_timeout parameter

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -159,7 +159,7 @@ func Open(name string) (_ driver.Conn, err error) {
 		}
 	}
 
-	c, err := net.Dial(network(o))
+	c, err := dial(o)
 	if err != nil {
 		return nil, err
 	}
@@ -169,6 +169,25 @@ func Open(name string) (_ driver.Conn, err error) {
 	cn.buf = bufio.NewReader(cn.c)
 	cn.startup(o)
 	return cn, nil
+}
+
+func dial(o values) (net.Conn, error) {
+	ntw, addr := network(o)
+
+	timeout := o.Get("connect_timeout")
+	// Ensure the option will not be sent.
+	o.Unset("connect_timeout")
+
+	// Zero or not specified means wait indefinitely.
+	if timeout != "" && timeout != "0" {
+		seconds, err := strconv.ParseInt(timeout, 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		duration := time.Duration(seconds) * time.Second
+		return net.DialTimeout(ntw, addr, duration)
+	}
+	return net.Dial(ntw, addr)
 }
 
 func network(o values) (string, string) {
@@ -1162,7 +1181,7 @@ func parseEnviron(env []string) (out map[string]string) {
 		case "PGKRBSRVNAME", "PGGSSLIB":
 			unsupported()
 		case "PGCONNECT_TIMEOUT":
-			unsupported()
+			accrue("connect_timeout")
 		case "PGCLIENTENCODING":
 			accrue("client_encoding")
 		case "PGDATESTYLE":

--- a/conn_test.go
+++ b/conn_test.go
@@ -19,6 +19,7 @@ type Fatalistic interface {
 func openTestConnConninfo(conninfo string) (*sql.DB, error) {
 	datname := os.Getenv("PGDATABASE")
 	sslmode := os.Getenv("PGSSLMODE")
+	timeout := os.Getenv("PGCONNECT_TIMEOUT")
 
 	if datname == "" {
 		os.Setenv("PGDATABASE", "pqgotest")
@@ -26,6 +27,10 @@ func openTestConnConninfo(conninfo string) (*sql.DB, error) {
 
 	if sslmode == "" {
 		os.Setenv("PGSSLMODE", "disable")
+	}
+
+	if timeout == "" {
+		os.Setenv("PGCONNECT_TIMEOUT", "20")
 	}
 
 	return sql.Open("postgres", conninfo)
@@ -722,6 +727,10 @@ var envParseTests = []struct {
 	{
 		Env:      []string{"PGDATESTYLE=ISO, MDY"},
 		Expected: map[string]string{"datestyle": "ISO, MDY"},
+	},
+	{
+		Env:      []string{"PGCONNECT_TIMEOUT=30"},
+		Expected: map[string]string{"connect_timeout": "30"},
 	},
 }
 

--- a/doc.go
+++ b/doc.go
@@ -46,6 +46,7 @@ supported:
 	* port - The port to bind to. (default is 5432)
 	* sslmode - Whether or not to use SSL (default is require, this is not the default for libpq)
 	* fallback_application_name - An application_name to fall back to if one isn't provided.
+	* connect_timeout - Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely.
 
 Valid values for sslmode are:
 


### PR DESCRIPTION
Make the driver recognize and use [connect_timeout](http://www.postgresql.org/docs/9.3/static/libpq-connect.html#LIBPQ-CONNECT-CONNECT-TIMEOUT) as indicated by postgres documentation.
Also set a low value for  `PGCONNECT_TIMEOUT` when running test.
