### PR TITLE
Clean up .travis.yml and reduce build time

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -eu
+
+client_configure() {
+	sudo chmod 600 $PQSSLCERTTEST_PATH/postgresql.key
+}
+
+pgdg_repository() {
+	local sourcelist='sources.list.d/postgresql.list'
+
+	curl -sS 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | sudo apt-key add -
+	echo deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main $PGVERSION | sudo tee "/etc/apt/$sourcelist"
+	sudo apt-get -o Dir::Etc::sourcelist="$sourcelist" -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0' update
+}
+
+postgresql_configure() {
+	sudo tee /etc/postgresql/$PGVERSION/main/pg_hba.conf > /dev/null <<-config
+		local     all         all                               trust
+		hostnossl all         pqgossltest 127.0.0.1/32          reject
+		hostnossl all         pqgosslcert 127.0.0.1/32          reject
+		hostssl   all         pqgossltest 127.0.0.1/32          trust
+		hostssl   all         pqgosslcert 127.0.0.1/32          cert
+		host      all         all         127.0.0.1/32          trust
+		hostnossl all         pqgossltest ::1/128               reject
+		hostnossl all         pqgosslcert ::1/128               reject
+		hostssl   all         pqgossltest ::1/128               trust
+		hostssl   all         pqgosslcert ::1/128               cert
+		host      all         all         ::1/128               trust
+	config
+
+	xargs sudo install -o postgres -g postgres -m 600 -t /var/lib/postgresql/$PGVERSION/main/ <<-certificates
+		certs/root.crt
+		certs/server.crt
+		certs/server.key
+	certificates
+
+	sort -VCu <<-versions ||
+		$PGVERSION
+		9.2
+	versions
+	sudo tee -a /etc/postgresql/$PGVERSION/main/postgresql.conf > /dev/null <<-config
+		ssl_ca_file   = 'root.crt'
+		ssl_cert_file = 'server.crt'
+		ssl_key_file  = 'server.key'
+	config
+
+	echo 127.0.0.1 postgres | sudo tee -a /etc/hosts > /dev/null
+
+	sudo service postgresql restart
+}
+
+postgresql_install() {
+	xargs sudo apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confnew' install <<-packages
+		postgresql-$PGVERSION
+		postgresql-server-dev-$PGVERSION
+		postgresql-contrib-$PGVERSION
+	packages
+}
+
+postgresql_uninstall() {
+	sudo service postgresql stop
+	xargs sudo apt-get -y --purge remove <<-packages
+		libpq-dev
+		libpq5
+		postgresql
+		postgresql-client-common
+		postgresql-common
+	packages
+	sudo rm -rf /var/lib/postgresql
+}
+
+$1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,12 @@ env:
     - PQSSLCERTTEST_PATH=$PWD/certs
     - PGHOST=127.0.0.1
   matrix:
-    - PGVERSION=9.5 PQTEST_BINARY_PARAMETERS=yes
-    - PGVERSION=9.4 PQTEST_BINARY_PARAMETERS=yes
-    - PGVERSION=9.3 PQTEST_BINARY_PARAMETERS=yes
-    - PGVERSION=9.2 PQTEST_BINARY_PARAMETERS=yes
-    - PGVERSION=9.1 PQTEST_BINARY_PARAMETERS=yes
-    - PGVERSION=9.0 PQTEST_BINARY_PARAMETERS=yes
-    - PGVERSION=9.5 PQTEST_BINARY_PARAMETERS=no
-    - PGVERSION=9.4 PQTEST_BINARY_PARAMETERS=no
-    - PGVERSION=9.3 PQTEST_BINARY_PARAMETERS=no
-    - PGVERSION=9.2 PQTEST_BINARY_PARAMETERS=no
-    - PGVERSION=9.1 PQTEST_BINARY_PARAMETERS=no
-    - PGVERSION=9.0 PQTEST_BINARY_PARAMETERS=no
+    - PGVERSION=9.5
+    - PGVERSION=9.4
+    - PGVERSION=9.3
+    - PGVERSION=9.2
+    - PGVERSION=9.1
+    - PGVERSION=9.0
 
 before_install:
   - .travis.sh postgresql_uninstall
@@ -43,4 +37,5 @@ script:
   - >
     goimports -d -e $(find -name '*.go') | awk '{ print } END { exit NR == 0 ? 0 : 1 }'
   - go vet ./...
-  - go test -v ./...
+  - PQTEST_BINARY_PARAMETERS=no  go test -v ./...
+  - PQTEST_BINARY_PARAMETERS=yes go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,39 +6,6 @@ go:
   - 1.6
   - tip
 
-before_install:
-  - psql --version
-  - sudo /etc/init.d/postgresql stop
-  - sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
-  - sudo rm -rf /var/lib/postgresql
-  - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo sh -c "echo deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main $PGVERSION >> /etc/apt/sources.list.d/postgresql.list"
-  - sudo apt-get update -qq
-  - sudo apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::="--force-confnew" install postgresql-$PGVERSION postgresql-server-dev-$PGVERSION postgresql-contrib-$PGVERSION
-  - sudo chmod 777 /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "local     all         postgres                          trust" > /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "local     all         all                               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "hostnossl all         pqgossltest 127.0.0.1/32          reject" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "hostnossl all         pqgosslcert 127.0.0.1/32          reject" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "hostssl   all         pqgossltest 127.0.0.1/32          trust"  >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "hostssl   all         pqgosslcert 127.0.0.1/32          cert"  >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "host      all         all         127.0.0.1/32          trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "hostnossl all         pqgossltest ::1/128               reject" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "hostnossl all         pqgosslcert ::1/128               reject" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "hostssl   all         pqgossltest ::1/128               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "hostssl   all         pqgosslcert ::1/128               cert" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - echo "host      all         all         ::1/128               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
-  - sudo install -o postgres -g postgres -m 600 -t /var/lib/postgresql/$PGVERSION/main/ certs/server.key certs/server.crt certs/root.crt
-  - sudo bash -c "[[ '${PGVERSION}' < '9.2' ]] || (echo \"ssl_cert_file = 'server.crt'\" >> /etc/postgresql/$PGVERSION/main/postgresql.conf)"
-  - sudo bash -c "[[ '${PGVERSION}' < '9.2' ]] || (echo \"ssl_key_file = 'server.key'\" >> /etc/postgresql/$PGVERSION/main/postgresql.conf)"
-  - sudo bash -c "[[ '${PGVERSION}' < '9.2' ]] || (echo \"ssl_ca_file = 'root.crt'\" >> /etc/postgresql/$PGVERSION/main/postgresql.conf)"
-  - sudo sh -c "echo 127.0.0.1 postgres >> /etc/hosts"
-  - sudo ls -l /var/lib/postgresql/$PGVERSION/main/
-  - sudo cat /etc/postgresql/$PGVERSION/main/postgresql.conf
-  - sudo chmod 600 $PQSSLCERTTEST_PATH/postgresql.key
-  - sudo /etc/init.d/postgresql restart
-  - go get golang.org/x/tools/cmd/goimports
-
 env:
   global:
     - PGUSER=postgres
@@ -59,10 +26,21 @@ env:
     - PGVERSION=9.1 PQTEST_BINARY_PARAMETERS=no
     - PGVERSION=9.0 PQTEST_BINARY_PARAMETERS=no
 
-script:
- - result=$(goimports -d -e $(find -name \*.go)); test -z "$result" || (echo "$result" && false) && go vet ./... && go test -v ./...
+before_install:
+  - .travis.sh postgresql_uninstall
+  - .travis.sh pgdg_repository
+  - .travis.sh postgresql_install
+  - .travis.sh postgresql_configure
+  - .travis.sh client_configure
+  - go get golang.org/x/tools/cmd/goimports
 
 before_script:
- - psql -c 'create database pqgotest' -U postgres
- - psql -c 'create user pqgossltest' -U postgres
- - psql -c 'create user pqgosslcert' -U postgres
+  - createdb pqgotest
+  - createuser -DRS pqgossltest
+  - createuser -DRS pqgosslcert
+
+script:
+  - >
+    goimports -d -e $(find -name '*.go') | awk '{ print } END { exit NR == 0 ? 0 : 1 }'
+  - go vet ./...
+  - go test -v ./...


### PR DESCRIPTION
With four Go versions, six PostgreSQL versions, and one connection parameter, we are generating *48* jobs during every build in Travis. While each job takes only a minute or two, the vast majority of time is spent doing the setup. (`goimports`, `go vet`, and `go test` take only 3 to 4 seconds combined.)

Moving `PQTEST_BINARY_PARAMETERS` to the `script` step reduces the number of jobs to 24 and nearly halves the CPU time, from [72 minutes](https://travis-ci.org/lib/pq/builds/129461243) to [38 minutes](https://travis-ci.org/lib/pq/builds/136559221). 💡

This changes how the build behaves during a failure. Without this PR, `go test` only runs when both `goimports` and `go vet` succeed. Now, `goimports`, `go vet`, and `go test` run sequentially regardless of each other's result. [The build fails when any of them fail.](https://docs.travis-ci.com/user/customizing-the-build#Customizing-the-Build-Step)