### PR TITLE
Add read_timeout and write_timeout

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -115,6 +115,11 @@ type conn struct {
 	// Whether to always send []byte parameters over as binary.  Enables single
 	// round-trip mode for non-prepared Query calls.
 	binaryParameters bool
+
+	// Timeouts for read and write operations against the database server.
+	// A duration of 0 indicates no timeout.
+	readTimeout  time.Duration
+	writeTimeout time.Duration
 }
 
 // Handle driver-side settings in parsed connection string.
@@ -132,6 +137,13 @@ func (c *conn) handleDriverSettings(o values) (err error) {
 		return nil
 	}
 
+	intSetting := func(key string) (int, error) {
+		if value := o.Get(key); value != "" {
+			return strconv.Atoi(value)
+		}
+		return 0, nil
+	}
+
 	err = boolSetting("disable_prepared_binary_result", &c.disablePreparedBinaryResult)
 	if err != nil {
 		return err
@@ -140,6 +152,21 @@ func (c *conn) handleDriverSettings(o values) (err error) {
 	if err != nil {
 		return err
 	}
+
+	rt, err := intSetting("read_timeout")
+	if err != nil {
+		return err
+	}
+	// read_timeout is specified in milliseconds.
+	c.readTimeout = time.Duration(rt) * time.Millisecond
+
+	wt, err := intSetting("write_timeout")
+	if err != nil {
+		return err
+	}
+	// write_timeout is specified in milliseconds.
+	c.writeTimeout = time.Duration(wt) * time.Millisecond
+
 	return nil
 }
 
@@ -750,7 +777,7 @@ func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
 
 func (cn *conn) Close() (err error) {
 	if cn.bad {
-		return driver.ErrBadConn
+		return cn.c.Close()
 	}
 	defer cn.errRecover(&err)
 
@@ -836,6 +863,18 @@ func (cn *conn) Exec(query string, args []driver.Value) (res driver.Result, err 
 }
 
 func (cn *conn) send(m *writeBuf) {
+	defer func() {
+		if cn.writeTimeout != 0 {
+			// Clear the write deadline if we set one.
+			cn.c.SetWriteDeadline(time.Time{})
+		}
+	}()
+
+	// Set the write deadline if we have a write timeout set.
+	if cn.writeTimeout != 0 {
+		cn.c.SetWriteDeadline(time.Now().Add(cn.writeTimeout))
+	}
+
 	_, err := cn.c.Write(m.wrap())
 	if err != nil {
 		panic(err)
@@ -843,6 +882,18 @@ func (cn *conn) send(m *writeBuf) {
 }
 
 func (cn *conn) sendStartupPacket(m *writeBuf) {
+	defer func() {
+		if cn.writeTimeout != 0 {
+			// Clear the write deadline if we set one.
+			cn.c.SetWriteDeadline(time.Time{})
+		}
+	}()
+
+	// Set the write deadline if we have a write timeout set.
+	if cn.writeTimeout != 0 {
+		cn.c.SetWriteDeadline(time.Now().Add(cn.writeTimeout))
+	}
+
 	// sanity check
 	if m.buf[0] != 0 {
 		panic("oops")
@@ -858,6 +909,18 @@ func (cn *conn) sendStartupPacket(m *writeBuf) {
 // message should have no payload.  This method does not use the scratch
 // buffer.
 func (cn *conn) sendSimpleMessage(typ byte) (err error) {
+	defer func() {
+		if cn.writeTimeout != 0 {
+			// Clear the write deadline if we set one.
+			cn.c.SetWriteDeadline(time.Time{})
+		}
+	}()
+
+	// Set the write deadline if we have a write timeout set.
+	if cn.writeTimeout != 0 {
+		cn.c.SetWriteDeadline(time.Now().Add(cn.writeTimeout))
+	}
+
 	_, err = cn.c.Write([]byte{typ, '\x00', '\x00', '\x00', '\x04'})
 	return err
 }
@@ -879,6 +942,18 @@ func (cn *conn) saveMessage(typ byte, buf *readBuf) {
 // recvMessage receives any message from the backend, or returns an error if
 // a problem occurred while reading the message.
 func (cn *conn) recvMessage(r *readBuf) (byte, error) {
+	defer func() {
+		if cn.readTimeout != 0 {
+			// Clear the read deadline if we set one.
+			cn.c.SetReadDeadline(time.Time{})
+		}
+	}()
+
+	// Set the read deadline if we have a read timeout set.
+	if cn.readTimeout != 0 {
+		cn.c.SetReadDeadline(time.Now().Add(cn.readTimeout))
+	}
+
 	// workaround for a QueryRow bug, see exec
 	if cn.saveMessageType != 0 {
 		t := cn.saveMessageType
@@ -1143,6 +1218,10 @@ func isDriverSetting(key string) bool {
 	case "disable_prepared_binary_result":
 		return true
 	case "binary_parameters":
+		return true
+	case "read_timeout":
+		return true
+	case "write_timeout":
 		return true
 
 	default:


### PR DESCRIPTION
I believe this addresses issue #450.

While doing some failure testing connected to an AWS HA RDS cluster, we noticed that our connections would hang on a net.(*conn).Read forever. The Postgres server was no longer responding so, statement_timeout had no effect. The stack trace for the affected goroutines looked like this:
```
#    0x43d4e8    net.runtime_pollWait+0x58                                    /usr/local/go/src/runtime/netpoll.go:160
#    0x5654f7    net.(*pollDesc).wait+0x37                                    /usr/local/go/src/net/fd_poll_runtime.go:73
#    0x565563    net.(*pollDesc).waitRead+0x33                                    /usr/local/go/src/net/fd_poll_runtime.go:78
#    0x566c00    net.(*netFD).Read+0x1a0                                        /usr/local/go/src/net/fd_unix.go:243
#    0x571d8f    net.(*conn).Read+0x6f                                        /usr/local/go/src/net/net.go:173
#    0x608490    crypto/tls.(*block).readFromUntil+0x90                                /usr/local/go/src/crypto/tls/conn.go:472
#    0x6089d3    crypto/tls.(*Conn).readRecord+0xc3                                /usr/local/go/src/crypto/tls/conn.go:574
#    0x60c805    crypto/tls.(*Conn).Read+0x115                                    /usr/local/go/src/crypto/tls/conn.go:1109
#    0x637b2b    bufio.(*Reader).fill+0x10b                                    /usr/local/go/src/bufio/bufio.go:97
#    0x63818b    bufio.(*Reader).Read+0x1bb                                    /usr/local/go/src/bufio/bufio.go:209
#    0x5e5393    io.ReadAtLeast+0xa3                                        /usr/local/go/src/io/io.go:307
#    0x5e54f7    io.ReadFull+0x57                                        /usr/local/go/src/io/io.go:325
#    0x591b06    myproject/vendor/github.com/lib/pq.(*conn).recvMessage+0x116    /home/pneisen/myproject/vendor/github.com/lib/pq/conn.go:892
#    0x591e28    myproject/vendor/github.com/lib/pq.(*conn).recv1Buf+0x38        /home/pneisen/myproject/vendor/github.com/lib/pq/conn.go:942
#    0x591f36    myproject/vendor/github.com/lib/pq.(*conn).recv1+0x86        /home/pneisen/myproject/vendor/github.com/lib/pq/conn.go:963
#    0x59981e    myproject/vendor/github.com/lib/pq.(*conn).readParseResponse+0x2e    /home/pneisen/myproject/vendor/github.com/lib/pq/conn.go:1594
#    0x59056b    myproject/vendor/github.com/lib/pq.(*conn).prepareTo+0x63b        /home/pneisen/myproject/vendor/github.com/lib/pq/conn.go:732
#    0x5912b5    myproject/vendor/github.com/lib/pq.(*conn).Query+0x3d5        /home/pneisen/myproject/vendor/github.com/lib/pq/conn.go:790
#    0x5406e6    database/sql.(*DB).queryConn+0x5d6                                /usr/local/go/src/database/sql/sql.go:1092
#    0x54007f    database/sql.(*DB).query+0xef                                    /usr/local/go/src/database/sql/sql.go:1079
#    0x53fdcf    database/sql.(*DB).Query+0x8f                                    /usr/local/go/src/database/sql/sql.go:1062
#    0x5409bf    database/sql.(*DB).QueryRow+0x6f                                /usr/local/go/src/database/sql/sql.go:1143
```

Since the connect_timeout only applies to the initial connection before it is placed in the pool, and statement_timeout is a Postgres thing that doesn't apply when Postgres is down, we decided we wanted more timeout options. So, I added read_timeout and write_timeout (in milliseconds) to the connection string parameters and use them to set deadlines on reads and writes to the database connection. If a read or write returns before the deadline, then the deadline is cleared so the connection can be returned to the pool. If the deadline is reached an error is returned and eventually the connection gets marked as bad.

This fixed the issue we were seeing, but we did notice that the old, hung, established connections were still around in netstat. Looking at pq.(*conn).Close(), when the sql layer called to close the bad connection, the code would just return driver.ErrBadConn and not try to close the connection. I changed that to close the connection and return the result of the close call, similar to what is done at the bottom of that function. This seemed to do the trick and the hung connections were cleaned up.

Any feedback on these changes would be greatly appreciated. We have tested them in our fork as part of our applications failure testing and have had good results.