### PR TITLE
Check for postgres driver before registering

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -41,7 +41,15 @@ func (d *drv) Open(name string) (driver.Conn, error) {
 }
 
 func init() {
-	sql.Register("postgres", &drv{})
+	register := true
+	for _, d := range sql.Drivers() {
+		if d == "postgres" {
+			register = false
+		}
+	}
+	if register {
+		sql.Register("postgres", &drv{})
+	}
 }
 
 type parameterStatus struct {


### PR DESCRIPTION
Please forgive me for not having a good test case for this on hand but I wanted to get this PR open for discussion as quickly as possible.

With Go 1.6 (I assume 1.5 with `GO15VENDOREXPERIMENT=1` too) we started experiencing issues where vendored code that used lib/pq would cause an error in our main application that also used lib/pq.

The error was `panic: sql: Register called twice for driver postgres`.

The full traceback is

```
goroutine 1 [running]:
panic(0x808ba0, 0xc820102400)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
database/sql.Register(0x9873e0, 0x8, 0x7f242d4812f0, 0xc24748)
	/usr/local/go/src/database/sql/sql.go:45 +0x181
github.com/yhat/repo/src/vendor/github.com/yhat/events/vendor/github.com/lib/pq.init.1()
	/home/ubuntu/.go_workspace/src/github.com/yhat/repo/src/vendor/github.com/yhat/events/vendor/github.com/lib/pq/conn.go:44 +0x71
github.com/yhat/repo/src/vendor/github.com/yhat/events/vendor/github.com/lib/pq.init()
	/home/ubuntu/.go_workspace/src/github.com/yhat/repo/src/vendor/github.com/yhat/events/vendor/github.com/lib/pq/user_posix.go:24 +0x4ee
github.com/yhat/repo/src/vendor/github.com/yhat/events/events.init()
	/home/ubuntu/.go_workspace/src/github.com/yhat/repo/src/vendor/github.com/yhat/events/events/events.go:383 +0x68
github.com/yhat/repo/src/app.init()
	/home/ubuntu/.go_workspace/src/github.com/yhat/repo/src/app/deploy_test.go:30 +0xd3
main.init()
	github.com/yhat/repo/src/app/_test/_testmain.go:56 +0x4a
exit status 2
FAIL	github.com/yhat/repo/src/app	0.041s
```

The directory structure we had in place looks like:

```
.
├── src
│   ├── app (imports github.com/lib/pq & github.com/yhat/events/events
│   ├── ...
└── ├── vendor
├── github.com
│   ├── lib
│   │   └── pq
│   └── yhat
│       ├── events
│       │   ├── events
│       │   │   ├── events.go (imports github.com/lib/pq)
│       │   ├── main.go
│       │   └── vendor
│       │       └── github.com
│       │           ├── lib
│       │           │   └── pq
```

Referencing the the structure above:
`src/app/db.go` imports `github.com/lib/pq`
`src/app/events.go` imports `github.com/yhat/events/events`
`vendor/github.com/yhat/events/events/events.go` imports `github.com/lib/pq` which is also vendored within events.

In this case it appears the `init()` was being invoked twice and producing the error.

@bajh suggested this change; it simply checks to see if `"postgres"` is already registered before calling register. I've rolled out the patch on our fork and it did, indeed, solve the problem.

I suspect most people are not using vendoring and haven't encountered this issue yet.