### PR TITLE
Allow transactions to begin mid-query

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1358,7 +1358,7 @@ func (rs *rows) Next(dest []driver.Value) (err error) {
 		switch t {
 		case 'E':
 			err = parseError(&rs.rb)
-		case 'C', 'I':
+		case 'C', 'I', 'T':
 			continue
 		case 'Z':
 			conn.processReadyForQuery(&rs.rb)

--- a/conn_test.go
+++ b/conn_test.go
@@ -1118,6 +1118,21 @@ func TestCommit(t *testing.T) {
 	}
 }
 
+func TestTransactionMultipleRequest(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	rows, err := db.Query("SELECT 1; BEGIN; SELECT 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestErrorClass(t *testing.T) {
 	db := openTestConn(t)
 	defer db.Close()


### PR DESCRIPTION
This was discovered in some synthetic tests in
github.com/cockroachdb/cockroach where we are running raw SQL rather
than starting transactions in the normal Go way.

Still, this is a bug.