### PR TITLE
fix ISO year vs Gregorian year.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -218,6 +218,8 @@ func (c *locationCache) getLocation(offset int) *time.Location {
 // time.Parse and the Postgres date formatting quirks.
 func parseTs(currentLocation *time.Location, str string) (result time.Time) {
 	monSep := strings.IndexRune(str, '-')
+	// this is Gregorian year, not ISO Year
+	// In Gregorian system, the year 1 BC is followed by AD 1
 	year := mustAtoi(str[:monSep])
 	daySep := monSep + 3
 	month := mustAtoi(str[monSep+1 : daySep])
@@ -245,7 +247,6 @@ func parseTs(currentLocation *time.Location, str string) (result time.Time) {
 
 	nanoSec := 0
 	tzOff := 0
-	bcSign := 1
 
 	if remainderIdx < len(str) && str[remainderIdx:remainderIdx+1] == "." {
 		fracStart := remainderIdx + 1
@@ -281,14 +282,17 @@ func parseTs(currentLocation *time.Location, str string) (result time.Time) {
 		}
 		tzOff = tzSign * ((tzHours * 60 * 60) + (tzMin * 60) + tzSec)
 	}
+	var isoYear int
 	if remainderIdx < len(str) && str[remainderIdx:remainderIdx+3] == " BC" {
-		bcSign = -1
+		isoYear = 1 - year
 		remainderIdx += 3
+	} else {
+		isoYear = year
 	}
 	if remainderIdx < len(str) {
 		errorf("expected end of input, got %v", str[remainderIdx:])
 	}
-	t := time.Date(bcSign*year, time.Month(month), day,
+	t := time.Date(isoYear, time.Month(month), day,
 		hour, minute, second, nanoSec,
 		globalLocationCache.getLocation(tzOff))
 
@@ -306,15 +310,26 @@ func parseTs(currentLocation *time.Location, str string) (result time.Time) {
 	return t
 }
 
+const (
+	RFC3339NanoNoYear = "-01-02T15:04:05.999999999Z07:00"
+)
+
 // formatTs formats t as time.RFC3339Nano and appends time zone seconds if
 // needed.
 func formatTs(t time.Time) (b []byte) {
-	b = []byte(t.Format(time.RFC3339Nano))
+	timeString := t.Format(RFC3339NanoNoYear)
 	// Need to send dates before 0001 A.D. with " BC" suffix, instead of the
 	// minus sign preferred by Go.
-	if b[0] == '-' {
-		b = append(b[1:], ' ', 'B', 'C')
+	// Beware, "0000" in ISO is "1 BC", "-0001" is "2 BC" and so on
+	yyyy := t.Year()
+	if yyyy > 0 {
+		yearString := fmt.Sprintf("%04d", yyyy)
+		timeString = yearString + timeString
+	} else {
+		yearString := fmt.Sprintf("%04d", 1-yyyy)
+		timeString = yearString + timeString + " BC"
 	}
+	b = []byte(timeString)
 
 	_, offset := t.Zone()
 	offset = offset % 60

--- a/encode_test.go
+++ b/encode_test.go
@@ -57,11 +57,17 @@ var timeTests = []struct {
 		time.FixedZone("", -(7*60*60+30*60+9)))},
 	{"2001-02-03 04:05:06+07", time.Date(2001, time.February, 3, 4, 5, 6, 0,
 		time.FixedZone("", 7*60*60))},
-	//{"10000-02-03 04:05:06 BC", time.Date(-10000, time.February, 3, 4, 5, 6, 0, time.FixedZone("", 0))},
-	{"0010-02-03 04:05:06 BC", time.Date(-10, time.February, 3, 4, 5, 6, 0, time.FixedZone("", 0))},
-	{"0010-02-03 04:05:06.123 BC", time.Date(-10, time.February, 3, 4, 5, 6, 123000000, time.FixedZone("", 0))},
-	{"0010-02-03 04:05:06.123-07 BC", time.Date(-10, time.February, 3, 4, 5, 6, 123000000,
+	{"0011-02-03 04:05:06 BC", time.Date(-10, time.February, 3, 4, 5, 6, 0, time.FixedZone("", 0))},
+	{"0011-02-03 04:05:06.123 BC", time.Date(-10, time.February, 3, 4, 5, 6, 123000000, time.FixedZone("", 0))},
+	{"0011-02-03 04:05:06.123-07 BC", time.Date(-10, time.February, 3, 4, 5, 6, 123000000,
 		time.FixedZone("", -7*60*60))},
+	{"0001-02-03 04:05:06.123", time.Date(1, time.February, 3, 4, 5, 6, 123000000, time.FixedZone("", 0))},
+	{"0001-02-03 04:05:06.123 BC", time.Date(1, time.February, 3, 4, 5, 6, 123000000, time.FixedZone("", 0)).AddDate(-1, 0, 0)},
+	{"0001-02-03 04:05:06.123 BC", time.Date(0, time.February, 3, 4, 5, 6, 123000000, time.FixedZone("", 0))},
+	{"0002-02-03 04:05:06.123 BC", time.Date(0, time.February, 3, 4, 5, 6, 123000000, time.FixedZone("", 0)).AddDate(-1, 0, 0)},
+	{"0002-02-03 04:05:06.123 BC", time.Date(-1, time.February, 3, 4, 5, 6, 123000000, time.FixedZone("", 0))},
+	{"12345-02-03 04:05:06.1", time.Date(12345, time.February, 3, 4, 5, 6, 100000000, time.FixedZone("", 0))},
+	{"123456-02-03 04:05:06.1", time.Date(123456, time.February, 3, 4, 5, 6, 100000000, time.FixedZone("", 0))},
 }
 
 // Helper function for the two tests below


### PR DESCRIPTION
In this Gregorian system, the year 1 BC is followed by AD 1. In ISO system, year 1 is followed by year 0, and then -1.

Ref b7af72a and #320 