### PR TITLE
Use space to separate date and time portions of Time literals

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -477,7 +477,7 @@ func FormatTimestamp(t time.Time) []byte {
 		t = t.AddDate((-t.Year())*2+1, 0, 0)
 		bc = true
 	}
-	b := []byte(t.Format(time.RFC3339Nano))
+	b := []byte(t.Format("2006-01-02 15:04:05.999999999Z07:00"))
 
 	_, offset := t.Zone()
 	offset = offset % 60


### PR DESCRIPTION
Fixes the error in (and motivation for) #391:

> pq: invalid input syntax for type time: "0001-01-01T17:00:00Z BC"

I couldn't find a spec that called for space rather than `T`, but every version of Postgres I tested behaves this way.

I've included a test for the negative case in case Postgres changes and we want to revert this.
