### PR TITLE
Partially fix setup for SSL tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,14 @@ before_install:
   - sudo sh -c "echo 127.0.0.1 postgres >> /etc/hosts"
   - sudo ls -l /var/lib/postgresql/$PGVERSION/main/
   - sudo cat /etc/postgresql/$PGVERSION/main/postgresql.conf
-  - sudo chmod og-xwr certs/postgresql.key
+  - sudo chmod 600 $PQSSLCERTTEST_PATH/postgresql.key
   - sudo /etc/init.d/postgresql restart
 
 env:
   global:
     - PGUSER=postgres
     - PQGOSSLTESTS=1
-    - PQSSLCERTTEST_CERT=$PWD/certs/postgresql.crt
-    - PQSSLCERTTEST_KEY=$PWD/certs/postgresql.key
+    - PQSSLCERTTEST_PATH=$PWD/certs
   matrix:
     - PGVERSION=9.3
     - PGVERSION=9.2


### PR DESCRIPTION
1. The tests look for `PQSSLCERTTEST_PATH` rather than `PQSSLCERTTEST_CERT` or `PQSSLCERTTEST_KEY` when skipping.
2. `chmod` of the key by relative path did not seem to change the file for tests, but `PQSSLCERTTEST_PATH` does.
3. :boom: The `verify-ca` and `verify-full` tests are no longer skipped, but they fail with the following error:
   
   ```
   x509: certificate signed by unknown authority
   ```
   
   I'm not sure what to do with those.
