### PR TITLE
allow Go tip to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ go:
   - 1.5
   - tip
 
+matrix:
+  allow_failures:
+    - go: tip
+
 before_install:
   - psql --version
   - sudo /etc/init.d/postgresql stop


### PR DESCRIPTION
Go 1.5 was released in August of 2015.

The "tip" version of Go isn't guaranteed to be backwards
compatible or even stable, so those builds might fail
for reasons unrelated to any lib/pq pull request. It's
useful to see the results, but they shouldn't block a
pull request from being landed.