### PR TITLE
Make copyin.Close() idempotent

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -215,9 +215,7 @@ func (ci *copyin) Exec(v []driver.Value) (r driver.Result, err error) {
 	}
 
 	if len(v) == 0 {
-		err = ci.Close()
-		ci.closed = true
-		return nil, err
+		return nil, ci.Close()
 	}
 
 	numValues := len(v)
@@ -240,9 +238,10 @@ func (ci *copyin) Exec(v []driver.Value) (r driver.Result, err error) {
 }
 
 func (ci *copyin) Close() (err error) {
-	if ci.closed {
-		return errCopyInClosed
+	if ci.closed { // Don't do anything, we're already closed
+		return nil
 	}
+	ci.closed = true
 
 	if ci.cn.bad {
 		return driver.ErrBadConn


### PR DESCRIPTION
This change is causing breakage on tip:
https://github.com/golang/go/issues/12798

I think it's a reasonable upstream change.

Looking at the commit that added the code that is failing on our side
the lack of error propagation is called out and is the reason we're now
failing.
https://github.com/lib/pq/commit/72f84510ec4899677ec603abbaec5ba17a438a8c

This change attempts to preserve old behavior while supporting the fact
that errors are now propagated properly by Stmt.Close().

Open to better ways to handle this though.