### PR TITLE
Correctly encode time zones with seconds

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -88,6 +88,27 @@ func TestParseTs(t *testing.T) {
 	}
 }
 
+var formatTimeTests = []struct {
+	time     time.Time
+	expected string
+}{
+	{time.Time{}, "0001-01-01T00:00:00Z"},
+	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 0)), "2001-02-03T04:05:06.123456789Z"},
+	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 2*60*60)), "2001-02-03T04:05:06.123456789+02:00"},
+	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", -6*60*60)), "2001-02-03T04:05:06.123456789-06:00"},
+	{time.Date(1, time.January, 1, 0, 0, 0, 0, time.FixedZone("", 19*60+32)), "0001-01-01T00:00:00+00:19:32"},
+	{time.Date(2001, time.February, 3, 4, 5, 6, 0, time.FixedZone("", -(7*60*60+30*60+9))), "2001-02-03T04:05:06-07:30:09"},
+}
+
+func TestFormatTs(t *testing.T) {
+	for i, tt := range formatTimeTests {
+		val := string(formatTs(tt.time))
+		if val != tt.expected {
+			t.Errorf("%d: incorrect time format '%v', want '%v'", i, val, tt.expected)
+		}
+	}
+}
+
 func TestTimestampWithTimeZone(t *testing.T) {
 	db := openTestConn(t)
 	defer db.Close()


### PR DESCRIPTION
The previously used RFC3339Nano format to encode times does not take
seconds into account for time zones. This commit fixes that by appending
the time zone seconds to the formatted time, but only if it's non-zero.

Fixes #286
