### PR TITLE
Avoid concurrent use of the scratch buffer in copyin.Close

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -532,7 +532,7 @@ func (cn *conn) Close() (err error) {
 
 	// Don't go through send(); ListenerConn relies on us not scribbling on the
 	// scratch buffer of this connection.
-	_, err = cn.c.Write([]byte("X\x00\x00\x00\x04"))
+	err = cn.sendSimpleMessage('X')
 	if err != nil {
 		return err
 	}
@@ -600,6 +600,14 @@ func (cn *conn) send(m *writeBuf) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// Send a message of type typ to the server on the other end of cn.  The
+// message should have no payload.  This method does not use the scratch
+// buffer.
+func (cn *conn) sendSimpleMessage(typ byte) (err error) {
+	_, err = cn.c.Write([]byte{typ, '\x00', '\x00', '\x00', '\x04'})
+	return err
 }
 
 // recvMessage receives any message from the backend, or returns an error if

--- a/copy.go
+++ b/copy.go
@@ -225,7 +225,11 @@ func (ci *copyin) Close() (err error) {
 	if len(ci.buffer) > 0 {
 		ci.flush(ci.buffer)
 	}
-	ci.cn.send(ci.cn.writeBuf('c'))
+	// Avoid touching the scratch buffer as resploop could be using it.
+	err = ci.cn.sendSimpleMessage('c')
+	if err != nil {
+		return err
+	}
 
 	<-ci.done
 


### PR DESCRIPTION
This should fix the problem I managed to reproduce in #235.  I'll have to do another pass over that code to see if there are other similar problems or if something else could explain the Travis failure, but I think we should commit this in the meanwhile.
