### PR TITLE
Cache time.Location for Better parseTs Performance

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -372,7 +372,7 @@ func BenchmarkDecodeTimestamptzMultiThread(b *testing.B) {
 	f := func(wg *sync.WaitGroup, loops int) {
 		defer wg.Done()
 		for i := 0; i < loops; i++ {
-		decode(&parameterStatus{}, testTimestamptzBytes, oid.T_timestamptz)
+			decode(&parameterStatus{}, testTimestamptzBytes, oid.T_timestamptz)
 		}
 	}
 
@@ -380,7 +380,7 @@ func BenchmarkDecodeTimestamptzMultiThread(b *testing.B) {
 	b.ResetTimer()
 	for j := 0; j < 10; j++ {
 		wg.Add(1)
-		go f(wg, b.N / 10)
+		go f(wg, b.N/10)
 	}
 	wg.Wait()
 }
@@ -409,7 +409,7 @@ func BenchmarkLocationCacheMultiThread(b *testing.B) {
 	b.ResetTimer()
 	for j := 0; j < 10; j++ {
 		wg.Add(1)
-		go f(wg, b.N / 10)
+		go f(wg, b.N/10)
 	}
 	wg.Wait()
 }

--- a/encode.go
+++ b/encode.go
@@ -179,11 +179,11 @@ func mustAtoi(str string) int {
 	}
 	return result
 }
-  
+
 // The location cache caches the time zones typically used by the client. A RWMutex does not seem to improve performance.
 type locationCache struct {
 	cache map[int]*time.Location
-	lock sync.Mutex
+	lock  sync.Mutex
 }
 
 // All connections share the same list of timezones. Benchmarking shows that about 5% speed could be gained by putting
@@ -192,22 +192,22 @@ type locationCache struct {
 var globalLocationCache *locationCache = newLocationCache()
 
 func newLocationCache() *locationCache {
-	return &locationCache { cache: make(map[int]*time.Location) }
+	return &locationCache{cache: make(map[int]*time.Location)}
 }
 
 // Returns the cached timezone for the specified offset, creating and caching it if necessary.
 func (c *locationCache) getLocation(offset int) *time.Location {
- 	c.lock.Lock()
- 	defer c.lock.Unlock()
- 
- 	location, ok := c.cache[offset]
- 	if !ok {
- 		location = time.FixedZone("", offset)
- 		c.cache[offset] = location
- 	}
- 
- 	return location
- }
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	location, ok := c.cache[offset]
+	if !ok {
+		location = time.FixedZone("", offset)
+		c.cache[offset] = location
+	}
+
+	return location
+}
 
 // This is a time function specific to the Postgres default DateStyle
 // setting ("ISO, MDY"), the only one we currently support. This


### PR DESCRIPTION
Previously a new time.FixedZone was created for every single timestamp fetched from the database. The time library treats the Location struct as immutable. It is also somewhat expensive to create as it uses two arrays internally in addition to the object itself. Since most applications will use relatively few time zones, caching is a good option to improve the performance here.

Prior Benchmark:
BenchmarkDecodeTimestamptz       1000000              1005 ns/op             213 B/op          5 allocs/op

Committed Benchmark:
BenchmarkDecodeTimestamptz       2000000               815 ns/op              66 B/op          2 allocs/op

Caching gives us slightly under a 20% speed improvement mostly coming from the reduction in allocations.
