### PR TITLE
Optionally enable infinity timestamp(tz)

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -207,11 +207,68 @@ func (c *locationCache) getLocation(offset int) *time.Location {
 	return location
 }
 
+var infinityTsEnabled = false
+var infinityTsNegative time.Time
+var infinityTsPositive time.Time
+
+const (
+	negativeInfinityString          = "-infinity"
+	positiveInfinityString          = "infinity"
+	infinityTsEnabledAlready        = "pq: infinity timestamp enabled already"
+	infinityTsNegativeMustBeSmaller = "pq: infinity timestamp: negative value must be smaller (before) than positive"
+)
+
+/**
+ * If EnableInfinityTs is not called, "-infinity" and "infinity" will return
+ * []byte("-infinity") and []byte("infinity") respectively, and potentially
+ * cause error "sql: Scan error on column index 0: unsupported driver -> Scan pair: []uint8 -> *time.Time",
+ * unless the input param is `*interface{}` instead of `*time.Time`
+ *
+ * If EnableInfinityTs is called with negative >= positive, it will panic
+ *
+ * If EnableInfinityTs is called once correctly, it enables this driver to decode
+ * Postgres' "-infinity" and "infinity" to predefined boundary minimum and maximum time.
+ * When encoding, any time that equals or exceeds predefined minimum or maximum time
+ * will be encoded to "-infinity" and "infinity" respectively.
+ *
+ * If EnableInfinityTs is called more than once, it will panic.
+ */
+func EnableInfinityTs(negative time.Time, positive time.Time) {
+	if infinityTsEnabled {
+		panic(infinityTsEnabledAlready)
+	}
+	if !negative.Before(positive) {
+		panic(infinityTsNegativeMustBeSmaller)
+	}
+	infinityTsEnabled = true
+	infinityTsNegative = negative
+	infinityTsPositive = positive
+}
+
+/**
+ * Testing might want to toggle infinityTsEnabled
+ */
+func disableInfinityTs() {
+	infinityTsEnabled = false
+}
+
 // This is a time function specific to the Postgres default DateStyle
 // setting ("ISO, MDY"), the only one we currently support. This
 // accounts for the discrepancies between the parsing available with
 // time.Parse and the Postgres date formatting quirks.
-func parseTs(currentLocation *time.Location, str string) (result time.Time) {
+func parseTs(currentLocation *time.Location, str string) interface{} {
+	switch str {
+	case negativeInfinityString:
+		if infinityTsEnabled {
+			return infinityTsNegative
+		}
+		return []byte(negativeInfinityString)
+	case positiveInfinityString:
+		if infinityTsEnabled {
+			return infinityTsPositive
+		}
+		return []byte(positiveInfinityString)
+	}
 	monSep := strings.IndexRune(str, '-')
 	// this is Gregorian year, not ISO Year
 	// In Gregorian system, the year 1 BC is followed by AD 1
@@ -307,6 +364,16 @@ func parseTs(currentLocation *time.Location, str string) (result time.Time) {
 
 // formatTs formats t into a format postgres understands.
 func formatTs(t time.Time) (b []byte) {
+	if infinityTsEnabled {
+		// t <= -infinity : ! (t > -infinity)
+		if !t.After(infinityTsNegative) {
+			return []byte(negativeInfinityString)
+		}
+		// t >= infinity : ! (!t < infinity)
+		if !t.Before(infinityTsPositive) {
+			return []byte(positiveInfinityString)
+		}
+	}
 	// Need to send dates before 0001 A.D. with " BC" suffix, instead of the
 	// minus sign preferred by Go.
 	// Beware, "0000" in ISO is "1 BC", "-0001" is "2 BC" and so on

--- a/encode_test.go
+++ b/encode_test.go
@@ -78,7 +78,11 @@ func tryParse(str string) (t time.Time, err error) {
 			return
 		}
 	}()
-	t = parseTs(nil, str)
+	i := parseTs(nil, str)
+	t, ok := i.(time.Time)
+	if !ok {
+		err = fmt.Errorf("Not a time.Time type, got %#v", i)
+	}
 	return
 }
 
@@ -257,6 +261,131 @@ func TestTimestampWithOutTimezone(t *testing.T) {
 
 	// Test higher precision time
 	test("2013-01-04T20:14:58.80033Z", "2013-01-04 20:14:58.80033")
+}
+
+func TestInfinityTimestamp(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+	var err error
+	var resultT time.Time
+
+	expectedError := fmt.Errorf(`sql: Scan error on column index 0: unsupported driver -> Scan pair: []uint8 -> *time.Time`)
+	type testCases []struct {
+		Query       string
+		Param       string
+		ExpectedErr error
+		ExpectedVal interface{}
+	}
+	tc := testCases{
+		{"SELECT $1::timestamp", "-infinity", expectedError, negativeInfinityString},
+		{"SELECT $1::timestamptz", "-infinity", expectedError, negativeInfinityString},
+		{"SELECT $1::timestamp", "infinity", expectedError, positiveInfinityString},
+		{"SELECT $1::timestamptz", "infinity", expectedError, positiveInfinityString},
+	}
+	// try to assert []byte to time.Time
+	for _, q := range tc {
+		err = db.QueryRow(q.Query, q.Param).Scan(&resultT)
+		if err.Error() != q.ExpectedErr.Error() {
+			t.Errorf("Scanning -/+infinity, expected error, %q, got %q", q.ExpectedErr, err)
+		}
+	}
+	// yield []byte
+	for _, q := range tc {
+		var resultI interface{}
+		err = db.QueryRow(q.Query, q.Param).Scan(&resultI)
+		if err != nil {
+			t.Errorf("Scanning -/+infinity, expected no error, got %q", err)
+		}
+		result, ok := resultI.([]byte)
+		if !ok {
+			t.Errorf("Scanning -/+infinity, expected []byte, got %#v", resultI)
+		}
+		if string(result) != q.ExpectedVal {
+			t.Errorf("Scanning -/+infinity, expected %q, got %q", q.ExpectedVal, result)
+		}
+	}
+
+	y1500 := time.Date(1500, time.January, 1, 0, 0, 0, 0, time.UTC)
+	y2500 := time.Date(2500, time.January, 1, 0, 0, 0, 0, time.UTC)
+	EnableInfinityTs(y1500, y2500)
+
+	err = db.QueryRow("SELECT $1::timestamp", positiveInfinityString).Scan(&resultT)
+	if err != nil {
+		t.Errorf("Scanning infinity, expected no error, got %q", err)
+	}
+	if !resultT.Equal(y2500) {
+		t.Errorf("Scanning infinity, expected %q, got %q", y2500, resultT)
+	}
+
+	err = db.QueryRow("SELECT $1::timestamptz", positiveInfinityString).Scan(&resultT)
+	if err != nil {
+		t.Errorf("Scanning infinity, expected no error, got %q", err)
+	}
+	if !resultT.Equal(y2500) {
+		t.Errorf("Scanning Infinity, expected time %q, got %q", y2500, resultT.String())
+	}
+
+	err = db.QueryRow("SELECT $1::timestamp", negativeInfinityString).Scan(&resultT)
+	if err != nil {
+		t.Errorf("Scanning -infinity, expected no error, got %q", err)
+	}
+	if !resultT.Equal(y1500) {
+		t.Errorf("Scanning -infinity, expected time %q, got %q", y1500, resultT.String())
+	}
+
+	err = db.QueryRow("SELECT $1::timestamptz", negativeInfinityString).Scan(&resultT)
+	if err != nil {
+		t.Errorf("Scanning -infinity, expected no error, got %q", err)
+	}
+	if !resultT.Equal(y1500) {
+		t.Errorf("Scanning -infinity, expected time %q, got %q", y1500, resultT.String())
+	}
+
+	y_1500 := time.Date(-1500, time.January, 1, 0, 0, 0, 0, time.UTC)
+	y11500 := time.Date(11500, time.January, 1, 0, 0, 0, 0, time.UTC)
+	var s string
+	err = db.QueryRow("SELECT $1::timestamp::text", y_1500).Scan(&s)
+	if err != nil {
+		t.Errorf("Encoding -infinity, expected no error, got %q", err)
+	}
+	if s != negativeInfinityString {
+		t.Errorf("Encoding -infinity, expected %q, got %q", negativeInfinityString, s)
+	}
+	err = db.QueryRow("SELECT $1::timestamptz::text", y_1500).Scan(&s)
+	if err != nil {
+		t.Errorf("Encoding -infinity, expected no error, got %q", err)
+	}
+	if s != negativeInfinityString {
+		t.Errorf("Encoding -infinity, expected %q, got %q", negativeInfinityString, s)
+	}
+
+	err = db.QueryRow("SELECT $1::timestamp::text", y11500).Scan(&s)
+	if err != nil {
+		t.Errorf("Encoding infinity, expected no error, got %q", err)
+	}
+	if s != positiveInfinityString {
+		t.Errorf("Encoding infinity, expected %q, got %q", positiveInfinityString, s)
+	}
+	err = db.QueryRow("SELECT $1::timestamptz::text", y11500).Scan(&s)
+	if err != nil {
+		t.Errorf("Encoding infinity, expected no error, got %q", err)
+	}
+	if s != positiveInfinityString {
+		t.Errorf("Encoding infinity, expected %q, got %q", positiveInfinityString, s)
+	}
+
+	disableInfinityTs()
+
+	var panicErrorString string
+	func() {
+		defer func() {
+			panicErrorString, _ = recover().(string)
+		}()
+		EnableInfinityTs(y2500, y1500)
+	}()
+	if panicErrorString != infinityTsNegativeMustBeSmaller {
+		t.Errorf("Expected error, %q, got %q", infinityTsNegativeMustBeSmaller, panicErrorString)
+	}
 }
 
 func TestStringWithNul(t *testing.T) {


### PR DESCRIPTION
If EnableInfinityTs is not called, "-infinity" and "infinity" will yield error when decoding.

If EnableInfinityTs is called once, it enables this driver to decode Postgres' "-infinity" and "infinity" to predefined boundary minimum and maximum time. When encoding, any time that equals or exceeds predefined minimum or maximum time will be encoded to "-infinity" and "infinity" respectively.

If EnableInfinityTs is called more than once, it will panic.