### PR TITLE
Array support with delimiter interface

### DIFF
--- a/array.go
+++ b/array.go
@@ -9,6 +9,13 @@ import (
 
 var typeByteSlice = reflect.TypeOf([]byte{})
 
+// ArrayDelimiter may be optionally implemented by driver.Valuer to override the
+// array delimiter used by GenericArray.
+type ArrayDelimiter interface {
+	// ArrayDelimiter returns the delimiter character(s) for this element's type.
+	ArrayDelimiter() string
+}
+
 // GenericArray implements the driver.Valuer interface for an array or slice
 // of any dimension.
 type GenericArray struct{ A interface{} }
@@ -81,6 +88,10 @@ func appendArrayElement(b []byte, rv reflect.Value) ([]byte, string, error) {
 	var del string = ","
 	var err error
 	var iv interface{} = rv.Interface()
+
+	if ad, ok := iv.(ArrayDelimiter); ok {
+		del = ad.ArrayDelimiter()
+	}
 
 	if iv, err = driver.DefaultParameterConverter.ConvertValue(iv); err != nil {
 		return b, del, err

--- a/array.go
+++ b/array.go
@@ -1,0 +1,121 @@
+package pq
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+)
+
+var typeByteSlice = reflect.TypeOf([]byte{})
+
+// GenericArray implements the driver.Valuer interface for an array or slice
+// of any dimension.
+type GenericArray struct{ A interface{} }
+
+// Value implements the driver.Valuer interface.
+func (a GenericArray) Value() (driver.Value, error) {
+	if a.A == nil {
+		return nil, nil
+	}
+
+	rv := reflect.ValueOf(a.A)
+
+	if k := rv.Kind(); k != reflect.Array && k != reflect.Slice {
+		return nil, fmt.Errorf("pq: Unable to convert %T to array", a.A)
+	}
+
+	if n := rv.Len(); n > 0 {
+		// There will be at least two curly brackets, N bytes of values,
+		// and N-1 bytes of delimiters.
+		b := make([]byte, 0, 1+2*n)
+
+		b, _, err := appendArray(b, rv, n)
+		return string(b), err
+	}
+
+	return "{}", nil
+}
+
+// appendArray appends rv to the buffer, returning the extended buffer and
+// the delimiter used between elements.
+//
+// It panics when n <= 0 or rv's Kind is not reflect.Array nor reflect.Slice.
+func appendArray(b []byte, rv reflect.Value, n int) ([]byte, string, error) {
+	var del string
+	var err error
+
+	b = append(b, '{')
+
+	if b, del, err = appendArrayElement(b, rv.Index(0)); err != nil {
+		return b, del, err
+	}
+
+	for i := 1; i < n; i++ {
+		b = append(b, del...)
+		if b, del, err = appendArrayElement(b, rv.Index(i)); err != nil {
+			return b, del, err
+		}
+	}
+
+	return append(b, '}'), del, nil
+}
+
+// appendArrayElement appends rv to the buffer, returning the extended buffer
+// and the delimiter to use before the next element.
+//
+// When rv's Kind is neither reflect.Array nor reflect.Slice, it is converted
+// using driver.DefaultParameterConverter and the resulting []byte or string
+// is double-quoted.
+//
+// See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+func appendArrayElement(b []byte, rv reflect.Value) ([]byte, string, error) {
+	if k := rv.Kind(); k == reflect.Array || (k == reflect.Slice && rv.Type() != typeByteSlice) {
+		if n := rv.Len(); n > 0 {
+			return appendArray(b, rv, n)
+		}
+
+		return b, "", nil
+	}
+
+	var del string = ","
+	var err error
+	var iv interface{} = rv.Interface()
+
+	if iv, err = driver.DefaultParameterConverter.ConvertValue(iv); err != nil {
+		return b, del, err
+	}
+
+	switch v := iv.(type) {
+	case nil:
+		return append(b, "NULL"...), del, nil
+	case []byte:
+		return appendArrayQuotedBytes(b, v), del, nil
+	case string:
+		return appendArrayQuotedBytes(b, []byte(v)), del, nil
+	}
+
+	b, err = appendValue(b, iv)
+	return b, del, err
+}
+
+func appendArrayQuotedBytes(b, v []byte) []byte {
+	b = append(b, '"')
+	for {
+		i := bytes.IndexAny(v, `"\`)
+		if i < 0 {
+			b = append(b, v...)
+			break
+		}
+		if i > 0 {
+			b = append(b, v[:i]...)
+		}
+		b = append(b, '\\', v[i])
+		v = v[i+1:]
+	}
+	return append(b, '"')
+}
+
+func appendValue(b []byte, v driver.Value) ([]byte, error) {
+	return append(b, encode(nil, v, 0)...), nil
+}

--- a/array.go
+++ b/array.go
@@ -15,6 +15,41 @@ var typeByteSlice = reflect.TypeOf([]byte{})
 var typeDriverValuer = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
 var typeSqlScanner = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
 
+// Array returns the optimal driver.Valuer and sql.Scanner for an array or
+// slice of any dimension.
+//
+// For example:
+//  db.Query(`SELECT * FROM t WHERE id = ANY($1)`, pq.Array([]int{235, 401}))
+//
+//  var x []sql.NullInt64
+//  db.QueryRow('SELECT ARRAY[235, 401]').Scan(pq.Array(&x))
+func Array(a interface{}) interface {
+	driver.Valuer
+	sql.Scanner
+} {
+	switch a := a.(type) {
+	case []bool:
+		return (*BoolArray)(&a)
+	case []float64:
+		return (*Float64Array)(&a)
+	case []int64:
+		return (*Int64Array)(&a)
+	case []string:
+		return (*StringArray)(&a)
+
+	case *[]bool:
+		return (*BoolArray)(a)
+	case *[]float64:
+		return (*Float64Array)(a)
+	case *[]int64:
+		return (*Int64Array)(a)
+	case *[]string:
+		return (*StringArray)(a)
+	}
+
+	return GenericArray{a}
+}
+
 // ArrayDelimiter may be optionally implemented by driver.Valuer or sql.Scanner
 // to override the array delimiter used by GenericArray.
 type ArrayDelimiter interface {

--- a/array_test.go
+++ b/array_test.go
@@ -10,6 +10,218 @@ import (
 	"testing"
 )
 
+func TestBoolArrayValue(t *testing.T) {
+	result, err := BoolArray(nil).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for nil, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil, got %q", result)
+	}
+
+	result, err = BoolArray([]bool{}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for empty, got %v", err)
+	}
+	if expected := `{}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected empty, got %q", result)
+	}
+
+	result, err = BoolArray([]bool{false, true, false}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if expected := `{f,t,f}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func BenchmarkBoolArrayValue(b *testing.B) {
+	rand.Seed(1)
+	x := make([]bool, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = rand.Intn(2) == 0
+	}
+	a := BoolArray(x)
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
+func TestByteaArrayValue(t *testing.T) {
+	result, err := ByteaArray(nil).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for nil, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil, got %q", result)
+	}
+
+	result, err = ByteaArray([][]byte{}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for empty, got %v", err)
+	}
+	if expected := `{}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected empty, got %q", result)
+	}
+
+	result, err = ByteaArray([][]byte{{'\xDE', '\xAD', '\xBE', '\xEF'}, {'\xFE', '\xFF'}, {}}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if expected := `{"\\xdeadbeef","\\xfeff","\\x"}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func BenchmarkByteaArrayValue(b *testing.B) {
+	rand.Seed(1)
+	x := make([][]byte, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = make([]byte, len(x))
+		for j := 0; j < len(x); j++ {
+			x[i][j] = byte(rand.Int())
+		}
+	}
+	a := ByteaArray(x)
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
+func TestFloat64ArrayValue(t *testing.T) {
+	result, err := Float64Array(nil).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for nil, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil, got %q", result)
+	}
+
+	result, err = Float64Array([]float64{}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for empty, got %v", err)
+	}
+	if expected := `{}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected empty, got %q", result)
+	}
+
+	result, err = Float64Array([]float64{1.2, 3.4, 5.6}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if expected := `{1.2,3.4,5.6}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func BenchmarkFloat64ArrayValue(b *testing.B) {
+	rand.Seed(1)
+	x := make([]float64, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = rand.NormFloat64()
+	}
+	a := Float64Array(x)
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
+func TestInt64ArrayValue(t *testing.T) {
+	result, err := Int64Array(nil).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for nil, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil, got %q", result)
+	}
+
+	result, err = Int64Array([]int64{}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for empty, got %v", err)
+	}
+	if expected := `{}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected empty, got %q", result)
+	}
+
+	result, err = Int64Array([]int64{1, 2, 3}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if expected := `{1,2,3}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func BenchmarkInt64ArrayValue(b *testing.B) {
+	rand.Seed(1)
+	x := make([]int64, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = rand.Int63()
+	}
+	a := Int64Array(x)
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
+func TestStringArrayValue(t *testing.T) {
+	result, err := StringArray(nil).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for nil, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil, got %q", result)
+	}
+
+	result, err = StringArray([]string{}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for empty, got %v", err)
+	}
+	if expected := `{}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected empty, got %q", result)
+	}
+
+	result, err = StringArray([]string{`a`, `\b`, `c"`, `d,e`}).Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if expected := `{"a","\\b","c\"","d,e"}`; !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func BenchmarkStringArrayValue(b *testing.B) {
+	x := make([]string, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = strings.Repeat(`abc"def\ghi`, 5)
+	}
+	a := StringArray(x)
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
 func TestGenericArrayValueUnsupported(t *testing.T) {
 	_, err := GenericArray{true}.Value()
 

--- a/array_test.go
+++ b/array_test.go
@@ -84,6 +84,81 @@ func TestParseArrayError(t *testing.T) {
 	}
 }
 
+func TestArrayScanner(t *testing.T) {
+	var s sql.Scanner
+
+	s = Array(&[]bool{})
+	if _, ok := s.(*BoolArray); !ok {
+		t.Errorf("Expected *BoolArray, got %T", s)
+	}
+
+	s = Array(&[]float64{})
+	if _, ok := s.(*Float64Array); !ok {
+		t.Errorf("Expected *Float64Array, got %T", s)
+	}
+
+	s = Array(&[]int64{})
+	if _, ok := s.(*Int64Array); !ok {
+		t.Errorf("Expected *Int64Array, got %T", s)
+	}
+
+	s = Array(&[]string{})
+	if _, ok := s.(*StringArray); !ok {
+		t.Errorf("Expected *StringArray, got %T", s)
+	}
+
+	for _, tt := range []interface{}{
+		&[]sql.Scanner{},
+		&[][]bool{},
+		&[][]float64{},
+		&[][]int64{},
+		&[][]string{},
+	} {
+		s = Array(tt)
+		if _, ok := s.(GenericArray); !ok {
+			t.Errorf("Expected GenericArray for %T, got %T", tt, s)
+		}
+	}
+}
+
+func TestArrayValuer(t *testing.T) {
+	var v driver.Valuer
+
+	v = Array([]bool{})
+	if _, ok := v.(*BoolArray); !ok {
+		t.Errorf("Expected *BoolArray, got %T", v)
+	}
+
+	v = Array([]float64{})
+	if _, ok := v.(*Float64Array); !ok {
+		t.Errorf("Expected *Float64Array, got %T", v)
+	}
+
+	v = Array([]int64{})
+	if _, ok := v.(*Int64Array); !ok {
+		t.Errorf("Expected *Int64Array, got %T", v)
+	}
+
+	v = Array([]string{})
+	if _, ok := v.(*StringArray); !ok {
+		t.Errorf("Expected *StringArray, got %T", v)
+	}
+
+	for _, tt := range []interface{}{
+		nil,
+		[]driver.Value{},
+		[][]bool{},
+		[][]float64{},
+		[][]int64{},
+		[][]string{},
+	} {
+		v = Array(tt)
+		if _, ok := v.(GenericArray); !ok {
+			t.Errorf("Expected GenericArray for %T, got %T", tt, v)
+		}
+	}
+}
+
 func TestBoolArrayScanUnsupported(t *testing.T) {
 	var arr BoolArray
 	err := arr.Scan(1)

--- a/array_test.go
+++ b/array_test.go
@@ -10,6 +10,80 @@ import (
 	"testing"
 )
 
+func TestParseArray(t *testing.T) {
+	for _, tt := range []struct {
+		input string
+		delim string
+		dims  []int
+		elems [][]byte
+	}{
+		{`{}`, `,`, nil, [][]byte{}},
+		{`{NULL}`, `,`, []int{1}, [][]byte{nil}},
+		{`{a}`, `,`, []int{1}, [][]byte{{'a'}}},
+		{`{a,b}`, `,`, []int{2}, [][]byte{{'a'}, {'b'}}},
+		{`{{a,b}}`, `,`, []int{1, 2}, [][]byte{{'a'}, {'b'}}},
+		{`{{a},{b}}`, `,`, []int{2, 1}, [][]byte{{'a'}, {'b'}}},
+		{`{{{a,b},{c,d},{e,f}}}`, `,`, []int{1, 3, 2}, [][]byte{
+			{'a'}, {'b'}, {'c'}, {'d'}, {'e'}, {'f'},
+		}},
+		{`{""}`, `,`, []int{1}, [][]byte{{}}},
+		{`{","}`, `,`, []int{1}, [][]byte{{','}}},
+		{`{",",","}`, `,`, []int{2}, [][]byte{{','}, {','}}},
+		{`{{",",","}}`, `,`, []int{1, 2}, [][]byte{{','}, {','}}},
+		{`{{","},{","}}`, `,`, []int{2, 1}, [][]byte{{','}, {','}}},
+		{`{{{",",","},{",",","},{",",","}}}`, `,`, []int{1, 3, 2}, [][]byte{
+			{','}, {','}, {','}, {','}, {','}, {','},
+		}},
+		{`{"\"}"}`, `,`, []int{1}, [][]byte{{'"', '}'}}},
+		{`{"\"","\""}`, `,`, []int{2}, [][]byte{{'"'}, {'"'}}},
+		{`{{"\"","\""}}`, `,`, []int{1, 2}, [][]byte{{'"'}, {'"'}}},
+		{`{{"\""},{"\""}}`, `,`, []int{2, 1}, [][]byte{{'"'}, {'"'}}},
+		{`{{{"\"","\""},{"\"","\""},{"\"","\""}}}`, `,`, []int{1, 3, 2}, [][]byte{
+			{'"'}, {'"'}, {'"'}, {'"'}, {'"'}, {'"'},
+		}},
+		{`{axyzb}`, `xyz`, []int{2}, [][]byte{{'a'}, {'b'}}},
+	} {
+		dims, elems, err := parseArray([]byte(tt.input), []byte(tt.delim))
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %q", tt.input, err)
+		}
+		if !reflect.DeepEqual(dims, tt.dims) {
+			t.Errorf("Expected %v dimensions for %q, got %v", tt.dims, tt.input, dims)
+		}
+		if !reflect.DeepEqual(elems, tt.elems) {
+			t.Errorf("Expected %v elements for %q, got %v", tt.elems, tt.input, elems)
+		}
+	}
+}
+
+func TestParseArrayError(t *testing.T) {
+	for _, tt := range []struct {
+		input, err string
+	}{
+		{``, "expected '{' at offset 0"},
+		{`x`, "expected '{' at offset 0"},
+		{`}`, "expected '{' at offset 0"},
+		{`{`, "expected '}' at offset 1"},
+		{`{{}`, "expected '}' at offset 3"},
+		{`{}}`, "unexpected '}' at offset 2"},
+		{`{,}`, "unexpected ',' at offset 1"},
+		{`{,x}`, "unexpected ',' at offset 1"},
+		{`{x,}`, "unexpected '}' at offset 3"},
+		{`{""x}`, "unexpected 'x' at offset 3"},
+		{`{{a},{b,c}}`, "multidimensional arrays must have elements with matching dimensions"},
+	} {
+		_, _, err := parseArray([]byte(tt.input), []byte{','})
+
+		if err == nil {
+			t.Fatalf("Expected error for %q, got none", tt.input)
+		}
+		if !strings.Contains(err.Error(), tt.err) {
+			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
+		}
+	}
+}
+
 func TestBoolArrayValue(t *testing.T) {
 	result, err := BoolArray(nil).Value()
 

--- a/array_test.go
+++ b/array_test.go
@@ -84,6 +84,93 @@ func TestParseArrayError(t *testing.T) {
 	}
 }
 
+func TestBoolArrayScanUnsupported(t *testing.T) {
+	var arr BoolArray
+	err := arr.Scan(1)
+
+	if err == nil {
+		t.Fatal("Expected error when scanning from int")
+	}
+	if !strings.Contains(err.Error(), "int to BoolArray") {
+		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+var BoolArrayStringTests = []struct {
+	str string
+	arr BoolArray
+}{
+	{`{}`, BoolArray{}},
+	{`{t}`, BoolArray{true}},
+	{`{f,t}`, BoolArray{false, true}},
+}
+
+func TestBoolArrayScanBytes(t *testing.T) {
+	for _, tt := range BoolArrayStringTests {
+		bytes := []byte(tt.str)
+		arr := BoolArray{true, true, true}
+		err := arr.Scan(bytes)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", bytes, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
+		}
+	}
+}
+
+func BenchmarkBoolArrayScanBytes(b *testing.B) {
+	var a BoolArray
+	var x interface{} = []byte(`{t,f,t,f,t,f,t,f,t,f}`)
+
+	for i := 0; i < b.N; i++ {
+		a = BoolArray{}
+		a.Scan(x)
+	}
+}
+
+func TestBoolArrayScanString(t *testing.T) {
+	for _, tt := range BoolArrayStringTests {
+		arr := BoolArray{true, true, true}
+		err := arr.Scan(tt.str)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
+		}
+	}
+}
+
+func TestBoolArrayScanError(t *testing.T) {
+	for _, tt := range []struct {
+		input, err string
+	}{
+		{``, "unable to parse array"},
+		{`{`, "unable to parse array"},
+		{`{{t},{f}}`, "cannot convert ARRAY[2][1] to BoolArray"},
+		{`{NULL}`, `parsing array element index 0: invalid boolean ""`},
+		{`{a}`, `parsing array element index 0: invalid boolean "a"`},
+		{`{t,b}`, `parsing array element index 1: invalid boolean "b"`},
+		{`{t,f,cd}`, `parsing array element index 2: invalid boolean "cd"`},
+	} {
+		arr := BoolArray{true, true, true}
+		err := arr.Scan(tt.input)
+
+		if err == nil {
+			t.Fatalf("Expected error for %q, got none", tt.input)
+		}
+		if !strings.Contains(err.Error(), tt.err) {
+			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
+		}
+		if !reflect.DeepEqual(arr, BoolArray{true, true, true}) {
+			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
+		}
+	}
+}
+
 func TestBoolArrayValue(t *testing.T) {
 	result, err := BoolArray(nil).Value()
 
@@ -123,6 +210,90 @@ func BenchmarkBoolArrayValue(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		a.Value()
+	}
+}
+
+func TestByteaArrayScanUnsupported(t *testing.T) {
+	var arr ByteaArray
+	err := arr.Scan(1)
+
+	if err == nil {
+		t.Fatal("Expected error when scanning from int")
+	}
+	if !strings.Contains(err.Error(), "int to ByteaArray") {
+		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+var ByteaArrayStringTests = []struct {
+	str string
+	arr ByteaArray
+}{
+	{`{}`, ByteaArray{}},
+	{`{NULL}`, ByteaArray{nil}},
+	{`{"\\xfeff"}`, ByteaArray{{'\xFE', '\xFF'}}},
+	{`{"\\xdead","\\xbeef"}`, ByteaArray{{'\xDE', '\xAD'}, {'\xBE', '\xEF'}}},
+}
+
+func TestByteaArrayScanBytes(t *testing.T) {
+	for _, tt := range ByteaArrayStringTests {
+		bytes := []byte(tt.str)
+		arr := ByteaArray{{2}, {6}, {0, 0}}
+		err := arr.Scan(bytes)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", bytes, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
+		}
+	}
+}
+
+func BenchmarkByteaArrayScanBytes(b *testing.B) {
+	var a ByteaArray
+	var x interface{} = []byte(`{"\\xfe","\\xff","\\xdead","\\xbeef","\\xfe","\\xff","\\xdead","\\xbeef","\\xfe","\\xff"}`)
+
+	for i := 0; i < b.N; i++ {
+		a = ByteaArray{}
+		a.Scan(x)
+	}
+}
+
+func TestByteaArrayScanString(t *testing.T) {
+	for _, tt := range ByteaArrayStringTests {
+		arr := ByteaArray{{2}, {6}, {0, 0}}
+		err := arr.Scan(tt.str)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
+		}
+	}
+}
+
+func TestByteaArrayScanError(t *testing.T) {
+	for _, tt := range []struct {
+		input, err string
+	}{
+		{``, "unable to parse array"},
+		{`{`, "unable to parse array"},
+		{`{{"\\xfeff"},{"\\xbeef"}}`, "cannot convert ARRAY[2][1] to ByteaArray"},
+	} {
+		arr := ByteaArray{{2}, {6}, {0, 0}}
+		err := arr.Scan(tt.input)
+
+		if err == nil {
+			t.Fatalf("Expected error for %q, got none", tt.input)
+		}
+		if !strings.Contains(err.Error(), tt.err) {
+			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
+		}
+		if !reflect.DeepEqual(arr, ByteaArray{{2}, {6}, {0, 0}}) {
+			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
+		}
 	}
 }
 
@@ -171,6 +342,94 @@ func BenchmarkByteaArrayValue(b *testing.B) {
 	}
 }
 
+func TestFloat64ArrayScanUnsupported(t *testing.T) {
+	var arr Float64Array
+	err := arr.Scan(true)
+
+	if err == nil {
+		t.Fatal("Expected error when scanning from bool")
+	}
+	if !strings.Contains(err.Error(), "bool to Float64Array") {
+		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+var Float64ArrayStringTests = []struct {
+	str string
+	arr Float64Array
+}{
+	{`{}`, Float64Array{}},
+	{`{1.2}`, Float64Array{1.2}},
+	{`{3.456,7.89}`, Float64Array{3.456, 7.89}},
+	{`{3,1,2}`, Float64Array{3, 1, 2}},
+}
+
+func TestFloat64ArrayScanBytes(t *testing.T) {
+	for _, tt := range Float64ArrayStringTests {
+		bytes := []byte(tt.str)
+		arr := Float64Array{5, 5, 5}
+		err := arr.Scan(bytes)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", bytes, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
+		}
+	}
+}
+
+func BenchmarkFloat64ArrayScanBytes(b *testing.B) {
+	var a Float64Array
+	var x interface{} = []byte(`{1.2,3.4,5.6,7.8,9.01,2.34,5.67,8.90,1.234,5.678}`)
+
+	for i := 0; i < b.N; i++ {
+		a = Float64Array{}
+		a.Scan(x)
+	}
+}
+
+func TestFloat64ArrayScanString(t *testing.T) {
+	for _, tt := range Float64ArrayStringTests {
+		arr := Float64Array{5, 5, 5}
+		err := arr.Scan(tt.str)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
+		}
+	}
+}
+
+func TestFloat64ArrayScanError(t *testing.T) {
+	for _, tt := range []struct {
+		input, err string
+	}{
+		{``, "unable to parse array"},
+		{`{`, "unable to parse array"},
+		{`{{5.6},{7.8}}`, "cannot convert ARRAY[2][1] to Float64Array"},
+		{`{NULL}`, "parsing array element index 0:"},
+		{`{a}`, "parsing array element index 0:"},
+		{`{5.6,a}`, "parsing array element index 1:"},
+		{`{5.6,7.8,a}`, "parsing array element index 2:"},
+	} {
+		arr := Float64Array{5, 5, 5}
+		err := arr.Scan(tt.input)
+
+		if err == nil {
+			t.Fatalf("Expected error for %q, got none", tt.input)
+		}
+		if !strings.Contains(err.Error(), tt.err) {
+			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
+		}
+		if !reflect.DeepEqual(arr, Float64Array{5, 5, 5}) {
+			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
+		}
+	}
+}
+
 func TestFloat64ArrayValue(t *testing.T) {
 	result, err := Float64Array(nil).Value()
 
@@ -213,6 +472,93 @@ func BenchmarkFloat64ArrayValue(b *testing.B) {
 	}
 }
 
+func TestInt64ArrayScanUnsupported(t *testing.T) {
+	var arr Int64Array
+	err := arr.Scan(true)
+
+	if err == nil {
+		t.Fatal("Expected error when scanning from bool")
+	}
+	if !strings.Contains(err.Error(), "bool to Int64Array") {
+		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+var Int64ArrayStringTests = []struct {
+	str string
+	arr Int64Array
+}{
+	{`{}`, Int64Array{}},
+	{`{12}`, Int64Array{12}},
+	{`{345,678}`, Int64Array{345, 678}},
+}
+
+func TestInt64ArrayScanBytes(t *testing.T) {
+	for _, tt := range Int64ArrayStringTests {
+		bytes := []byte(tt.str)
+		arr := Int64Array{5, 5, 5}
+		err := arr.Scan(bytes)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", bytes, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
+		}
+	}
+}
+
+func BenchmarkInt64ArrayScanBytes(b *testing.B) {
+	var a Int64Array
+	var x interface{} = []byte(`{1,2,3,4,5,6,7,8,9,0}`)
+
+	for i := 0; i < b.N; i++ {
+		a = Int64Array{}
+		a.Scan(x)
+	}
+}
+
+func TestInt64ArrayScanString(t *testing.T) {
+	for _, tt := range Int64ArrayStringTests {
+		arr := Int64Array{5, 5, 5}
+		err := arr.Scan(tt.str)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
+		}
+	}
+}
+
+func TestInt64ArrayScanError(t *testing.T) {
+	for _, tt := range []struct {
+		input, err string
+	}{
+		{``, "unable to parse array"},
+		{`{`, "unable to parse array"},
+		{`{{5},{6}}`, "cannot convert ARRAY[2][1] to Int64Array"},
+		{`{NULL}`, "parsing array element index 0:"},
+		{`{a}`, "parsing array element index 0:"},
+		{`{5,a}`, "parsing array element index 1:"},
+		{`{5,6,a}`, "parsing array element index 2:"},
+	} {
+		arr := Int64Array{5, 5, 5}
+		err := arr.Scan(tt.input)
+
+		if err == nil {
+			t.Fatalf("Expected error for %q, got none", tt.input)
+		}
+		if !strings.Contains(err.Error(), tt.err) {
+			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
+		}
+		if !reflect.DeepEqual(arr, Int64Array{5, 5, 5}) {
+			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
+		}
+	}
+}
+
 func TestInt64ArrayValue(t *testing.T) {
 	result, err := Int64Array(nil).Value()
 
@@ -252,6 +598,96 @@ func BenchmarkInt64ArrayValue(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		a.Value()
+	}
+}
+
+func TestStringArrayScanUnsupported(t *testing.T) {
+	var arr StringArray
+	err := arr.Scan(true)
+
+	if err == nil {
+		t.Fatal("Expected error when scanning from bool")
+	}
+	if !strings.Contains(err.Error(), "bool to StringArray") {
+		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+var StringArrayStringTests = []struct {
+	str string
+	arr StringArray
+}{
+	{`{}`, StringArray{}},
+	{`{t}`, StringArray{"t"}},
+	{`{f,1}`, StringArray{"f", "1"}},
+	{`{"a\\b","c d",","}`, StringArray{"a\\b", "c d", ","}},
+}
+
+func TestStringArrayScanBytes(t *testing.T) {
+	for _, tt := range StringArrayStringTests {
+		bytes := []byte(tt.str)
+		arr := StringArray{"x", "x", "x"}
+		err := arr.Scan(bytes)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", bytes, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
+		}
+	}
+}
+
+func BenchmarkStringArrayScanBytes(b *testing.B) {
+	var a StringArray
+	var x interface{} = []byte(`{a,b,c,d,e,f,g,h,i,j}`)
+	var y interface{} = []byte(`{"\a","\b","\c","\d","\e","\f","\g","\h","\i","\j"}`)
+
+	for i := 0; i < b.N; i++ {
+		a = StringArray{}
+		a.Scan(x)
+		a = StringArray{}
+		a.Scan(y)
+	}
+}
+
+func TestStringArrayScanString(t *testing.T) {
+	for _, tt := range StringArrayStringTests {
+		arr := StringArray{"x", "x", "x"}
+		err := arr.Scan(tt.str)
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
+		}
+		if !reflect.DeepEqual(arr, tt.arr) {
+			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
+		}
+	}
+}
+
+func TestStringArrayScanError(t *testing.T) {
+	for _, tt := range []struct {
+		input, err string
+	}{
+		{``, "unable to parse array"},
+		{`{`, "unable to parse array"},
+		{`{{a},{b}}`, "cannot convert ARRAY[2][1] to StringArray"},
+		{`{NULL}`, "parsing array element index 0: cannot convert nil to string"},
+		{`{a,NULL}`, "parsing array element index 1: cannot convert nil to string"},
+		{`{a,b,NULL}`, "parsing array element index 2: cannot convert nil to string"},
+	} {
+		arr := StringArray{"x", "x", "x"}
+		err := arr.Scan(tt.input)
+
+		if err == nil {
+			t.Fatalf("Expected error for %q, got none", tt.input)
+		}
+		if !strings.Contains(err.Error(), tt.err) {
+			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
+		}
+		if !reflect.DeepEqual(arr, StringArray{"x", "x", "x"}) {
+			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
+		}
 	}
 }
 

--- a/array_test.go
+++ b/array_test.go
@@ -1,0 +1,144 @@
+package pq
+
+import (
+	"bytes"
+	"database/sql"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGenericArrayValueUnsupported(t *testing.T) {
+	_, err := GenericArray{true}.Value()
+
+	if err == nil {
+		t.Fatal("Expected error for bool")
+	}
+	if !strings.Contains(err.Error(), "bool to array") {
+		t.Errorf("Expected type to be mentioned, got %q", err)
+	}
+}
+
+func TestGenericArrayValue(t *testing.T) {
+	result, err := GenericArray{nil}.Value()
+
+	if err != nil {
+		t.Fatalf("Expected no error for nil, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil, got %q", result)
+	}
+
+	for _, tt := range []struct {
+		result string
+		input  interface{}
+	}{
+		{`{}`, []bool{}},
+		{`{true}`, []bool{true}},
+		{`{true,false}`, []bool{true, false}},
+		{`{true,false}`, [2]bool{true, false}},
+
+		{`{}`, [][]int{{}}},
+		{`{}`, [][]int{{}, {}}},
+		{`{{1}}`, [][]int{{1}}},
+		{`{{1},{2}}`, [][]int{{1}, {2}}},
+		{`{{1,2},{3,4}}`, [][]int{{1, 2}, {3, 4}}},
+		{`{{1,2},{3,4}}`, [2][2]int{{1, 2}, {3, 4}}},
+
+		{`{"a","\\b","c\"","d,e"}`, []string{`a`, `\b`, `c"`, `d,e`}},
+		{`{"a","\\b","c\"","d,e"}`, [][]byte{{'a'}, {'\\', 'b'}, {'c', '"'}, {'d', ',', 'e'}}},
+
+		{`{NULL}`, []*int{nil}},
+		{`{0,NULL}`, []*int{new(int), nil}},
+
+		{`{NULL}`, []sql.NullString{{}}},
+		{`{"\"",NULL}`, []sql.NullString{{String: `"`, Valid: true}, {}}},
+	} {
+		result, err := GenericArray{tt.input}.Value()
+
+		if err != nil {
+			t.Fatalf("Expected no error for %q, got %v", tt.input, err)
+		}
+		if !reflect.DeepEqual(result, tt.result) {
+			t.Errorf("Expected %q for %q, got %q", tt.result, tt.input, result)
+		}
+	}
+}
+
+func TestGenericArrayValueErrors(t *testing.T) {
+	var v []interface{}
+
+	v = []interface{}{func() {}}
+	if _, err := (GenericArray{v}).Value(); err == nil {
+		t.Errorf("Expected error for %q, got nil", v)
+	}
+
+	v = []interface{}{nil, func() {}}
+	if _, err := (GenericArray{v}).Value(); err == nil {
+		t.Errorf("Expected error for %q, got nil", v)
+	}
+}
+
+func BenchmarkGenericArrayValueBools(b *testing.B) {
+	rand.Seed(1)
+	x := make([]bool, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = rand.Intn(2) == 0
+	}
+	a := GenericArray{x}
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
+func BenchmarkGenericArrayValueFloat64s(b *testing.B) {
+	rand.Seed(1)
+	x := make([]float64, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = rand.NormFloat64()
+	}
+	a := GenericArray{x}
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
+func BenchmarkGenericArrayValueInt64s(b *testing.B) {
+	rand.Seed(1)
+	x := make([]int64, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = rand.Int63()
+	}
+	a := GenericArray{x}
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
+func BenchmarkGenericArrayValueByteSlices(b *testing.B) {
+	x := make([][]byte, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = bytes.Repeat([]byte(`abc"def\ghi`), 5)
+	}
+	a := GenericArray{x}
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}
+
+func BenchmarkGenericArrayValueStrings(b *testing.B) {
+	x := make([]string, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = strings.Repeat(`abc"def\ghi`, 5)
+	}
+	a := GenericArray{x}
+
+	for i := 0; i < b.N; i++ {
+		a.Value()
+	}
+}

--- a/array_test.go
+++ b/array_test.go
@@ -233,11 +233,15 @@ func TestGenericArrayValueUnsupported(t *testing.T) {
 	}
 }
 
+type ByteArrayValuer [1]byte
+type ByteSliceValuer []byte
 type FuncArrayValuer struct {
 	delimiter func() string
 	value     func() (driver.Value, error)
 }
 
+func (a ByteArrayValuer) Value() (driver.Value, error) { return a[:], nil }
+func (b ByteSliceValuer) Value() (driver.Value, error) { return []byte(b), nil }
 func (f FuncArrayValuer) ArrayDelimiter() string       { return f.delimiter() }
 func (f FuncArrayValuer) Value() (driver.Value, error) { return f.value() }
 
@@ -281,6 +285,12 @@ func TestGenericArrayValue(t *testing.T) {
 
 		{`{NULL}`, []sql.NullString{{}}},
 		{`{"\"",NULL}`, []sql.NullString{{String: `"`, Valid: true}, {}}},
+
+		{`{"a","b"}`, []ByteArrayValuer{{'a'}, {'b'}}},
+		{`{{"a","b"},{"c","d"}}`, [][]ByteArrayValuer{{{'a'}, {'b'}}, {{'c'}, {'d'}}}},
+
+		{`{"e","f"}`, []ByteSliceValuer{{'e'}, {'f'}}},
+		{`{{"e","f"},{"g","h"}}`, [][]ByteSliceValuer{{{'e'}, {'f'}}, {{'g'}, {'h'}}}},
 
 		{`{1~2}`, []FuncArrayValuer{Tilde(int64(1)), Tilde(int64(2))}},
 		{`{{1~2}~{3~4}}`, [][]FuncArrayValuer{{Tilde(int64(1)), Tilde(int64(2))}, {Tilde(int64(3)), Tilde(int64(4))}}},


### PR DESCRIPTION
This adds types that implement `driver.Valuer` and `sql.Scanner` for arrays and slices.

There are a handful of "native" types that efficiently handle one-dimensional slices (e.g. `StringArray` for `[]string`) and a "generic" type that uses reflection to traverse multi-dimensional arrays/slices.

The `ArrayDelimiter` interface can be implemented by a type that does not use comma as [its delimiter](https://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO). For example,

```go
type Box struct { ... }
func (b Box) Value() (driver.Value, error) { ... }
func (b Box) ArrayDelimiter() string { return ";" }
```

The most convenient way to use these types is probably the `Array` function. It provides a consistent way to send and receive arrays and slices of various types. For example,

```go
db.Query(..., pq.Array([]string{ ... }))
db.Query(..., pq.Array([][]int{ ... }))

var x []sql.NullInt64
var y []string
db.QueryRow(...).Scan(pq.Array(&x))
db.QueryRow(...).Scan(pq.Array(&y))
```

See also #49, #130, #327, #353, #364, #464.