### PR TITLE
Seems schema shouldn't be quoted:

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -32,7 +32,7 @@ func CopyIn(table string, columns ...string) string {
 // CopyInSchema creates a COPY FROM statement which can be prepared with
 // Tx.Prepare().
 func CopyInSchema(schema, table string, columns ...string) string {
-	stmt := "COPY " + QuoteIdentifier(schema) + "." + QuoteIdentifier(table) + " ("
+	stmt := "COPY " + schema + "." + QuoteIdentifier(table) + " ("
 	for i, col := range columns {
 		if i != 0 {
 			stmt += ", "


### PR DESCRIPTION
Some example snippet when doing it manually in psql:

```
sink=# COPY "DATE20151113PERIOD10m"."dyno_error" ("id", "time", "cnt",
"dyno_type", "code") FROM STDIN;
ERROR:  schema "DATE20151113PERIOD10m" does not exist

sink=# create schema DATE20151113PERIOD10m;
ERROR:  schema "date20151113period10m" already exists

sink=# COPY DATE20151113PERIOD10m.dyno_error ("id", "time", "cnt",
"dyno_type", "code") FROM STDIN;
Enter data to be copied followed by a newline.
End with a backslash and a period on a line by itself.

sink=# COPY DATE20151113PERIOD10m."dyno_error" ("id", "time", "cnt",
"dyno_type", "code") FROM STDIN;
Enter data to be copied followed by a newline.
End with a backslash and a period on a line by itself.
```