### PR TITLE
Fix empty query `Columns()` handling

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -557,13 +557,15 @@ func (cn *conn) simpleQuery(q string) (res *rows, err error) {
 				cn.bad = true
 				errorf("unexpected message %q in simple query execution", t)
 			}
-			res = &rows{
-				cn:       cn,
-				colNames: st.colNames,
-				colTyps:  st.colTyps,
-				colFmts:  st.colFmts,
-				done:     true,
+			if res == nil {
+				res = &rows{
+					cn:       cn,
+					colNames: st.colNames,
+					colTyps:  st.colTyps,
+					colFmts:  st.colFmts,
+				}
 			}
+			res.done = true
 		case 'Z':
 			cn.processReadyForQuery(r)
 			// done


### PR DESCRIPTION
A query which returns an empty dataset no longer discards its
`Columns()`.

Best to review this with whitespace suppressed.