### PR TITLE
Changes to conn.Close()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -749,19 +749,24 @@ func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
 }
 
 func (cn *conn) Close() (err error) {
-	if cn.bad {
-		return driver.ErrBadConn
-	}
 	defer cn.errRecover(&err)
 
 	// Don't go through send(); ListenerConn relies on us not scribbling on the
 	// scratch buffer of this connection.
-	err = cn.sendSimpleMessage('X')
-	if err != nil {
-		return err
+	if cn.c != nil {
+		err := cn.sendSimpleMessage('X')
+		if err != nil {
+			return err
+		}
+
+		err = cn.c.Close()
+		cn.c = nil
+		if err != nil {
+			return err
+		}
 	}
 
-	return cn.c.Close()
+	return nil
 }
 
 // Implement the "Queryer" interface

--- a/conn.go
+++ b/conn.go
@@ -751,9 +751,9 @@ func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
 func (cn *conn) Close() (err error) {
 	defer cn.errRecover(&err)
 
-	// Don't go through send(); ListenerConn relies on us not scribbling on the
-	// scratch buffer of this connection.
 	if cn.c != nil {
+		// Don't go through send(); ListenerConn relies on us not scribbling on the
+		// scratch buffer of this connection.
 		err := cn.sendSimpleMessage('X')
 		if err != nil {
 			return err

--- a/conn.go
+++ b/conn.go
@@ -115,6 +115,11 @@ type conn struct {
 	// Whether to always send []byte parameters over as binary.  Enables single
 	// round-trip mode for non-prepared Query calls.
 	binaryParameters bool
+
+	// Timeouts for read and write operations against the database server.
+	// A duration of 0 indicates no timeout.
+	readTimeout  time.Duration
+	writeTimeout time.Duration
 }
 
 // Handle driver-side settings in parsed connection string.
@@ -132,6 +137,13 @@ func (c *conn) handleDriverSettings(o values) (err error) {
 		return nil
 	}
 
+	intSetting := func(key string) (int, error) {
+		if value := o.Get(key); value != "" {
+			return strconv.Atoi(value)
+		}
+		return 0, nil
+	}
+
 	err = boolSetting("disable_prepared_binary_result", &c.disablePreparedBinaryResult)
 	if err != nil {
 		return err
@@ -140,6 +152,21 @@ func (c *conn) handleDriverSettings(o values) (err error) {
 	if err != nil {
 		return err
 	}
+
+	rt, err := intSetting("read_timeout")
+	if err != nil {
+		return err
+	}
+	// read_timeout is specified in milliseconds.
+	c.readTimeout = time.Duration(rt) * time.Millisecond
+
+	wt, err := intSetting("write_timeout")
+	if err != nil {
+		return err
+	}
+	// write_timeout is specified in milliseconds.
+	c.writeTimeout = time.Duration(wt) * time.Millisecond
+
 	return nil
 }
 
@@ -750,7 +777,7 @@ func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
 
 func (cn *conn) Close() (err error) {
 	if cn.bad {
-		return driver.ErrBadConn
+		return cn.c.Close()
 	}
 	defer cn.errRecover(&err)
 
@@ -836,6 +863,18 @@ func (cn *conn) Exec(query string, args []driver.Value) (res driver.Result, err 
 }
 
 func (cn *conn) send(m *writeBuf) {
+	defer func() {
+		if cn.writeTimeout != 0 {
+			// Clear the write deadline if we set one.
+			cn.c.SetWriteDeadline(time.Time{})
+		}
+	}()
+
+	// Set the write deadline if we have a write timeout set.
+	if cn.writeTimeout != 0 {
+		cn.c.SetWriteDeadline(time.Now().Add(cn.writeTimeout))
+	}
+
 	_, err := cn.c.Write(m.wrap())
 	if err != nil {
 		panic(err)
@@ -843,6 +882,18 @@ func (cn *conn) send(m *writeBuf) {
 }
 
 func (cn *conn) sendStartupPacket(m *writeBuf) {
+	defer func() {
+		if cn.writeTimeout != 0 {
+			// Clear the write deadline if we set one.
+			cn.c.SetWriteDeadline(time.Time{})
+		}
+	}()
+
+	// Set the write deadline if we have a write timeout set.
+	if cn.writeTimeout != 0 {
+		cn.c.SetWriteDeadline(time.Now().Add(cn.writeTimeout))
+	}
+
 	// sanity check
 	if m.buf[0] != 0 {
 		panic("oops")
@@ -858,6 +909,18 @@ func (cn *conn) sendStartupPacket(m *writeBuf) {
 // message should have no payload.  This method does not use the scratch
 // buffer.
 func (cn *conn) sendSimpleMessage(typ byte) (err error) {
+	defer func() {
+		if cn.writeTimeout != 0 {
+			// Clear the write deadline if we set one.
+			cn.c.SetWriteDeadline(time.Time{})
+		}
+	}()
+
+	// Set the write deadline if we have a write timeout set.
+	if cn.writeTimeout != 0 {
+		cn.c.SetWriteDeadline(time.Now().Add(cn.writeTimeout))
+	}
+
 	_, err = cn.c.Write([]byte{typ, '\x00', '\x00', '\x00', '\x04'})
 	return err
 }
@@ -879,6 +942,18 @@ func (cn *conn) saveMessage(typ byte, buf *readBuf) {
 // recvMessage receives any message from the backend, or returns an error if
 // a problem occurred while reading the message.
 func (cn *conn) recvMessage(r *readBuf) (byte, error) {
+	defer func() {
+		if cn.readTimeout != 0 {
+			// Clear the read deadline if we set one.
+			cn.c.SetReadDeadline(time.Time{})
+		}
+	}()
+
+	// Set the read deadline if we have a read timeout set.
+	if cn.readTimeout != 0 {
+		cn.c.SetReadDeadline(time.Now().Add(cn.readTimeout))
+	}
+
 	// workaround for a QueryRow bug, see exec
 	if cn.saveMessageType != 0 {
 		t := cn.saveMessageType
@@ -1143,6 +1218,10 @@ func isDriverSetting(key string) bool {
 	case "disable_prepared_binary_result":
 		return true
 	case "binary_parameters":
+		return true
+	case "read_timeout":
+		return true
+	case "write_timeout":
 		return true
 
 	default:


### PR DESCRIPTION
While doing load and failover testing, we noticed that connections marked as bad (timeouts, disconnections, errors, etc) were never being closed and remained marked as ESTABLISHED in a netstat listing. 

Looking at the code, Close() is never called on the connection in the case of the connection being marked bad. Looking around at the code for other golang database/sql drivers, they seem to all call Close() on the connection regardless of the state of the connection. I think this is what lib/pq should be doing as well. Thoughts?