### PR TITLE
Proof of concept for supporting temporal values as Scanners

### DIFF
--- a/datetime.go
+++ b/datetime.go
@@ -1,0 +1,52 @@
+package pq
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"time"
+)
+
+// Clock represents a value of the PostgreSQL `time without time zone` type.
+// It implements the sql.Scanner interface so it can be used as a scan
+// destination.
+type Clock struct {
+	Hour, Minute, Second, Nanosecond int
+}
+
+// Scan implements the sql.Scanner interface.
+func (c *Clock) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return c.scanString(string(src))
+
+	case string:
+		return c.scanString(src)
+
+	case time.Time:
+		return c.scanTime(src)
+	}
+
+	return fmt.Errorf("pq: cannot convert %T to Clock", src)
+}
+
+func (c *Clock) scanString(src string) (err error) {
+	t, err := time.Parse("15:04:05", src)
+	if err == nil {
+		err = c.scanTime(t)
+	}
+
+	return
+}
+
+func (c *Clock) scanTime(src time.Time) error {
+	hour, min, sec := src.Clock()
+	nsec := src.Nanosecond()
+
+	*c = Clock{Hour: hour, Minute: min, Second: sec, Nanosecond: nsec}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (c Clock) Value() (driver.Value, error) {
+	return fmt.Sprintf("%02d:%02d:%02d.%09d", c.Hour, c.Minute, c.Second, c.Nanosecond), nil
+}

--- a/datetime.go
+++ b/datetime.go
@@ -50,3 +50,70 @@ func (c *Clock) scanTime(src time.Time) error {
 func (c Clock) Value() (driver.Value, error) {
 	return fmt.Sprintf("%02d:%02d:%02d.%09d", c.Hour, c.Minute, c.Second, c.Nanosecond), nil
 }
+
+// Date represents a value of the PostgreSQL `date` type. It supports the
+// special values "infinity" and "-infinity" and implements the sql.Scanner
+// interface so it can be used as a scan destination.
+//
+// A positive or negative value in Infinity represents the special value
+// "infinity" or "-infinity", respectively.
+type Date struct {
+	Infinity int
+	Year     int
+	Month    time.Month
+	Day      int
+}
+
+// Scan implements the sql.Scanner interface.
+func (d *Date) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return d.scanString(string(src))
+
+	case string:
+		return d.scanString(src)
+
+	case time.Time:
+		return d.scanTime(src)
+	}
+
+	return fmt.Errorf("pq: cannot convert %T to Date", src)
+}
+
+func (d *Date) scanString(src string) (err error) {
+	switch src {
+	case "-infinity":
+		*d = Date{Infinity: -1}
+
+	case "infinity":
+		*d = Date{Infinity: 1}
+
+	default:
+		t, err := time.Parse("2006-01-02", src)
+		if err == nil {
+			err = d.scanTime(t)
+		}
+	}
+
+	return
+}
+
+func (d *Date) scanTime(src time.Time) error {
+	year, month, day := src.Date()
+	*d = Date{Year: year, Month: month, Day: day}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (d Date) Value() (driver.Value, error) {
+	switch {
+	case d.Infinity < 0:
+		return "-infinity", nil
+
+	case d.Infinity > 0:
+		return "infinity", nil
+
+	default:
+		return fmt.Sprintf("%04d-%02d-%02d", d.Year, d.Month, d.Day), nil
+	}
+}

--- a/datetime.go
+++ b/datetime.go
@@ -117,3 +117,22 @@ func (d Date) Value() (driver.Value, error) {
 		return fmt.Sprintf("%04d-%02d-%02d", d.Year, d.Month, d.Day), nil
 	}
 }
+
+// Timestamp represents a value of the PostgreSQL `timestamp without time zone`
+// type. It supports the special values "infinity" and "-infinity" and
+// implements the sql.Scanner interface so it can be used as a scan destination.
+type Timestamp struct {
+	Date
+	Clock
+}
+
+// TimestampTZ represents a value of the PostgreSQL `timestamp with time zone`
+// type. It supports the special values "infinity" and "-infinity" and
+// implements the sql.Scanner interface so it can be used as a scan destination.
+//
+// A positive or negative value in Infinity represents the special value
+// "infinity" or "-infinity", respectively.
+type TimestampTZ struct {
+	Infinity int
+	Time     time.Time
+}

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -92,3 +92,84 @@ func TestClockValue(t *testing.T) {
 		}
 	}
 }
+
+func TestDateScanUnsupported(t *testing.T) {
+	var date Date
+	err := date.Scan(true)
+
+	if err == nil {
+		t.Fatal("Expected error when scanning from bool")
+	}
+	if !strings.Contains(err.Error(), "bool to Date") {
+		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+func TestDateScanTime(t *testing.T) {
+	date := Date{9, 9, 9, 9}
+	err := date.Scan(time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC))
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if date != (Date{Year: 2001, Month: 2, Day: 3}) {
+		t.Errorf("Expected 2001-02-03, got %v", date)
+	}
+}
+
+func TestDateScanBytes(t *testing.T) {
+	for _, tt := range []struct {
+		bytes []byte
+		date  Date
+	}{
+		{[]byte(`infinity`), Date{Infinity: 1}},
+		{[]byte(`-infinity`), Date{Infinity: -1}},
+		{[]byte(`2001-02-03`), Date{Year: 2001, Month: 2, Day: 3}},
+	} {
+		date := Date{9, 9, 9, 9}
+		err := date.Scan(tt.bytes)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.bytes, err)
+		}
+		if date != tt.date {
+			t.Errorf("Expected %+v, got %+v", tt.date, date)
+		}
+	}
+}
+
+var DateStringTests = []struct {
+	str  string
+	date Date
+}{
+	{`infinity`, Date{Infinity: 1}},
+	{`-infinity`, Date{Infinity: -1}},
+	{`2001-02-03`, Date{Year: 2001, Month: 2, Day: 3}},
+}
+
+func TestDateScanString(t *testing.T) {
+	for _, tt := range DateStringTests {
+		date := Date{9, 9, 9, 9}
+		err := date.Scan(tt.str)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
+		}
+		if date != tt.date {
+			t.Errorf("Expected %+v, got %+v", tt.date, date)
+		}
+	}
+}
+
+func TestDateValue(t *testing.T) {
+	for _, tt := range DateStringTests {
+		value, err := tt.date.Value()
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.date, err)
+		}
+		if value != tt.str {
+			t.Errorf("Expected %v, got %v", tt.str, value)
+		}
+	}
+}

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -1,0 +1,94 @@
+package pq
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClockScanUnsupported(t *testing.T) {
+	var clock Clock
+	err := clock.Scan(true)
+
+	if err == nil {
+		t.Fatal("Expected error when scanning from bool")
+	}
+	if !strings.Contains(err.Error(), "bool to Clock") {
+		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+func TestClockScanTime(t *testing.T) {
+	clock := Clock{9, 9, 9, 9}
+	err := clock.Scan(time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC))
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if clock != (Clock{Hour: 4, Minute: 5, Second: 6, Nanosecond: 7}) {
+		t.Errorf("Expected 04:05:06.000000007, got %+v", clock)
+	}
+}
+
+func TestClockScanBytes(t *testing.T) {
+	for _, tt := range []struct {
+		bytes []byte
+		clock Clock
+	}{
+		{[]byte(`04:05:06`), Clock{Hour: 4, Minute: 5, Second: 6}},
+		{[]byte(`04:05:06.007`), Clock{Hour: 4, Minute: 5, Second: 6, Nanosecond: 7000000}},
+		{[]byte(`04:05:06.000007`), Clock{Hour: 4, Minute: 5, Second: 6, Nanosecond: 7000}},
+	} {
+		clock := Clock{9, 9, 9, 9}
+		err := clock.Scan(tt.bytes)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.bytes, err)
+		}
+		if clock != tt.clock {
+			t.Errorf("Expected %+v, got %+v", tt.clock, clock)
+		}
+	}
+}
+
+func TestClockScanString(t *testing.T) {
+	for _, tt := range []struct {
+		str   string
+		clock Clock
+	}{
+		{`04:05:06`, Clock{Hour: 4, Minute: 5, Second: 6}},
+		{`04:05:06.007`, Clock{Hour: 4, Minute: 5, Second: 6, Nanosecond: 7000000}},
+		{`04:05:06.000007`, Clock{Hour: 4, Minute: 5, Second: 6, Nanosecond: 7000}},
+	} {
+		clock := Clock{9, 9, 9, 9}
+		err := clock.Scan(tt.str)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
+		}
+		if clock != tt.clock {
+			t.Errorf("Expected %+v, got %+v", tt.clock, clock)
+		}
+	}
+}
+
+func TestClockValue(t *testing.T) {
+	for _, tt := range []struct {
+		str   string
+		clock Clock
+	}{
+		{`04:05:06.000000000`, Clock{Hour: 4, Minute: 5, Second: 6}},
+		{`04:05:06.007000000`, Clock{Hour: 4, Minute: 5, Second: 6, Nanosecond: 7000000}},
+		{`04:05:06.000007000`, Clock{Hour: 4, Minute: 5, Second: 6, Nanosecond: 7000}},
+		{`04:05:06.000000007`, Clock{Hour: 4, Minute: 5, Second: 6, Nanosecond: 7}},
+	} {
+		value, err := tt.clock.Value()
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.clock, err)
+		}
+		if value != tt.str {
+			t.Errorf("Expected %v, got %v", tt.str, value)
+		}
+	}
+}


### PR DESCRIPTION
The features provided by the [temporal](http://www.postgresql.org/docs/current/static/datatype-datetime.html) types of Postgres differ from those of Go's `time.Time`. We should read and write values of these types in such a way as to:

* Preserve their meaning
* Minimize the physical effort (user code) required to use them
* Minimize the mental effort (cognitive load) required to use them
* Maximize the ways in which they can be used
* Minimize the burden of maintaining this package
* Maximize performance

This PR proposes to use a handful of Go types that implement `sql.Scanner` and `driver.Valuer` to achieve these goals.

#### Preserve meaning

The `date`, `timestamp` and `timestamptz` types support infinite values which are explicitly outside the range of non-infinite (i.e. normal) values. The proposed `pq.Date`, `pq.Timestamp` and `pq.TimestampTZ` types have an `Infinity` field to represent these special values.

The Postgres temporal types that lack a date or a time zone contain only as much information as a calendar or a wall clock. The proposed types contain the same amount of information (e.g. no default time zone.)

#### Maximize usability

When not concerned about infinite values, a user can scan a `timestamptz` value directly into a `time.Time`.

Multiple proposed types can be used as scan destinations for multiple Postgres temporal values. For example, a `timestamp` can be scanned into a `pq.Date`.

When using `pq.Clock`, `pq.Date` or `pq.Timestamp`, a user need not consider the behavior of the `time` package at all. Even so, these types are congruous with the `time` package. For example, one may implement an `sql.Scanner` that uses these types as intermediaries, passing their fields directly to `time.Date()`.

#### Minimize maintenance

Since there is little to no guidance for how a driver should return `time.Time` values, it is important to clearly document how temporal values are handled. The proposed, exported types provide a natural place for such documentation, including the disparities between Postgres temporal types and the `time` package.

The composition of these types should result in a few small units of shared code, and these units will likely return `error` to match the `sql.Scanner` interface. The related tests can be focused, succinct and thorough.

#### Maximize performance

For most temporal types, parsing can be deferred until the scan destination is known. In these cases, it is possible to limit processing to only the fields requested by the user. For example, only the year, month and day of a `timestamp` value need to be parsed when populating a `pq.Date`.

For these same types, the driver is responsible only for parsing the various Postgres output formats into numeric fields. The user decides if/when to incur the cost of calculating a `time.Time` value.


### Mappings to/from Go and Postgres

##### From Backend

| Data Type | Value | Compatible Scanners |
| --------- | ----- | ------------------- |
| `timestamp` | `[]byte` | `pq.Date`, `pq.Timestamp` |
| `timestamptz` | `[]byte`,<sup>1</sup> `time.Time` | `pq.Date`, `pq.Timestamp`, `pq.TimestampTZ` |
| `date`    | `[]byte` | `pq.Date`        |
| `time`    | `[]byte` | `pq.Clock`       |
| `timetz`  | `[]byte` | *?*              |

##### To Backend

| Valuer | Value | Compatible Data Types |
| ------ | ----- | --------------------- |
| *n/a*  | `time.Time` | `date`,<sup>2</sup> `time`,<sup>2</sup> `timetz`, `timestamp`,<sup>2</sup> `timestamptz` |
| `pq.Timestamp` | `[]byte` | `date`, `timestamp`, `timestamptz`<sup>3</sup> |
| `pq.TimestampTZ` | `[]byte` | `date`,<sup>2</sup> `timestamp`,<sup>2</sup> `timestamptz` |
| `pq.Date` | `[]byte` | `date`, `timestamp`, `timestamptz`<sup>3</sup> |
| `pq.Clock` | `[]byte` | `time`, `timetz`<sup>3</sup> |

<sup>1</sup> When `"infinity"` or `"-infinity"`
<sup>2</sup> Time zone is [silently ignored](http://www.postgresql.org/docs/current/static/datatype-datetime.html)
<sup>3</sup> Interpreted as being in the [session time zone](http://www.postgresql.org/docs/current/static/runtime-config-client.html#GUC-TIMEZONE)


### Transition

The proposed types work correctly without any changes to the existing driver encode/decode process. The existing (driver) parsing and formatting code can be refactored toward this interface, eliminating duplicated functionality.

The (expected) performance gains from returning `[]byte` for most types can be activated with a package-level configuration.

If this interface is preferred by maintainers, the existing/default behavior can be deprecated and eventually eliminated.