### PR TITLE
Support extra decode types

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -75,6 +75,8 @@ func decode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) interface{}
 			errorf("%s", err)
 		}
 		return f
+	case oid.T_varchar, oid.T_text:
+		return string(s)
 	}
 
 	return s

--- a/encode_test.go
+++ b/encode_test.go
@@ -330,6 +330,26 @@ func TestByteaOutputFormats(t *testing.T) {
 	testByteaOutputFormat("escape")
 }
 
+func TestTextOutput(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	s := "hello world"
+	var resText, resVarchar interface{}
+	err := db.QueryRow("SELECT $1::text, $2::varchar", s, s).Scan(&resText, &resVarchar)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := resText.(string); !ok {
+		t.Errorf("unexpected data type output: %T", resText)
+	}
+
+	if _, ok := resVarchar.(string); !ok {
+		t.Errorf("unexpected data type output: %T", resVarchar)
+	}
+}
+
 func TestAppendEncodedText(t *testing.T) {
 	var buf []byte
 


### PR DESCRIPTION
This adds support for decoding `varchar`, `text` -> **string** and `numeric` -> **float**.

The use case is scanning a row with an `interface{}` type when the postgres column types are unknown.This will currently decode columns of text and numeric types as `[]uint8`. 