### PR TITLE
remove double call to t.Format() in formatTs

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -323,9 +323,12 @@ func formatTs(t time.Time) (b []byte) {
 		bc = true
 	}
 	b = []byte(t.Format(time.RFC3339Nano))
-	if bc {
-		b = append(b, "  BC"...)
-	}
+	// there are more than one `return` statements in this function
+	defer func (){
+		if bc {
+			b = append(b, " BC"...)
+		}
+	}()
 
 	_, offset := t.Zone()
 	offset = offset % 60

--- a/encode.go
+++ b/encode.go
@@ -313,7 +313,6 @@ func parseTs(currentLocation *time.Location, str string) (result time.Time) {
 // formatTs formats t as time.RFC3339Nano and appends time zone seconds if
 // needed.
 func formatTs(t time.Time) (b []byte) {
-	b = []byte(t.Format(time.RFC3339Nano))
 	// Need to send dates before 0001 A.D. with " BC" suffix, instead of the
 	// minus sign preferred by Go.
 	// Beware, "0000" in ISO is "1 BC", "-0001" is "2 BC" and so on

--- a/encode.go
+++ b/encode.go
@@ -323,28 +323,26 @@ func formatTs(t time.Time) (b []byte) {
 		bc = true
 	}
 	b = []byte(t.Format(time.RFC3339Nano))
-	// there are more than one `return` statements in this function
-	defer func (){
-		if bc {
-			b = append(b, " BC"...)
-		}
-	}()
 
 	_, offset := t.Zone()
 	offset = offset % 60
-	if offset == 0 {
-		return b
+	if offset != 0 {
+
+		if offset < 0 {
+			offset = -offset
+		}
+
+		b = append(b, ':')
+		if offset < 10 {
+			b = append(b, '0')
+		}
+		b = strconv.AppendInt(b, int64(offset), 10)
 	}
 
-	if offset < 0 {
-		offset = -offset
+	if bc {
+		b = append(b, " BC"...)
 	}
-
-	b = append(b, ':')
-	if offset < 10 {
-		b = append(b, '0')
-	}
-	return strconv.AppendInt(b, int64(offset), 10)
+	return b       
 }
 
 // Parse a bytea value received from the server.  Both "hex" and the legacy

--- a/encode_test.go
+++ b/encode_test.go
@@ -132,8 +132,18 @@ var formatTimeTests = []struct {
 	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 0)), "2001-02-03T04:05:06.123456789Z"},
 	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 2*60*60)), "2001-02-03T04:05:06.123456789+02:00"},
 	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", -6*60*60)), "2001-02-03T04:05:06.123456789-06:00"},
-	{time.Date(1, time.January, 1, 0, 0, 0, 0, time.FixedZone("", 19*60+32)), "0001-01-01T00:00:00+00:19:32"},
 	{time.Date(2001, time.February, 3, 4, 5, 6, 0, time.FixedZone("", -(7*60*60+30*60+9))), "2001-02-03T04:05:06-07:30:09"},
+
+	{time.Date(1, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 0)), "0001-02-03T04:05:06.123456789Z"},
+	{time.Date(1, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 2*60*60)), "0001-02-03T04:05:06.123456789+02:00"},
+	{time.Date(1, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", -6*60*60)), "0001-02-03T04:05:06.123456789-06:00"},
+
+	{time.Date(0, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 0)), "0001-02-03T04:05:06.123456789Z BC"},
+	{time.Date(0, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 2*60*60)), "0001-02-03T04:05:06.123456789+02:00 BC"},
+	{time.Date(0, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", -6*60*60)), "0001-02-03T04:05:06.123456789-06:00 BC"},
+
+	{time.Date(1, time.February, 3, 4, 5, 6, 0, time.FixedZone("", -(7*60*60+30*60+9))), "0001-02-03T04:05:06-07:30:09"},
+	{time.Date(0, time.February, 3, 4, 5, 6, 0, time.FixedZone("", -(7*60*60+30*60+9))), "0001-02-03T04:05:06-07:30:09 BC"},
 }
 
 func TestFormatTs(t *testing.T) {


### PR DESCRIPTION
From what I can tell there is no reason to call t.Format() twice. The first result is always discarded no matter what. The tests passed before and after.