### PR TITLE
Fix panic when parsing malformed array input

### DIFF
--- a/array.go
+++ b/array.go
@@ -639,6 +639,9 @@ Element:
 	for i < len(src) {
 		switch src[i] {
 		case '{':
+			if depth == len(dims) {
+				break Element
+			}
 			depth++
 			dims[depth-1] = 0
 			i++
@@ -680,11 +683,11 @@ Element:
 	}
 
 	for i < len(src) {
-		if bytes.HasPrefix(src[i:], del) {
+		if bytes.HasPrefix(src[i:], del) && depth > 0 {
 			dims[depth-1]++
 			i += len(del)
 			goto Element
-		} else if src[i] == '}' {
+		} else if src[i] == '}' && depth > 0 {
 			dims[depth-1]++
 			depth--
 			i++

--- a/array_test.go
+++ b/array_test.go
@@ -70,6 +70,10 @@ func TestParseArrayError(t *testing.T) {
 		{`{,}`, "unexpected ',' at offset 1"},
 		{`{,x}`, "unexpected ',' at offset 1"},
 		{`{x,}`, "unexpected '}' at offset 3"},
+		{`{x,{`, "unexpected '{' at offset 3"},
+		{`{x},`, "unexpected ',' at offset 3"},
+		{`{x}}`, "unexpected '}' at offset 3"},
+		{`{{x}`, "expected '}' at offset 4"},
 		{`{""x}`, "unexpected 'x' at offset 3"},
 		{`{{a},{b,c}}`, "multidimensional arrays must have elements with matching dimensions"},
 	} {


### PR DESCRIPTION
Noticed one possible out-of-bounds when reviewing 80f8150043c80fb52dee6bc863a709cdac7ec8f8. Found and verified the others with go-fuzz.
