### PR TITLE
Add Scanner/Value implementations for Postgres network address types.

### DIFF
--- a/netaddr/cidr.go
+++ b/netaddr/cidr.go
@@ -1,0 +1,45 @@
+package netaddr
+
+import (
+	"database/sql/driver"
+	"errors"
+	"net"
+)
+
+// A wrapper for transferring Cidr values back and forth easily.
+type Cidr struct {
+	Cidr  net.IPNet
+	Valid bool
+}
+
+// Scan implements the Scanner interface.
+func (c *Cidr) Scan(value interface{}) error {
+	c.Cidr.IP = nil
+	c.Cidr.Mask = nil
+	c.Valid = false
+	if value == nil {
+		c.Valid = false
+		return nil
+	}
+	cidrAsBytes, ok := value.([]byte)
+	if !ok {
+		return errors.New("Could not convert scanned value to bytes")
+	}
+	_, parsedIPNet, error := net.ParseCIDR(string(cidrAsBytes))
+	if error != nil {
+		return error
+	}
+	c.Valid = true
+	c.Cidr.IP = parsedIPNet.IP
+	c.Cidr.Mask = parsedIPNet.Mask
+	return nil
+}
+
+// Value implements the driver Valuer interface. Note if c.Valid is false
+// or c.Cidr.IP is nil the database column value will be set to NULL.
+func (c Cidr) Value() (driver.Value, error) {
+	if c.Valid == false || c.Cidr.IP == nil {
+		return nil, nil
+	}
+	return []byte(c.Cidr.String()), nil
+}

--- a/netaddr/cidr.go
+++ b/netaddr/cidr.go
@@ -6,7 +6,7 @@ import (
 	"net"
 )
 
-// A wrapper for transferring Cidr values back and forth easily.
+// Cidr is a wrapper for transferring CIDR values back and forth easily.
 type Cidr struct {
 	Cidr  net.IPNet
 	Valid bool
@@ -38,7 +38,7 @@ func (c *Cidr) Scan(value interface{}) error {
 // Value implements the driver Valuer interface. Note if c.Valid is false
 // or c.Cidr.IP is nil the database column value will be set to NULL.
 func (c Cidr) Value() (driver.Value, error) {
-	if c.Valid == false || c.Cidr.IP == nil {
+	if !c.Valid || c.Cidr.IP == nil {
 		return nil, nil
 	}
 	return []byte(c.Cidr.String()), nil

--- a/netaddr/cidr_test.go
+++ b/netaddr/cidr_test.go
@@ -1,0 +1,116 @@
+package netaddr
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	_ "github.com/lib/pq"
+)
+
+func TestCidr(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	cidr := Cidr{}
+
+	// Test scanning NULL values
+	err := db.QueryRow("SELECT NULL::cidr").Scan(&cidr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cidr.Valid {
+		t.Fatalf("expected null result")
+	}
+
+	// Test setting NULL values
+	err = db.QueryRow("SELECT $1::cidr", cidr).Scan(&cidr)
+	if err != nil {
+		t.Fatalf("re-query null value failed: %s", err.Error())
+	}
+	if cidr.Valid {
+		t.Fatalf("expected null result")
+	}
+
+	// test encoding in query params, then decoding during Scan
+	testBidirectional := func(c Cidr, label string) {
+		err = db.QueryRow("SELECT $1::cidr", c).Scan(&cidr)
+		if err != nil {
+			t.Fatalf("re-query %s cidr failed: %s", label, err.Error())
+		}
+		if !cidr.Valid {
+			t.Fatalf("expected non-null value, got null for %s", label)
+		}
+		if bytes.Compare(c.Cidr.IP, cidr.Cidr.IP) != 0 {
+			t.Fatalf("expected IP addresses to match, but did not for %s - %s %s", label, c.Cidr.IP.String(), cidr.Cidr.IP.String())
+		}
+		if bytes.Compare(c.Cidr.Mask, cidr.Cidr.Mask) != 0 {
+			t.Fatalf("expected net masks to match, but did not for %s", label)
+		}
+	}
+
+	// a few example CIDRs to test out
+	_, exampleCidr, err := net.ParseCIDR("135.104.0.0/32")
+	if err != nil {
+		t.Fatalf("Fatal error while building simple IP example - %s", err.Error())
+	}
+	var simpleIP4 = Cidr{Cidr: *exampleCidr, Valid: true}
+	testBidirectional(simpleIP4, "Simple IPv4")
+
+	_, exampleCidr, err = net.ParseCIDR("0.0.0.0/24")
+	if err != nil {
+		t.Fatalf("Fatal error while building Zero IP example - %s", err.Error())
+	}
+	var zeroIP4Subnet = Cidr{Cidr: *exampleCidr, Valid: true}
+	testBidirectional(zeroIP4Subnet, "Zero IPv4 Subnet")
+
+	_, exampleCidr, err = net.ParseCIDR("135.104.0.0/24")
+	if err != nil {
+		t.Fatalf("Fatal error while building simple IPv4 subnet example - %s", err.Error())
+	}
+	var simpleIP4Subnet = Cidr{Cidr: *exampleCidr, Valid: true}
+	testBidirectional(simpleIP4Subnet, "Simple IPv4 Subnet")
+
+	_, exampleCidr, err = net.ParseCIDR("::1/128")
+	if err != nil {
+		t.Fatalf("Fatal error while building simple IPv6 loopback example - %s", err.Error())
+	}
+	var ip6Loopback = Cidr{Cidr: *exampleCidr, Valid: true}
+	testBidirectional(ip6Loopback, "IPv6 Loopback")
+
+	_, exampleCidr, err = net.ParseCIDR("abcd:2345::/65")
+	if err != nil {
+		t.Fatalf("Fatal error while building simple IPv6 subnet example - %s", err.Error())
+	}
+	var ip6Subnet = Cidr{Cidr: *exampleCidr, Valid: true}
+	testBidirectional(ip6Subnet, "IPv6 Subnet #1")
+
+	_, exampleCidr, err = net.ParseCIDR("abcd:2300::/24")
+	if err != nil {
+		t.Fatalf("Fatal error while building simple IPv6 subnet #2 example - %s", err.Error())
+	}
+	var ip6Subnet2 = Cidr{Cidr: *exampleCidr, Valid: true}
+	testBidirectional(ip6Subnet2, "IPv6 Subnet #2")
+
+	_, exampleCidr, err = net.ParseCIDR("2001:DB8::1/48")
+	if err != nil {
+		t.Fatalf("Fatal error while building simple IPv6 subnet #3 example - %s", err.Error())
+	}
+	var ip6Subnet3 = Cidr{Cidr: *exampleCidr, Valid: true}
+	testBidirectional(ip6Subnet3, "IPv6 Subnet #3")
+
+	// Error handling
+
+	// Bad argument
+	cidr = Cidr{}
+	err = cidr.Scan(456)
+	if err == nil {
+		t.Fatal("Expected error for non-byte[] argument to Scan")
+	}
+
+	cidr = Cidr{}
+	err = cidr.Scan([]byte(""))
+	if err == nil {
+		t.Fatalf("Expected error for invalid CIDR")
+	}
+}

--- a/netaddr/cidr_test.go
+++ b/netaddr/cidr_test.go
@@ -41,10 +41,10 @@ func TestCidr(t *testing.T) {
 		if !cidr.Valid {
 			t.Fatalf("expected non-null value, got null for %s", label)
 		}
-		if bytes.Compare(c.Cidr.IP, cidr.Cidr.IP) != 0 {
+		if !net.IP.Equal(c.Cidr.IP, cidr.Cidr.IP) {
 			t.Fatalf("expected IP addresses to match, but did not for %s - %s %s", label, c.Cidr.IP.String(), cidr.Cidr.IP.String())
 		}
-		if bytes.Compare(c.Cidr.Mask, cidr.Cidr.Mask) != 0 {
+		if !bytes.Equal(c.Cidr.Mask, cidr.Cidr.Mask) {
 			t.Fatalf("expected net masks to match, but did not for %s", label)
 		}
 	}

--- a/netaddr/inet.go
+++ b/netaddr/inet.go
@@ -1,0 +1,44 @@
+package netaddr
+
+import (
+	"database/sql/driver"
+	"errors"
+	"net"
+)
+
+// A wrapper for transferring Inet values back and forth easily.
+type Inet struct {
+	Inet  net.IP
+	Valid bool
+}
+
+// Scan implements the Scanner interface.
+func (i *Inet) Scan(value interface{}) error {
+	i.Inet = nil
+	i.Valid = false
+	if value == nil {
+		i.Valid = false
+		return nil
+	}
+	ipAsBytes, ok := value.([]byte)
+	if !ok {
+		return errors.New("Could not convert scanned value to bytes")
+	}
+	parsedIP := net.ParseIP(string(ipAsBytes))
+	if parsedIP == nil {
+		i.Valid = false
+		return nil
+	}
+	i.Valid = true
+	i.Inet = parsedIP
+	return nil
+}
+
+// Value implements the driver Valuer interface. Note if i.Valid is false
+// or i.IP is nil the database column value will be set to NULL.
+func (i Inet) Value() (driver.Value, error) {
+	if i.Valid == false || i.Inet == nil {
+		return nil, nil
+	}
+	return []byte(i.Inet.String()), nil
+}

--- a/netaddr/inet.go
+++ b/netaddr/inet.go
@@ -8,28 +8,20 @@ import (
 
 // A wrapper for transferring Inet values back and forth easily.
 type Inet struct {
-	Inet  net.IP
-	Valid bool
+	Inet net.IP
 }
 
 // Scan implements the Scanner interface.
 func (i *Inet) Scan(value interface{}) error {
 	i.Inet = nil
-	i.Valid = false
-	if value == nil {
-		i.Valid = false
-		return nil
-	}
 	ipAsBytes, ok := value.([]byte)
 	if !ok {
 		return errors.New("Could not convert scanned value to bytes")
 	}
 	parsedIP := net.ParseIP(string(ipAsBytes))
 	if parsedIP == nil {
-		i.Valid = false
 		return nil
 	}
-	i.Valid = true
 	i.Inet = parsedIP
 	return nil
 }
@@ -37,7 +29,7 @@ func (i *Inet) Scan(value interface{}) error {
 // Value implements the driver Valuer interface. Note if i.Valid is false
 // or i.IP is nil the database column value will be set to NULL.
 func (i Inet) Value() (driver.Value, error) {
-	if i.Valid == false || i.Inet == nil {
+	if i.Inet == nil {
 		return nil, nil
 	}
 	return []byte(i.Inet.String()), nil

--- a/netaddr/inet.go
+++ b/netaddr/inet.go
@@ -14,6 +14,9 @@ type Inet struct {
 // Scan implements the Scanner interface.
 func (i *Inet) Scan(value interface{}) error {
 	i.Inet = nil
+	if value == nil {
+		return nil
+	}
 	ipAsBytes, ok := value.([]byte)
 	if !ok {
 		return errors.New("Could not convert scanned value to bytes")
@@ -26,8 +29,8 @@ func (i *Inet) Scan(value interface{}) error {
 	return nil
 }
 
-// Value implements the driver Valuer interface. Note if i.Valid is false
-// or i.IP is nil the database column value will be set to NULL.
+// Value implements the driver Valuer interface. Note if
+// i.IP is nil the database column value will be set to NULL.
 func (i Inet) Value() (driver.Value, error) {
 	if i.Inet == nil {
 		return nil, nil

--- a/netaddr/inet.go
+++ b/netaddr/inet.go
@@ -6,7 +6,7 @@ import (
 	"net"
 )
 
-// A wrapper for transferring Inet values back and forth easily.
+// Inet is a wrapper for transferring Inet values back and forth easily.
 type Inet struct {
 	Inet net.IP
 }

--- a/netaddr/inet_test.go
+++ b/netaddr/inet_test.go
@@ -1,0 +1,68 @@
+package netaddr
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	_ "github.com/lib/pq"
+)
+
+func TestInet(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	inet := Inet{}
+
+	// Test scanning NULL values
+	err := db.QueryRow("SELECT NULL::inet").Scan(&inet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inet.Valid {
+		t.Fatalf("expected null result")
+	}
+
+	// Test setting NULL values
+	err = db.QueryRow("SELECT $1::inet", inet).Scan(&inet)
+	if err != nil {
+		t.Fatalf("re-query null value failed: %s", err.Error())
+	}
+	if inet.Valid {
+		t.Fatalf("expected null result")
+	}
+
+	// test encoding in query params, then decoding during Scan
+	testBidirectional := func(i Inet, label string) {
+		err = db.QueryRow("SELECT $1::inet", i).Scan(&inet)
+		if err != nil {
+			t.Fatalf("re-query %s inet failed: %s", label, err.Error())
+		}
+		if !inet.Valid {
+			t.Fatalf("expected non-null value, got null for %s", label)
+		}
+		if bytes.Compare(i.Inet, inet.Inet) != 0 {
+			t.Fatalf("expected IP addresses to match, but did not for %s - %s %s", label, i.Inet.String(), inet.Inet.String())
+		}
+	}
+
+	testBidirectional(Inet{Inet: net.ParseIP("192.168.0.1"), Valid: true}, "Simple IPv4")
+	testBidirectional(Inet{Inet: net.ParseIP("::1"), Valid: true}, "Loopback IPv6")
+	testBidirectional(Inet{Inet: net.ParseIP("abcd:2345::"), Valid: true}, "Loopback IPv6")
+
+	// Bad argument
+	inet = Inet{}
+	err = inet.Scan(456)
+	if err == nil {
+		t.Fatal("Expected error for non-byte[] argument to Scan")
+	}
+
+	inet = Inet{}
+	err = inet.Scan([]byte(""))
+	if err != nil {
+		t.Fatalf("Unexpected error for empty string - %s", err.Error())
+	}
+	if inet.Valid {
+		t.Fatalf("Unexpected not null for empty/non-IP string string")
+	}
+}

--- a/netaddr/inet_test.go
+++ b/netaddr/inet_test.go
@@ -61,7 +61,7 @@ func TestInet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error for empty string - %s", err.Error())
 	}
-	if inet.Inet == nil {
+	if inet.Inet != nil {
 		t.Fatalf("Unexpected not null for empty/non-IP string string")
 	}
 }

--- a/netaddr/inet_test.go
+++ b/netaddr/inet_test.go
@@ -19,7 +19,7 @@ func TestInet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if inet.Valid {
+	if inet.Inet != nil {
 		t.Fatalf("expected null result")
 	}
 
@@ -28,7 +28,7 @@ func TestInet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-query null value failed: %s", err.Error())
 	}
-	if inet.Valid {
+	if inet.Inet != nil {
 		t.Fatalf("expected null result")
 	}
 
@@ -38,7 +38,7 @@ func TestInet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("re-query %s inet failed: %s", label, err.Error())
 		}
-		if !inet.Valid {
+		if inet.Inet == nil {
 			t.Fatalf("expected non-null value, got null for %s", label)
 		}
 		if bytes.Compare(i.Inet, inet.Inet) != 0 {
@@ -46,9 +46,9 @@ func TestInet(t *testing.T) {
 		}
 	}
 
-	testBidirectional(Inet{Inet: net.ParseIP("192.168.0.1"), Valid: true}, "Simple IPv4")
-	testBidirectional(Inet{Inet: net.ParseIP("::1"), Valid: true}, "Loopback IPv6")
-	testBidirectional(Inet{Inet: net.ParseIP("abcd:2345::"), Valid: true}, "Loopback IPv6")
+	testBidirectional(Inet{Inet: net.ParseIP("192.168.0.1")}, "Simple IPv4")
+	testBidirectional(Inet{Inet: net.ParseIP("::1")}, "Loopback IPv6")
+	testBidirectional(Inet{Inet: net.ParseIP("abcd:2345::")}, "Loopback IPv6")
 
 	// Bad argument
 	inet = Inet{}

--- a/netaddr/inet_test.go
+++ b/netaddr/inet_test.go
@@ -62,7 +62,7 @@ func TestInet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error for empty string - %s", err.Error())
 	}
-	if inet.Valid {
+	if inet.Inet == nil {
 		t.Fatalf("Unexpected not null for empty/non-IP string string")
 	}
 }

--- a/netaddr/inet_test.go
+++ b/netaddr/inet_test.go
@@ -1,7 +1,6 @@
 package netaddr
 
 import (
-	"bytes"
 	"net"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestInet(t *testing.T) {
 		if inet.Inet == nil {
 			t.Fatalf("expected non-null value, got null for %s", label)
 		}
-		if bytes.Compare(i.Inet, inet.Inet) != 0 {
+		if !net.IP.Equal(i.Inet, inet.Inet) {
 			t.Fatalf("expected IP addresses to match, but did not for %s - %s %s", label, i.Inet.String(), inet.Inet.String())
 		}
 	}

--- a/netaddr/macaddr.go
+++ b/netaddr/macaddr.go
@@ -6,7 +6,7 @@ import (
 	"net"
 )
 
-// A wrapper for transferring Macaddr values back and forth easily.
+// Macaddr is a wrapper for transferring Macaddr values back and forth easily.
 type Macaddr struct {
 	Macaddr net.HardwareAddr
 	Valid   bool
@@ -36,7 +36,7 @@ func (m *Macaddr) Scan(value interface{}) error {
 // Value implements the driver Valuer interface. Note if m.Valid is false
 // or m.Macaddr is nil the database column value will be set to NULL.
 func (m Macaddr) Value() (driver.Value, error) {
-	if m.Valid == false || m.Macaddr == nil {
+	if !m.Valid || m.Macaddr == nil {
 		return nil, nil
 	}
 	return []byte(m.Macaddr.String()), nil

--- a/netaddr/macaddr.go
+++ b/netaddr/macaddr.go
@@ -1,0 +1,43 @@
+package netaddr
+
+import (
+	"database/sql/driver"
+	"errors"
+	"net"
+)
+
+// A wrapper for transferring Macaddr values back and forth easily.
+type Macaddr struct {
+	Macaddr net.HardwareAddr
+	Valid   bool
+}
+
+// Scan implements the Scanner interface.
+func (m *Macaddr) Scan(value interface{}) error {
+	m.Macaddr = nil
+	m.Valid = false
+	if value == nil {
+		m.Valid = false
+		return nil
+	}
+	macaddrAsBytes, ok := value.([]byte)
+	if !ok {
+		return errors.New("Could not convert scanned value to bytes")
+	}
+	parsedMacaddr, error := net.ParseMAC(string(macaddrAsBytes))
+	if error != nil {
+		return error
+	}
+	m.Valid = true
+	m.Macaddr = parsedMacaddr
+	return nil
+}
+
+// Value implements the driver Valuer interface. Note if m.Valid is false
+// or m.Macaddr is nil the database column value will be set to NULL.
+func (m Macaddr) Value() (driver.Value, error) {
+	if m.Valid == false || m.Macaddr == nil {
+		return nil, nil
+	}
+	return []byte(m.Macaddr.String()), nil
+}

--- a/netaddr/macaddr_test.go
+++ b/netaddr/macaddr_test.go
@@ -41,7 +41,7 @@ func TestMacaddr(t *testing.T) {
 		if !macaddr.Valid {
 			t.Fatalf("expected non-null value, got null for %s", label)
 		}
-		if bytes.Compare(m.Macaddr, macaddr.Macaddr) != 0 {
+		if !bytes.Equal(m.Macaddr, macaddr.Macaddr) {
 			t.Fatalf("expected MAC addresses to match, but did not for %s", label)
 		}
 	}

--- a/netaddr/macaddr_test.go
+++ b/netaddr/macaddr_test.go
@@ -1,0 +1,64 @@
+package netaddr
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	_ "github.com/lib/pq"
+)
+
+func TestMacaddr(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	macaddr := Macaddr{}
+
+	// Test scanning NULL values
+	err := db.QueryRow("SELECT NULL::macaddr").Scan(&macaddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if macaddr.Valid {
+		t.Fatalf("expected null result")
+	}
+
+	// Test setting NULL values
+	err = db.QueryRow("SELECT $1::macaddr", macaddr).Scan(&macaddr)
+	if err != nil {
+		t.Fatalf("re-query null value failed: %s", err.Error())
+	}
+	if macaddr.Valid {
+		t.Fatalf("expected null result")
+	}
+
+	// test encoding in query params, then decoding during Scan
+	testBidirectional := func(m Macaddr, label string) {
+		err = db.QueryRow("SELECT $1::macaddr", m).Scan(&macaddr)
+		if err != nil {
+			t.Fatalf("re-query %s macaddr failed: %s", label, err.Error())
+		}
+		if !macaddr.Valid {
+			t.Fatalf("expected non-null value, got null for %s", label)
+		}
+		if bytes.Compare(m.Macaddr, macaddr.Macaddr) != 0 {
+			t.Fatalf("expected MAC addresses to match, but did not for %s", label)
+		}
+	}
+
+	var simpleMac = Macaddr{Macaddr: net.HardwareAddr{1, 0x23, 0x45, 0x67, 0x89, 0xab}, Valid: true}
+	testBidirectional(simpleMac, "Simple MAC Address")
+
+	// Bad argument
+	macaddr = Macaddr{}
+	err = macaddr.Scan(456)
+	if err == nil {
+		t.Fatal("Expected error for non-byte[] argument to Scan")
+	}
+
+	macaddr = Macaddr{}
+	err = macaddr.Scan([]byte(""))
+	if err == nil {
+		t.Fatalf("Expected error for invalid Macaddr")
+	}
+}

--- a/netaddr/testutil.go
+++ b/netaddr/testutil.go
@@ -1,0 +1,32 @@
+package netaddr
+
+import (
+	"database/sql"
+	"os"
+
+	_ "github.com/lib/pq"
+)
+
+type Fatalistic interface {
+	Fatal(args ...interface{})
+}
+
+func openTestConn(t Fatalistic) *sql.DB {
+	datname := os.Getenv("PGDATABASE")
+	sslmode := os.Getenv("PGSSLMODE")
+
+	if datname == "" {
+		os.Setenv("PGDATABASE", "pqgotest")
+	}
+
+	if sslmode == "" {
+		os.Setenv("PGSSLMODE", "disable")
+	}
+
+	conn, err := sql.Open("postgres", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return conn
+}


### PR DESCRIPTION
An implementation of Scanner / Value types for Postgres network address types, intended to make it easier to work with these types.  Includes the three current network address types - cidr, inet, macaddr.  Addresses issue #121 

Some quick comments:
1. The package name 'netaddr' was chosen to conform with Go recommended best practices.  Happy to change this package name if there's a strong preference on the maintainer's part for another package name.
2. I decided to give all of the types a consistent behavior with regards to NULL handling.  Like the native value types (Bool, Int64, etc.) the corresponding structs have a 'Valid' member.  When false, this indicates that the corresponding database value is NULL.  Technically the native types for inet and macaddr support a nil value, and so for these cases a simpler struct could have been used.  But I opted for a more consistent interface.
3. It was unclear to me from the existing Hstore implementation whether an error in a Scan should result in a panic or the explict return of an error.  I chose to explicitly return an error rather than panic if Scan received a value that cannot be coerced to a byte array.

Happy to discuss or revisit any of the above.  
