### PR TITLE
Add support for postgresql:// user scheme

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -152,7 +152,7 @@ func DialOpen(d Dialer, name string) (_ driver.Conn, err error) {
 		o.Set(k, v)
 	}
 
-	if strings.HasPrefix(name, "postgres://") {
+	if strings.HasPrefix(name, "postgres://") || strings.HasPrefix(name, "postgresql://") {
 		name, err = ParseURL(name)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
According to the postgresql documentation, this URI scheme is
considered to be the general form.

http://www.postgresql.org/docs/9.2/static/libpq-connect.html#LIBPQ-CONNSTRING