### PR TITLE
Add support for retrieving multiple results.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -164,7 +164,7 @@ func (c *conn) handlePgpass(o values) {
 		return
 	}
 	mode := fileinfo.Mode()
-	if mode & (0x77) != 0 {
+	if mode&(0x77) != 0 {
 		// XXX should warn about incorrect .pgpass permissions as psql does
 		return
 	}
@@ -180,7 +180,7 @@ func (c *conn) handlePgpass(o values) {
 	db := o.Get("dbname")
 	username := o.Get("user")
 	// From: https://github.com/tg/pgpass/blob/master/reader.go
-	getFields := func (s string) []string {
+	getFields := func(s string) []string {
 		fs := make([]string, 0, 5)
 		f := make([]rune, 0, len(s))
 
@@ -200,7 +200,7 @@ func (c *conn) handlePgpass(o values) {
 			}
 		}
 		return append(fs, string(f))
-	}	
+	}
 	for scanner.Scan() {
 		line := scanner.Text()
 		if len(line) == 0 || line[0] == '#' {
@@ -210,7 +210,7 @@ func (c *conn) handlePgpass(o values) {
 		if len(split) != 5 {
 			continue
 		}
-		if (split[0] == "*" || split[0] == hostname || (split[0] == "localhost" && (hostname == "" || ntw == "unix"))) && (split[1] == "*" || split[1] == port) && (split[2] == "*" || split[2] == db)  && (split[3] == "*" || split[3] == username)  {
+		if (split[0] == "*" || split[0] == hostname || (split[0] == "localhost" && (hostname == "" || ntw == "unix"))) && (split[1] == "*" || split[1] == port) && (split[2] == "*" || split[2] == db) && (split[3] == "*" || split[3] == username) {
 			o["password"] = split[4]
 			return
 		}
@@ -614,8 +614,6 @@ func (cn *conn) simpleExec(q string) (res driver.Result, commandTag string, err 
 func (cn *conn) simpleQuery(q string) (res *rows, err error) {
 	defer cn.errRecover(&err)
 
-	st := &stmt{cn: cn, name: ""}
-
 	b := cn.writeBuf('Q')
 	b.string(q)
 	cn.send(b)
@@ -634,10 +632,7 @@ func (cn *conn) simpleQuery(q string) (res *rows, err error) {
 			}
 			if res == nil {
 				res = &rows{
-					cn:       cn,
-					colNames: st.colNames,
-					colTyps:  st.colTyps,
-					colFmts:  st.colFmts,
+					cn: cn,
 				}
 			}
 			res.done = true


### PR DESCRIPTION
Reworked how the msg-ready command (`Z`) is processed. Previously
execution of a query would look for the msg-ready command before
completing the operation. Now, when executing a query, the driver places
the connection into a state where it knows there may be more results. If
another query is subsequently executed, the driver waits for the
msg-ready command to arrive, discarding any other commands, before
sending the new query. But if the special `NEXT` query is executed, the
driver looks for another set of results on the connection. If no such
results are found, ErrNoMoreResults is returned.
