### PR TITLE
Convert time to the UTC before sending to the server.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -35,7 +35,7 @@ func encode(parameterStatus *parameterStatus, x interface{}, pgtypOid oid.Oid) [
 	case bool:
 		return []byte(fmt.Sprintf("%t", v))
 	case time.Time:
-		return []byte(v.Format(time.RFC3339Nano))
+		return []byte(v.UTC().Format(time.RFC3339Nano))
 	default:
 		errorf("encode: unknown type for %T", v)
 	}
@@ -96,7 +96,7 @@ func appendEncodedText(parameterStatus *parameterStatus, buf []byte, x interface
 	case bool:
 		return strconv.AppendBool(buf, v)
 	case time.Time:
-		return append(buf, v.Format(time.RFC3339Nano)...)
+		return append(buf, v.UTC().Format(time.RFC3339Nano)...)
 	case nil:
 		return append(buf, "\\N"...)
 	default:


### PR DESCRIPTION
This patch improves timestamp support in case like this: https://gist.github.com/vmihailenco/6a7432d7c51c7fa8a718

Before this patch:
2014-03-26 16:31:24.341358434 +0200 EET 2014-03-26 16:31:24.341358 +0200 +0200

After:
2014-03-26 16:43:17.181876703 +0200 EET 2014-03-26 14:43:17.181877 +0000 +0000

Discovered this while working on the https://github.com/vmihailenco/pg/issues/4 . You can take tests there if you want...
