### PR TITLE
cache SSL client certs

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -5,11 +5,14 @@ package pq
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"database/sql"
 	"database/sql/driver"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"net"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -433,3 +436,96 @@ func BenchmarkResultParsing(b *testing.B) {
 		res.Close()
 	}
 }
+
+func BenchmarkSetupSSLClientCertificatesParse(b *testing.B) {
+	b.StopTimer()
+	keypath := tempfile(b, dummyKey)
+	certpath := tempfile(b, dummyCert)
+	defer os.Remove(keypath)
+	defer os.Remove(certpath)
+	defer b.StopTimer()
+	var tlsConfig tls.Config
+	o := values{
+		"sslkey":  keypath,
+		"sslcert": certpath,
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		setupSSLClientCertificates(&tlsConfig, o)
+	}
+}
+
+func BenchmarkSetupSSLClientCertificatesNoFile(b *testing.B) {
+	var tlsConfig tls.Config
+	o := make(values)
+	for i := 0; i < b.N; i++ {
+		setupSSLClientCertificates(&tlsConfig, o)
+	}
+}
+
+func tempfile(b *testing.B, body string) (path string) {
+	f, err := ioutil.TempFile("", "pqtest")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_, err = io.WriteString(f, body)
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = f.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+	return f.Name()
+}
+
+const dummyCert = `
+-----BEGIN CERTIFICATE-----
+MIIC+zCCAeOgAwIBAgIQf4S2Cm7JGlEJ2xZdnLXJxTANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMB4XDTE1MTAwNDIxNDI0OFoXDTE2MTAwMzIxNDI0
+OFowEjEQMA4GA1UEChMHQWNtZSBDbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAMx4GBx3vZjlpCu5fBra3keCq+ZNiU4WX3QXOUygWaBaB5KRZhFrcfY+
+mzMbptSyWYjA6+PnPyODDxn2vxPqLVommuspR4QkqIk+HuSVL3eAtH6jv/u91H+G
+COSrvqf4YCD99A81D0LryhL+x2GCyOaVsnHtwAbWsImZ/rhSkS3+DyLf/L96+GlF
+UsXNs7Vp+NeAjUEscZ0b7jkcrhpKMD/WBkmYR45Yxuq+KEZ7ilFHKu+a2b0xRHHC
+fCodqbSlZ6vvp2vluAJLvDF/Nk3jGSq10efHw8dz6iYMlxjRagQLgpViyKR6K8Az
+XJUmluFYGQQQsqET27ecFl1TngBGqd8CAwEAAaNNMEswDgYDVR0PAQH/BAQDAgWg
+MBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwFgYDVR0RBA8wDYIL
+ZXhhbXBsZS5vcmcwDQYJKoZIhvcNAQELBQADggEBAFQDL+Xx/EPdZgWvtTe/I4Ch
+ZwT78N7jZ39G4AEMusdf9WUY3RqimbWiLD8rub43uBr/uO1MYvKJTKp8dS7TVCYa
+YwxzS2I6bj4cOIXUVeXN/TiViWZwqshhVUCPvS4g4hXOMyIi0fqOjgaAvNMwxeDh
+fqG4nOD2Gpwax/1KrH3GawUFghFvC5T3CHC8Q/T7LXFeQ//jTtUMmJ+9PQzTTr/p
+Nx0ffnMXXiu7fdo42KTJoOA21bvZWQ5okA1Y6catVN8CNRNKIGIN/9w36ffDw8Un
+5Va3a5X5CnQvU2CK5o1E2IUEpbDwrmSKzn8mmpqBRurbFCD5q1fW0BafA+tmAwg=
+-----END CERTIFICATE-----
+`
+
+const dummyKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAzHgYHHe9mOWkK7l8GtreR4Kr5k2JThZfdBc5TKBZoFoHkpFm
+EWtx9j6bMxum1LJZiMDr4+c/I4MPGfa/E+otWiaa6ylHhCSoiT4e5JUvd4C0fqO/
++73Uf4YI5Ku+p/hgIP30DzUPQuvKEv7HYYLI5pWyce3ABtawiZn+uFKRLf4PIt/8
+v3r4aUVSxc2ztWn414CNQSxxnRvuORyuGkowP9YGSZhHjljG6r4oRnuKUUcq75rZ
+vTFEccJ8Kh2ptKVnq++na+W4Aku8MX82TeMZKrXR58fDx3PqJgyXGNFqBAuClWLI
+pHorwDNclSaW4VgZBBCyoRPbt5wWXVOeAEap3wIDAQABAoIBAQC5VOWt8A8Hpqb/
+BvppsRcnRFchwggBop/UrzQ9s15pzRDuFiKpCXXbmHW+hoLaaepj3VIzWijNvH6U
+ryYVG/8Nps5m9xyet0eYVplT4bGLpTp1S2G6Ah+5kzk+ZDnFMImZffaZTiPOKcEZ
+JJx+UzhcYTXEtJaI3FJZ9x593kE/qFk2Ylp+cSHsgvglxjZvD3hcBjIt37ovLGck
+zo826EjmS7xtUOuBWpSyrSjeQ2qHSL95hoiCUC2XKCTunCfy8kXhuhWzHzCwljPI
+ULgo0vVzzA9K8wsMVVXl2qEqvlSZGXFQtWV1gIwXbKSlqn0BDs4Y7QyBrlAop9Vf
+LggeqlYxAoGBAONcI4KoycT+mcg1Z4+cvX8vO8NDlkSW1RGsDyPNmIEAC6yZhj7+
+TaMrxeprFduZf6H8dFUhri56X57h7CuW7xHD2ryX524df8Mlhkcrf0F2QCB4pflx
+GvxgNR0XsxypZfbGdvgDTHXVz0FOD+SOpZORaZxw+9qrJ/omwHtqkQb3AoGBAOY5
+xvMbHHAiqqjGbAJ8LEb/Fztf24z7N0ouPoA7AFFAS9T1M+PYGmL3Rkfml5i4DLwA
++tGs/jA8ZEyQbfhsw/9hJmLojfyq6VG7Dvm0DEER8LIfpBXRP+tkpFSunUBWYC++
+J2k0igbz0kwLDlvo81T2Wg9ugWG/E1+qiMcouTJZAoGBAIXR/5yyGEB40q8Cr/fZ
+e7fWZ0ihCVtJpBOIwEiEhJS5ICXxHxEIwU2fQBif+veMO5FudFJ/RnRY1ts/grCN
+YB2Gt8J1bmRjvIVyGrzdH0O6hDgYiyhsqEOPpPOAtY3TLw629eM4ndJljF2Vwsj2
+JQLcfdr0rWihgSA9muGJcd81AoGAM/k5I6qsKdh5pG5e9dSofkKaMQo720DfQ3zb
+GUG4mZ8lP2c3lqkzk8H0+Mhi0tRB87NY7Drci3Emx24XlWygdqes7clIPJEs6QmM
+oOx3k70EFII2HcLGZlKrEn70+xBE2KJZ7VMyEc27XPVmAXO+cyDGRhORW8qyCffK
+twNHg8kCgYB5SYu5nkPisCKnNCfDVHci5IrwqwoC6ch0/kDx9oSpyUTSv2iiWqL4
+nKqj7r41SowYPGlYYxKZ9eAKnJBCovZ2wUbHDmKrmmDIigjv5Y3wlRzFAH/0Satf
+S0hoa0mHG3ZKxIH08lrCAr/IvMck2X0F6JC0JoQCzBKTN4WOJrC6yQ==
+-----END RSA PRIVATE KEY-----
+`

--- a/conn.go
+++ b/conn.go
@@ -988,7 +988,7 @@ func (cn *conn) ssl(o values) {
 		errorf(`unsupported sslmode %q; only "require" (default), "verify-full", "verify-ca", and "disable" supported`, mode)
 	}
 
-	cn.setupSSLClientCertificates(&tlsConf, o)
+	setupSSLClientCertificates(&tlsConf, o)
 	cn.setupSSLCA(&tlsConf, o)
 
 	w := cn.writeBuf(0)
@@ -1045,7 +1045,7 @@ func (cn *conn) verifyCA(client *tls.Conn, tlsConf *tls.Config) {
 // explicitly, the files must exist.  The key file must also not be
 // world-readable, or this function will panic with
 // ErrSSLKeyHasWorldPermissions.
-func (cn *conn) setupSSLClientCertificates(tlsConf *tls.Config, o values) {
+func setupSSLClientCertificates(tlsConf *tls.Config, o values) {
 	var missingOk bool
 
 	sslkey := o.Get("sslkey")


### PR DESCRIPTION

    benchmark                                       old ns/op     new ns/op     delta
    BenchmarkSetupSSLClientCertificatesParse-8      379742        77.8          -99.98%
    BenchmarkSetupSSLClientCertificatesNoFile-8     2592          59.7          -97.70%
    
    benchmark                                       old allocs     new allocs     delta
    BenchmarkSetupSSLClientCertificatesParse-8      2702           0              -100.00%
    BenchmarkSetupSSLClientCertificatesNoFile-8     15             0              -100.00%
    
    benchmark                                       old bytes     new bytes     delta
    BenchmarkSetupSSLClientCertificatesParse-8      206032        0             -100.00%
    BenchmarkSetupSSLClientCertificatesNoFile-8     680           0             -100.00%
