### PR TITLE
require sudo in travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ go:
   - 1.7
   - tip
 
+sudo: true
+
 env:
   global:
     - PGUSER=postgres


### PR DESCRIPTION
This is the first step towards fixing the Travis CI build. There are commands in .travis.sh that use sudo and so forth.