### PR TITLE
Allow using CopyIn in table associated with triggers that use raise stmt

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -148,7 +148,7 @@ func (ci *copyin) resploop() {
 			return
 		}
 		switch t {
-		case 'C':
+		case 'C','N':
 			// complete
 		case 'Z':
 			ci.cn.processReadyForQuery(&r)

--- a/copy.go
+++ b/copy.go
@@ -148,8 +148,9 @@ func (ci *copyin) resploop() {
 			return
 		}
 		switch t {
-		case 'C','N':
+		case 'C':
 			// complete
+		case 'N':
 		case 'Z':
 			ci.cn.processReadyForQuery(&r)
 			ci.done <- true

--- a/copy_test.go
+++ b/copy_test.go
@@ -115,9 +115,8 @@ func TestCopyInRaiseStmtTrigger(t *testing.T) {
 			$BODY$ begin
 				raise notice 'Hello world';
 				return new;
-			end; $BODY$ 
-			LANGUAGE plpgsql
-		`)
+			end $BODY$
+			LANGUAGE plpgsql`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,9 +126,7 @@ func TestCopyInRaiseStmtTrigger(t *testing.T) {
 			BEFORE INSERT
 			ON temp 
 			FOR EACH ROW
-			EXECUTE PROCEDURE pg_temp.temptest()
-		`)
-
+			EXECUTE PROCEDURE pg_temp.temptest()`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/copy_test.go
+++ b/copy_test.go
@@ -94,6 +94,85 @@ func TestCopyInMultipleValues(t *testing.T) {
 	}
 }
 
+/* Create this function in your DB to test the COPY statement with triggers that use RAISE
+statement to report messages
+
+CREATE OR REPLACE FUNCTION temptest()
+  RETURNS trigger AS
+$BODY$ begin
+  raise notice 'hello world';  
+  return new;
+end; $BODY$
+LANGUAGE plpgsql
+*/
+func TestCopyInRaiseStmtTrigger(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer txn.Rollback()
+
+	_, err = txn.Exec("CREATE TEMP TABLE temp (a int, b varchar)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Check if test function exists 
+	var num int
+	err = txn.QueryRow(`SELECT COUNT(*) FROM pg_proc where proname = 'temptest'`).Scan(&num)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if num == 1 {
+		_, err = txn.Exec(`
+			CREATE TRIGGER temptest_trigger
+			BEFORE INSERT
+			ON temp 
+			FOR EACH ROW
+			EXECUTE PROCEDURE temptest()
+		`)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stmt, err := txn.Prepare(CopyIn("temp", "a", "b"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	longString := strings.Repeat("#", 500)
+
+	_, err = stmt.Exec(int64(1), longString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = stmt.Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = stmt.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = txn.QueryRow("SELECT COUNT(*) FROM temp").Scan(&num)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if num != 1 {
+		t.Fatalf("expected 1 items, not %d", num)
+	}
+}
+
 func TestCopyInTypes(t *testing.T) {
 	db := openTestConn(t)
 	defer db.Close()


### PR DESCRIPTION
Hello,
  Thanks a lot for this package. We're using CopyIn in [Urban4m](http://www.urban4m.com) and it's really fast. When we use this feature in tables associated with triggers that use raise statement to report messages, the package throws the error "unknown response during CopyIn: N". To avoid it, we can add this case as valid response into resploop function.