### PR TITLE
Run goimports only when installed

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -6,6 +6,17 @@ client_configure() {
 	sudo chmod 600 $PQSSLCERTTEST_PATH/postgresql.key
 }
 
+golang_formatting() {
+	if command -v goimports > /dev/null ; then
+		echo "Checking formatting..."
+		goimports -d -e $(find -name '*.go') | awk '{ print } END { exit NR == 0 ? 0 : 1 }'
+	fi
+}
+
+golang_tools() {
+	go get golang.org/x/tools/cmd/goimports || true
+}
+
 pgdg_repository() {
 	local sourcelist='sources.list.d/postgresql.list'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ env:
     - PGVERSION=9.0
 
 before_install:
+  - ./.travis.sh golang_tools
   - ./.travis.sh postgresql_uninstall
   - ./.travis.sh pgdg_repository
   - ./.travis.sh postgresql_install
   - ./.travis.sh postgresql_configure
   - ./.travis.sh client_configure
-  - go get golang.org/x/tools/cmd/goimports
 
 before_script:
   - createdb pqgotest
@@ -34,8 +34,7 @@ before_script:
   - createuser -DRS pqgosslcert
 
 script:
-  - >
-    goimports -d -e $(find -name '*.go') | awk '{ print } END { exit NR == 0 ? 0 : 1 }'
+  - ./.travis.sh golang_formatting
   - go vet ./...
   - PQTEST_BINARY_PARAMETERS=no  go test -v ./...
   - PQTEST_BINARY_PARAMETERS=yes go test -v ./...


### PR DESCRIPTION
As expected upstream in golang/go \#16434, `goimports` is incompatible with Go 1.4.

This [Travis build](https://travis-ci.org/cbandy/go-pq/builds/150367748) shows what happens with incorrectly formatted code.