### PR TITLE
Prepared Statement Caching

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -239,6 +239,7 @@ func DialOpen(d Dialer, name string) (_ driver.Conn, err error) {
 	cn.ssl(o)
 	cn.buf = bufio.NewReader(cn.c)
 	cn.startup(o)
+	cn.prepared = make(map[string]*stmt)
 	// reset the deadline, in case one was set (see dial)
 	if timeout := o.Get("connect_timeout"); timeout != "" && timeout != "0" {
 		err = cn.c.SetDeadline(time.Time{})
@@ -717,7 +718,7 @@ func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
 		return prepared0, nil
 	}
 	prepared, err := cn.prepareTo(q, name)
-	if err != nil {
+	if err == nil {
 		cn.prepared[name] = prepared
 	}
 	return prepared, err

--- a/conn.go
+++ b/conn.go
@@ -706,16 +706,7 @@ func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
 	}
 	name := cn.hashedName(q)
 	if prepared, ok := cn.prepared[name]; ok {
-		prepared0 := &stmt{
-			parent:    prepared,
-			cn:        prepared.cn,
-			name:      prepared.name,
-			cols:      prepared.cols,
-			rowTyps:   prepared.rowTyps,
-			paramTyps: prepared.paramTyps,
-			closed:    prepared.closed,
-		}
-		return prepared0, nil
+		return prepared, nil
 	}
 	prepared, err := cn.prepareTo(q, name)
 	if err == nil {
@@ -1184,7 +1175,6 @@ var rowFmtDataAllBinary []byte = []byte{0, 1, 0, 1}
 var rowFmtDataAllText []byte = []byte{0, 0}
 
 type stmt struct {
-	parent     *stmt
 	cn         *conn
 	name       string
 	cols       []string
@@ -1196,9 +1186,6 @@ type stmt struct {
 }
 
 func (st *stmt) Close() (err error) {
-	if st.parent != nil {
-		return nil
-	}
 	if st.closed {
 		return nil
 	}

--- a/conn.go
+++ b/conn.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/base32"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -23,6 +24,7 @@ import (
 	"unicode"
 
 	"github.com/lib/pq/oid"
+	"github.com/spaolacci/murmur3"
 )
 
 // Common error types
@@ -102,6 +104,9 @@ type conn struct {
 
 	saveMessageType   byte
 	saveMessageBuffer []byte
+
+	// Prepared Query Cache
+	prepared map[string]*stmt
 
 	// If true, this connection is bad and all public-facing functions should
 	// return ErrBadConn.
@@ -497,6 +502,18 @@ func (cn *conn) Rollback() (err error) {
 	return nil
 }
 
+// hashedName takes a query string thats being prepared
+// and generates a unique hashed name for the query to be used
+// when executing later
+func (cn *conn) hashedName(query string) string {
+	hashedBytes := make([]byte, 8)
+	hashed := murmur3.Sum64([]byte(query))
+	binary.LittleEndian.PutUint64(hashedBytes, hashed)
+	name := base32.StdEncoding.EncodeToString(hashedBytes)
+	return "pq_" + strings.TrimRight(name, "=")
+
+}
+
 func (cn *conn) gname() string {
 	cn.namei++
 	return strconv.FormatInt(int64(cn.namei), 10)
@@ -686,7 +703,24 @@ func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
 	if len(q) >= 4 && strings.EqualFold(q[:4], "COPY") {
 		return cn.prepareCopyIn(q)
 	}
-	return cn.prepareTo(q, cn.gname())
+	name := cn.hashedName(q)
+	if prepared, ok := cn.prepared[name]; ok {
+		prepared0 := &stmt{
+			parent:    prepared,
+			cn:        prepared.cn,
+			name:      prepared.name,
+			cols:      prepared.cols,
+			rowTyps:   prepared.rowTyps,
+			paramTyps: prepared.paramTyps,
+			closed:    prepared.closed,
+		}
+		return prepared0, nil
+	}
+	prepared, err := cn.prepareTo(q, name)
+	if err != nil {
+		cn.prepared[name] = prepared
+	}
+	return prepared, err
 }
 
 func (cn *conn) Close() (err error) {
@@ -1149,6 +1183,7 @@ var rowFmtDataAllBinary []byte = []byte{0, 1, 0, 1}
 var rowFmtDataAllText []byte = []byte{0, 0}
 
 type stmt struct {
+	parent     *stmt
 	cn         *conn
 	name       string
 	cols       []string
@@ -1160,6 +1195,9 @@ type stmt struct {
 }
 
 func (st *stmt) Close() (err error) {
+	if st.parent != nil {
+		return nil
+	}
 	if st.closed {
 		return nil
 	}
@@ -1188,7 +1226,9 @@ func (st *stmt) Close() (err error) {
 		errorf("expected ready for query, but got: %q", t)
 	}
 	st.cn.processReadyForQuery(r)
-
+	if _, ok := st.cn.prepared[st.name]; ok {
+		delete(st.cn.prepared, st.name)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently Go's database/sql package does not allow you to keep prepared queries around per connection, only per transaction. This fixes that by keeping around unclosed prepared queries by naming them using a hash of their query string and holding on to a map[string]*stmt per connection.

This greatly speeds up our application which uses many complex queries containing 20+ joins. The plan was taking nearly 200ms, while the query itself only ~20ms. Our application performance was greatly improved by this.

I'm PRing this in hope it might be useful to others and that we might get some feedback.