### PR TITLE
Speed up bytea encoding

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -391,7 +391,10 @@ func parseBytea(s []byte) (result []byte) {
 func encodeBytea(serverVersion int, v []byte) (result []byte) {
 	if serverVersion >= 90000 {
 		// Use the hex format if we know that the server supports it
-		result = []byte(fmt.Sprintf("\\x%x", v))
+		result = make([]byte, 2+hex.EncodedLen(len(v)))
+		result[0] = '\\'
+		result[1] = 'x'
+		hex.Encode(result[2:], v)
 	} else {
 		// .. or resort to "escape"
 		for _, b := range v {


### PR DESCRIPTION
before:
```
BenchmarkEncodeByteaHex  1000000              1606 ns/op             313 B/op          8 allocs/op
```

after:
```
BenchmarkEncodeByteaHex  5000000               386 ns/op              96 B/op          2 allocs/op
```