### PR TITLE
remove unreachable code (return after panic)

### DIFF
--- a/notify_test.go
+++ b/notify_test.go
@@ -44,7 +44,6 @@ func expectEvent(t *testing.T, eventch <-chan ListenerEventType, et ListenerEven
 		return nil
 	case <-time.After(1500 * time.Millisecond):
 		panic("expectEvent timeout")
-		return fmt.Errorf("timeout")
 	}
 }
 


### PR DESCRIPTION
flagged by go tool vet:
```
$ go tool vet .
notify_test.go:47: unreachable code
```