### PR TITLE
Move from /var/run/postgresql to /run/postgresql in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ variables.
 
 Example:
 
-	PGHOST=/var/run/postgresql go test github.com/lib/pq
+	PGHOST=/run/postgresql go test github.com/lib/pq
 
 Optionally, a benchmark suite can be run as part of the tests:
 
-	PGHOST=/var/run/postgresql go test -bench .
+	PGHOST=/run/postgresql go test -bench .
 
 ## Features
 


### PR DESCRIPTION
Modern Linux has moved to plain /run. See http://lwn.net/Articles/436012/