### PR TITLE
Allow passing []byte slice into uuid field

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -5,12 +5,13 @@ import (
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
-	"github.com/lib/pq/oid"
 	"math"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/lib/pq/oid"
 )
 
 func encode(parameterStatus *parameterStatus, x interface{}, pgtypOid oid.Oid) []byte {
@@ -25,7 +26,12 @@ func encode(parameterStatus *parameterStatus, x interface{}, pgtypOid oid.Oid) [
 		if pgtypOid == oid.T_bytea {
 			return encodeBytea(parameterStatus.serverVersion, v)
 		}
-
+		if pgtypOid == oid.T_uuid {
+			if len(v) != 16 {
+				errorf("encode: slice of %v bytes, while server expects 16 byte uuid", v)
+			}
+			return []byte(fmt.Sprintf("%x", v))
+		}
 		return v
 	case string:
 		if pgtypOid == oid.T_bytea {

--- a/encode.go
+++ b/encode.go
@@ -28,7 +28,7 @@ func encode(parameterStatus *parameterStatus, x interface{}, pgtypOid oid.Oid) [
 		}
 		if pgtypOid == oid.T_uuid {
 			if len(v) != 16 {
-				errorf("encode: slice of %v bytes, while server expects 16 byte uuid", v)
+				errorf("encode: got slice of %v bytes, while server expects 16 byte uuid", len(v))
 			}
 			return []byte(fmt.Sprintf("%x", v))
 		}

--- a/encode.go
+++ b/encode.go
@@ -53,6 +53,13 @@ func encode(parameterStatus *parameterStatus, x interface{}, pgtypOid oid.Oid) [
 
 func decode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) interface{} {
 	switch typ {
+	case oid.T_uuid:
+		g := strings.Replace(string(s), "-", "", -1)
+		b, err := hex.DecodeString(g)
+		if err != nil {
+			errorf("decode: error while decoding uuid: %v", err)
+		}
+		return b
 	case oid.T_bytea:
 		return parseBytea(s)
 	case oid.T_timestamptz:

--- a/error.go
+++ b/error.go
@@ -468,11 +468,13 @@ func errRecover(err *error) {
 		panic(v)
 	case *Error:
 		if v.Fatal() {
+			l.Error("ErrBadConn: %s %s", v.Code, v.Message)
 			*err = driver.ErrBadConn
 		} else {
 			*err = v
 		}
 	case *net.OpError:
+		l.Error("ErrBadConn: %s ", v.Error())
 		*err = driver.ErrBadConn
 	case error:
 		if v == io.EOF || v.(error).Error() == "remote error: handshake failure" {

--- a/log.go
+++ b/log.go
@@ -1,0 +1,5 @@
+package pq
+
+import "github.com/op/go-logging"
+
+var l = logging.MustGetLogger("pq")


### PR DESCRIPTION
Postgresql supports [UUID](http://www.postgresql.org/docs/8.3/static/datatype-uuid.html) type for 16byte identifiers. This pull requests allows passing 16byte slices to `uuid` params instead of throwing "invalid UTF-8 encoding" error.