### PR TITLE
encode: `decode` T_text into a string

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -83,6 +83,8 @@ func binaryDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) inter
 
 func textDecode(parameterStatus *parameterStatus, s []byte, typ oid.Oid) interface{} {
 	switch typ {
+	case oid.T_char, oid.T_varchar, oid.T_text:
+		return string(s)
 	case oid.T_bytea:
 		return parseBytea(s)
 	case oid.T_timestamptz:

--- a/encode_test.go
+++ b/encode_test.go
@@ -575,6 +575,17 @@ func TestBinaryByteSliceToInt(t *testing.T) {
 	}
 }
 
+func TestTextDecodeIntoString(t *testing.T) {
+	input := []byte("hello world")
+	want := string(input)
+	for _, typ := range []oid.Oid{oid.T_char, oid.T_varchar, oid.T_text} {
+		got := decode(&parameterStatus{}, input, typ, formatText)
+		if got != want {
+			t.Errorf("invalid string decoding output for %T(%+v), got %v but expected %v", typ, typ, got, want)
+		}
+	}
+}
+
 func TestByteaOutputFormatEncoding(t *testing.T) {
 	input := []byte("\\x\x00\x01\x02\xFF\xFEabcdefg0123")
 	want := []byte("\\x5c78000102fffe6162636465666730313233")


### PR DESCRIPTION
This allows the caller to distinguish strings from byte arrays.