### PR TITLE
Test against Go 1.3 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.0.3
   - 1.1
   - 1.2
+  - 1.3
   - tip
 
 before_install:


### PR DESCRIPTION
Here's a PR for $SUBJECT.  Any objections, assuming this actually builds?

While we're changing Travis configuration, do we still need to specifically test against Go 1.0.2?  Would 1.0.3 not be enough?  (Has anyone thought about dropping support for Go 1.0?)
