### PR TITLE
Set ServerName in tlsConf when using verify-full mode.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -738,7 +738,7 @@ func (cn *conn) ssl(o values) {
 	case "require", "":
 		tlsConf.InsecureSkipVerify = true
 	case "verify-full":
-		// fall out
+		tlsConf.ServerName = o.Get("host")
 	case "disable":
 		return
 	default:


### PR DESCRIPTION
I found this to be necessary as my client broke when making SSL connects to postgres after the go 1.3 update. It seems that when using tls.Client, either ServerName or InsecureSkipVerify must be specified.

The tls authors seem to recommend using Dial; this takes care of setting ServerName for verification. That may be more appropriate, but this change at least fixes the immediate issue.

AFAICT, In go 1.2 if ServerName was not specified and tls.Client was used, no hostname checking was done, making MITM possible.
