### PR TITLE
Add driver.Valuer support for arrays

### DIFF
--- a/array.go
+++ b/array.go
@@ -1,0 +1,83 @@
+package pq
+
+import (
+	"database/sql/driver"
+	"reflect"
+)
+
+// Array wraps slices with a driver.Valuer interface.
+// For example:
+//  ids := []int{235, 401}
+//  db.Query("SELECT * FROM t WHERE id=ANY($1)", Array{ids})
+type Array struct {
+	A interface{} // A slice or array
+}
+
+// Value implements the driver Valuer interface.
+func (a Array) Value() (driver.Value, error) {
+	if a.A == nil {
+		return nil, nil
+	}
+	v := reflect.ValueOf(a.A)
+	return arrayValue(v)
+}
+
+func arrayValue(v reflect.Value) ([]byte, error) {
+	_, isBytes := v.Interface().([]byte)
+
+	if !isBytes && (v.Kind() == reflect.Slice || v.Kind() == reflect.Array) {
+		result := []byte{'{'}
+
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				result = append(result, ',')
+			}
+
+			item, err := arrayValue(v.Index(i))
+			if err != nil {
+				return nil, err
+			}
+
+			result = append(result, item...)
+		}
+
+		return append(result, '}'), nil
+	}
+
+	val := v.Interface()
+
+	// encode can handle float32 in addition to drive.Value types
+	// so we don't want to convert it to a float64
+	if _, ok := val.(float32); !ok {
+		var err error
+		val, err = driver.DefaultParameterConverter.ConvertValue(val)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if val == nil {
+		return []byte("NULL"), nil
+	}
+
+	encoded := encode(nil, val, 0)
+
+	switch val.(type) {
+	case []byte, string:
+		return escapedArrayText(encoded), nil
+	default:
+		return encoded, nil
+	}
+}
+
+func escapedArrayText(text []byte) []byte {
+	result := []byte{'"'}
+	for _, c := range text {
+		if c == '"' {
+			result = append(result, '\\')
+		}
+		result = append(result, c)
+	}
+
+	return append(result, '"')
+}

--- a/array.go
+++ b/array.go
@@ -73,10 +73,12 @@ func arrayValue(v reflect.Value) ([]byte, error) {
 func escapedArrayText(text []byte) []byte {
 	result := []byte{'"'}
 	for _, c := range text {
-		if c == '"' {
-			result = append(result, '\\')
+		switch c {
+		case '"', '\\':
+			result = append(result, '\\', c)
+		default:
+			result = append(result, c)
 		}
-		result = append(result, c)
 	}
 
 	return append(result, '"')

--- a/array.go
+++ b/array.go
@@ -49,16 +49,9 @@ func arrayValue(v reflect.Value) ([]byte, error) {
 		return append(result, '}'), nil
 	}
 
-	val := v.Interface()
-
-	// encode can handle float32 in addition to drive.Value types
-	// so we don't want to convert it to a float64
-	if _, ok := val.(float32); !ok {
-		var err error
-		val, err = driver.DefaultParameterConverter.ConvertValue(val)
-		if err != nil {
-			return nil, err
-		}
+	val, err := driver.DefaultParameterConverter.ConvertValue(v.Interface())
+	if err != nil {
+		return nil, err
 	}
 
 	if val == nil {

--- a/array.go
+++ b/array.go
@@ -19,6 +19,11 @@ func (a Array) Value() (driver.Value, error) {
 		return nil, nil
 	}
 	v := reflect.ValueOf(a.A)
+
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return nil, ErrInvalidArray
+	}
+
 	return arrayValue(v)
 }
 

--- a/array_test.go
+++ b/array_test.go
@@ -17,6 +17,7 @@ var arrayTests = []struct {
 	{[]byte(`{"a","b","c\"","d,e"}`), []string{"a", "b", "c\"", "d,e"}},
 	{[]byte(`{"a","b"}`), [][]byte{{'a'}, {'b'}}},
 	{[]byte(`{{"a","b"},{"c","d"}}`), [][]string{{"a", "b"}, {"c", "d"}}},
+	{[]byte(`{"\\a"}`), []string{"\\a"}},
 	{[]byte(`{12345,23456,34567890}`), []int64{12345, 23456, 34567890}},
 	{[]byte(`{12345,23456,34567890}`), []int{12345, 23456, 34567890}},
 	{[]byte(`{"",NULL}`), []*string{new(string), nil}},
@@ -34,7 +35,7 @@ func TestArrayValuer(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(test.resp, val) {
-			t.Errorf("%d: expected %q got %q", i, test.resp, val)
+			t.Errorf("%d: expected `%s` got `%s`", i, test.resp, val)
 		}
 	}
 }

--- a/array_test.go
+++ b/array_test.go
@@ -1,0 +1,113 @@
+package pq
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+var arrayTests = []struct {
+	resp interface{}
+	arr  interface{}
+}{
+	{[]byte(`{}`), []bool{}},
+	{[]byte(`{{}}`), [][]bool{{}}},
+	{[]byte(`{true,false}`), []bool{true, false}},
+	{[]byte(`{"a","b","c\"","d,e"}`), []string{"a", "b", "c\"", "d,e"}},
+	{[]byte(`{"a","b"}`), [][]byte{{'a'}, {'b'}}},
+	{[]byte(`{{"a","b"},{"c","d"}}`), [][]string{{"a", "b"}, {"c", "d"}}},
+	{[]byte(`{12345,23456,34567890}`), []int64{12345, 23456, 34567890}},
+	{[]byte(`{12345,23456,34567890}`), []int{12345, 23456, 34567890}},
+	{[]byte(`{"",NULL}`), []*string{new(string), nil}},
+	{nil, nil},
+}
+
+func TestArrayValuer(t *testing.T) {
+	array := Array{}
+	for i, test := range arrayTests {
+		array.A = test.arr
+
+		val, err := array.Value()
+		if err != nil {
+			t.Errorf("%d: got error: %v", i, err)
+		}
+
+		if !reflect.DeepEqual(test.resp, val) {
+			t.Errorf("%d: expected %q got %q", i, test.resp, val)
+		}
+	}
+}
+
+func BenchmarkArrayString(b *testing.B) {
+	arr := []string{"a", "b", "c\"", "d", "e"}
+	array := Array{arr}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		array.Value()
+	}
+}
+
+func BenchmarkCustomArrayString(b *testing.B) {
+	arr := []string{"a", "b", "c\"", "d", "e"}
+	strArray := StringArray(arr)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		strArray.Value()
+	}
+}
+
+func BenchmarkArrayInt64(b *testing.B) {
+	arr := []int64{2455, 229, 109, 285, 982995}
+	intArray := Array{arr}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		intArray.Value()
+	}
+}
+
+func BenchmarkCustomArrayInt64(b *testing.B) {
+	arr := []int64{2455, 229, 109, 285, 982995}
+	intArray := Int64Array(arr)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		intArray.Value()
+	}
+}
+
+type StringArray []string
+
+func (a StringArray) Value() (driver.Value, error) {
+	var val []byte
+	val = append(val, '{')
+	for i, s := range a {
+		if i > 0 {
+			val = append(val, ',')
+		}
+		b := []byte(s)
+		val = append(val, '"')
+		for _, c := range b {
+			if c == '"' {
+				val = append(val, '\\')
+			}
+			val = append(val, c)
+		}
+		val = append(val, '"')
+	}
+	return append(val, '}'), nil
+}
+
+type Int64Array []int64
+
+func (a Int64Array) Value() (driver.Value, error) {
+	var val []byte
+	val = append(val, '{')
+	for i, s := range a {
+		if i > 0 {
+			val = append(val, ',')
+		}
+		b := []byte(fmt.Sprintf("%d", s))
+		val = append(val, b...)
+	}
+	return append(val, '}'), nil
+}

--- a/conn.go
+++ b/conn.go
@@ -32,6 +32,7 @@ var (
 	ErrSSLNotSupported           = errors.New("pq: SSL is not enabled on the server")
 	ErrSSLKeyHasWorldPermissions = errors.New("pq: Private key file has group or world access. Permissions should be u=rw (0600) or less.")
 	ErrCouldNotDetectUsername    = errors.New("pq: Could not detect default username. Please provide one explicitly.")
+	ErrInvalidArray              = errors.New("pq: Array can only be used with slices and arrays.")
 )
 
 type drv struct{}


### PR DESCRIPTION
In reference to #327 

Starting with a Valuer that can handle any array type. I added benchmarks to compare against a Valuer specifically for strings and a Valuer specifically for int64s.

Results:
```
BenchmarkArrayString	 1000000	      2084 ns/op	     376 B/op	      30 allocs/op
BenchmarkCustomArrayString	 2000000	       598 ns/op	     128 B/op	       9 allocs/op
BenchmarkArrayInt64	  500000	      2538 ns/op	     297 B/op	      30 allocs/op
BenchmarkCustomArrayInt64	 1000000	      1687 ns/op	     208 B/op	      19 allocs/op
```