### PR TITLE
Use testing.TB instead of custom Fatalistic interface

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -13,10 +13,6 @@ import (
 	"time"
 )
 
-type Fatalistic interface {
-	Fatal(args ...interface{})
-}
-
 func openTestConnConninfo(conninfo string) (*sql.DB, error) {
 	datname := os.Getenv("PGDATABASE")
 	sslmode := os.Getenv("PGSSLMODE")
@@ -37,7 +33,7 @@ func openTestConnConninfo(conninfo string) (*sql.DB, error) {
 	return sql.Open("postgres", conninfo)
 }
 
-func openTestConn(t Fatalistic) *sql.DB {
+func openTestConn(t testing.TB) *sql.DB {
 	conn, err := openTestConnConninfo("")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Small bit of cleanup. AFAICT there is no need for this interface to exist since we can just use `testing.TB` instead.

Unless it's been left there for backwards compatibility reasons?
