### PR TITLE
Implement sslmode=verify-ca

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/md5"
 	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/binary"
@@ -789,10 +790,16 @@ func (cn *conn) recv1() (t byte, r *readBuf) {
 }
 
 func (cn *conn) ssl(o values) {
+	verifyCaOnly := false
 	tlsConf := tls.Config{}
 	switch mode := o.Get("sslmode"); mode {
 	case "require", "":
 		tlsConf.InsecureSkipVerify = true
+	case "verify-ca":
+		// We must skip TLS's own verification since it requires full
+		// verification since Go 1.3.
+		tlsConf.InsecureSkipVerify = true
+		verifyCaOnly = true
 	case "verify-full":
 		tlsConf.ServerName = o.Get("host")
 	case "disable":
@@ -817,7 +824,29 @@ func (cn *conn) ssl(o values) {
 		panic(ErrSSLNotSupported)
 	}
 
-	cn.c = tls.Client(cn.c, &tlsConf)
+	client := tls.Client(cn.c, &tlsConf)
+	if verifyCaOnly {
+		err = client.Handshake()
+		if err != nil {
+			panic(err)
+		}
+		certs := client.ConnectionState().PeerCertificates
+		opts := x509.VerifyOptions{
+			DNSName: client.ConnectionState().ServerName,
+			Intermediates: x509.NewCertPool(),
+		}
+		for i, cert := range certs {
+			if i == 0 {
+				continue
+			}
+			opts.Intermediates.AddCert(cert)
+		}
+		_, err = certs[0].Verify(opts)
+		if err != nil {
+			panic(err)
+		}
+	}
+	cn.c = client
 }
 
 // This function sets up SSL client certificates based on either the "sslkey"

--- a/doc.go
+++ b/doc.go
@@ -54,7 +54,8 @@ Valid values for sslmode are:
 
 	* disable - No SSL
 	* require - Always SSL (skip verification)
-	* verify-full - Always SSL (require verification)
+	* verify-ca - Always SSL (verify that the certificate presented by the server was signed by a trusted CA)
+	* verify-full - Always SSL (verify that the certification presented by the server was signed by a trusted CA and the server host name matches the one in the certificate)
 
 See http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
 for more information about connection string parameters.


### PR DESCRIPTION
Here's a patch for $SUBJECT according to agl's instructions [here](https://groups.google.com/forum/#!msg/golang-nuts/4vnt7NdLvVU/b1SJ4u0ikb0J).  I've verified that it appears to be working by testing it locally, but I certainly acknowledge the need for automated testing in Travis.
