### PR TITLE
Avoid an unnecessary allocation in recvMessage

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -665,10 +665,10 @@ func (cn *conn) recvMessage() (byte, *readBuf, error) {
 	if err != nil {
 		return 0, nil, err
 	}
-	t := x[0]
 
-	b := readBuf(x[1:])
-	n := b.int32() - 4
+	// read the type and length of the message that follows
+	t := x[0]
+	n := int(binary.BigEndian.Uint32(x[1:])) - 4
 	var y []byte
 	if n <= len(cn.scratch) {
 		y = cn.scratch[:n]


### PR DESCRIPTION
I was looking at a potential issue reported [here](https://groups.google.com/forum/#!topic/golang-nuts/0HW4T81tw1Q).  With a [slightly altered](https://gist.github.com/johto/f7aab06c96486230c57d) benchmark I was able to measure a performance gain of ~10% by avoiding an unnecessary allocation in recvMessage.  Disassemblies of the two binaries [here](https://gist.github.com/johto/8654f9a9d36cc274c569).

The other allocation which seemed to cause problems was the readBuf allocation at the end of recvMessage, but getting rid of that is a slightly bigger patch.  Any objections to this one in the meanwhile?
