### PR TITLE
Move driver registration to a sub-package.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,12 +4,10 @@ import (
 	"bufio"
 	"crypto/md5"
 	"crypto/tls"
-	"database/sql"
 	"database/sql/driver"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/lib/pq/oid"
 	"io"
 	"net"
 	"os"
@@ -18,6 +16,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/lib/pq/oid"
 )
 
 // Common error types
@@ -26,16 +26,6 @@ var (
 	ErrNotSupported        = errors.New("pq: Unsupported command")
 	ErrInFailedTransaction = errors.New("pq: Could not complete operation in a failed transaction")
 )
-
-type drv struct{}
-
-func (d *drv) Open(name string) (driver.Conn, error) {
-	return Open(name)
-}
-
-func init() {
-	sql.Register("postgres", &drv{})
-}
 
 type parameterStatus struct {
 	// server version in the same format as server_version_num, or 0 if

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -1,0 +1,19 @@
+// Package driver registers the lib/pq driver for use with database/sql.
+package driver
+
+import (
+	"database/sql"
+	"database/sql/driver"
+
+	"github.com/lib/pq"
+)
+
+type drv struct{}
+
+func (d *drv) Open(name string) (driver.Conn, error) {
+	return pq.Open(name)
+}
+
+func init() {
+	sql.Register("postgres", &drv{})
+}


### PR DESCRIPTION
I don't really expect this to be merged since it's not backwards compatible, but just wanna open it up for some discussion.

Currently, if you want to use `pq` as a library and wrap it with your own postgres driver (say, to increment statsd counters when opening/closing connections), you have to register your own driver under a different name or database/sql will complain.

Moving the driver registration to a sub-package alleviates this problem.
