### PR TITLE
Fix handling of auth errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,6 @@ before_install:
   - sudo sh -c "echo deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main $PGVERSION >> /etc/apt/sources.list.d/postgresql.list"
   - sudo apt-get update -qq
   - sudo apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::="--force-confnew" install postgresql-$PGVERSION postgresql-server-dev-$PGVERSION postgresql-contrib-$PGVERSION
-  - sudo chmod 777 /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - sudo echo "local   all         postgres                          trust" > /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - sudo echo "local   all         all                               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - sudo echo "host    all         all         127.0.0.1/32          trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - sudo echo "host    all         all         ::1/128               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - sudo /etc/init.d/postgresql restart
 
 env:
   matrix:
@@ -32,7 +26,28 @@ env:
     - PGVERSION=8.4
 
 script:
- - env PGUSER=postgres go test -v ./...
+  - export PGUSER=pqgotest
+  - export PGPASSWORD=pqgotest
+  - export TEST_PGAUTHMETHOD=trust
+  - sudo -u postgres sh -c "echo 'local all postgres trust' >  /etc/postgresql/$PGVERSION/main/pg_hba.conf"
+  - sudo -u postgres sh -c "echo 'host pqgotest all 127.0.0.1/32 $TEST_PGAUTHMETHOD' >>  /etc/postgresql/$PGVERSION/main/pg_hba.conf"
+  - sudo /etc/init.d/postgresql restart
+  - go test -v ./...
+  - export TEST_PGAUTHMETHOD=md5
+  - sudo -u postgres sh -c "echo 'local all postgres trust' >  /etc/postgresql/$PGVERSION/main/pg_hba.conf"
+  - sudo -u postgres sh -c "echo 'host pqgotest all 127.0.0.1/32 $TEST_PGAUTHMETHOD' >>  /etc/postgresql/$PGVERSION/main/pg_hba.conf"
+  - sudo /etc/init.d/postgresql restart
+  - go test -v ./...
+  - export TEST_PGAUTHMETHOD=password
+  - sudo -u postgres sh -c "echo 'local all postgres trust' >  /etc/postgresql/$PGVERSION/main/pg_hba.conf"
+  - sudo -u postgres sh -c "echo 'host pqgotest all 127.0.0.1/32 $TEST_PGAUTHMETHOD' >>  /etc/postgresql/$PGVERSION/main/pg_hba.conf"
+  - sudo /etc/init.d/postgresql restart
+  - go test -v ./...
 
 before_script:
- - psql -c 'create database pqgotest;' -U postgres
+  - sudo -u postgres sh -c "echo 'local all postgres trust' >  /etc/postgresql/$PGVERSION/main/pg_hba.conf"
+  - sudo /etc/init.d/postgresql restart
+  - psql -U postgres -c "create user pqgotest with password 'pqgotest'"
+  - psql -U postgres -c 'create database pqgotest'
+  - psql -U postgres -c "create extension if not exists hstore" pqgotest
+  - psql -U postgres -c "grant all privileges on database pqgotest to pqgotest"

--- a/conn.go
+++ b/conn.go
@@ -779,7 +779,8 @@ func (cn *conn) startup(o values) {
 func (cn *conn) auth(r *readBuf, o values) {
 	switch code := r.int32(); code {
 	case 0:
-		// OK
+		// This means the server is trust-ing connections... hence
+		// no challenge for password, md5 etc is made
 	case 3:
 		w := cn.writeBuf('p')
 		w.string(o.Get("password"))
@@ -790,7 +791,7 @@ func (cn *conn) auth(r *readBuf, o values) {
 			panic(err)
 		}
 		if t == 'E' {
-			// auth error
+			// auth error - either username or password not correct
 			errorf(parseError(r).Message)
 		}
 		if t != 'R' {
@@ -811,7 +812,7 @@ func (cn *conn) auth(r *readBuf, o values) {
 			panic(err)
 		}
 		if t == 'E' {
-			// auth error
+			// auth error - either username or password not correct
 			errorf(parseError(r).Message)
 		}
 		if t != 'R' {

--- a/conn_test.go
+++ b/conn_test.go
@@ -396,7 +396,7 @@ func TestNoData(t *testing.T) {
 func TestError(t *testing.T) {
 	// Don't use the normal connection setup, this is intended to
 	// blow up in the startup packet from a non-existent user.
-	// this also serves to test a bad password
+	// this also serves to test a bad password where TEST_PGAUTHMETHOD is password or md5
 	bad_user := "thisuserreallydoesntexist"
 	db, err := openTestConnConninfo("user=" + bad_user)
 	if err != nil {
@@ -409,8 +409,23 @@ func TestError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	if err.Error() != fmt.Sprintf("pq: password authentication failed for user \"%s\"", bad_user) {
-		t.Fatalf("expected authentication failed, got: %v", err)
+	tm := os.Getenv("TEST_PGAUTHMETHOD")
+	switch tm {
+	case "trust":
+		// no auth challenge is issued
+		// behaviour very much depends on the wider pg_hba.conf setup of the user
+		// i.e. does a route exist for bad_user
+		// testing every case here isn't sensible. we don't handle this in *conn.startup...
+		// hence we will just ensure we get the generic bad connection error
+		if err != driver.ErrBadConn {
+			t.Fatalf("expected driver.ErrBadConn, got: %v", err)
+		}
+	case "md5", "password":
+		if err.Error() != fmt.Sprintf("pq: password authentication failed for user \"%s\"", bad_user) {
+			t.Fatalf("expected authentication failed, got: %v", err)
+		}
+	default:
+		t.Fatalf("Need to ensure TEST_PGAUTHMETHOD is set to known value. Got %s", tm)
 	}
 }
 

--- a/hstore/hstore_test.go
+++ b/hstore/hstore_test.go
@@ -35,10 +35,13 @@ func TestHstore(t *testing.T) {
 	db := openTestConn(t)
 	defer db.Close()
 
-	// quitely create hstore if it doesn't exist
-	_, err := db.Exec("CREATE EXTENSION IF NOT EXISTS hstore")
-	if err != nil {
-		t.Log("Skipping hstore tests - hstore extension create failed. " + err.Error())
+	// ** IMPORTANT **
+	// test whether the superuser has setup hstore
+	// we want tests to run as unprivileged user
+	var i int
+	err := db.QueryRow("select count(*) from pg_extension where extname='hstore'").Scan(&i)
+	if i != 1 {
+		t.Skip("Skipping hstore tests - hstore extension not installed in this database")
 		return
 	}
 


### PR DESCRIPTION
Authentication errors previously returned a rather cryptic message:

``` go
package main

import (
   "database/sql"
   _ "github.com/lib/pq"
   "log"
)

func main() {
   db, err := sql.Open("postgres", "postgres://myitcv:@localhost/myitcv")
   if err != nil {
      log.Fatal(err)
   }

   err = db.Ping()
   if err != nil {
      log.Fatal(err)
   }
}
```

previously returned:

```
driver: bad connection
```

This PR fixes that such that the output is:

```
pq: password authentication failed for user "myitcv"
```

Test updated to cover this change.

Note that `conn_test.go` only covers the [`AuthenticationMD5Password` case of the auth switch](https://github.com/myitcv/pq/blob/8da4eb273c1b00983fdbd1a6b41a9d44350c4a0c/conn.go#L803). This PR does not attempt to increase coverage.

Indeed I'm at something of a loss to explain why this branch is even hit given the configuration in [`.travis.yml`](https://github.com/myitcv/pq/blob/master/.travis.yml) for `pg_hba.conf` - is MD5 something of a default?

Hence the `AuthenticationCleartextPassword` case remains untested.... because I can't work out how to test the other case.
