### PR TITLE
Add verify-ca to error message in conn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -985,7 +985,7 @@ func (cn *conn) ssl(o values) {
 	case "disable":
 		return
 	default:
-		errorf(`unsupported sslmode %q; only "require" (default), "verify-full", and "disable" supported`, mode)
+		errorf(`unsupported sslmode %q; only "require" (default), "verify-full", "verify-ca", and "disable" supported`, mode)
 	}
 
 	cn.setupSSLClientCertificates(&tlsConf, o)


### PR DESCRIPTION
There's a valid branch called "verify-ca" but it's not called out in the error message