### PR TITLE
Speed up encoding for int64, float32/64, and bool

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -17,11 +17,11 @@ import (
 func encode(parameterStatus *parameterStatus, x interface{}, pgtypOid oid.Oid) []byte {
 	switch v := x.(type) {
 	case int64:
-		return []byte(fmt.Sprintf("%d", v))
+		return strconv.AppendInt(nil, v, 10)
 	case float32:
-		return []byte(fmt.Sprintf("%.9f", v))
+		return strconv.AppendFloat(nil, float64(v), 'f', -1, 32)
 	case float64:
-		return []byte(fmt.Sprintf("%.17f", v))
+		return strconv.AppendFloat(nil, v, 'f', -1, 64)
 	case []byte:
 		if pgtypOid == oid.T_bytea {
 			return encodeBytea(parameterStatus.serverVersion, v)
@@ -35,7 +35,7 @@ func encode(parameterStatus *parameterStatus, x interface{}, pgtypOid oid.Oid) [
 
 		return []byte(v)
 	case bool:
-		return []byte(fmt.Sprintf("%t", v))
+		return strconv.AppendBool(nil, v)
 	case time.Time:
 		return formatTs(v)
 


### PR DESCRIPTION
Before:
```
BenchmarkEncodeInt64	 5000000	       301 ns/op
BenchmarkEncodeFloat64	 2000000	       892 ns/op
BenchmarkEncodeBool	 5000000	       255 ns/op
```

After:
```
BenchmarkEncodeInt64	10000000	       128 ns/op
BenchmarkEncodeFloat64	 5000000	       266 ns/op
BenchmarkEncodeBool	10000000	       124 ns/op
```

Relatively minor performance wins, but I thought I'd see what others thought.