### PR TITLE
TLS Renegotiation Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.test
 *~
 *.swp
+*.iml

--- a/bench_test.go
+++ b/bench_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lib/pq/oid"
+	"github.com/sendwithus/pq/oid"
 )
 
 var (

--- a/buf.go
+++ b/buf.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/lib/pq/oid"
+	"github.com/sendwithus/pq/oid"
 )
 
 type readBuf []byte

--- a/conn.go
+++ b/conn.go
@@ -22,7 +22,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/lib/pq/oid"
+	"github.com/sendwithus/pq/oid"
 )
 
 // Common error types

--- a/conn.go
+++ b/conn.go
@@ -998,6 +998,16 @@ func (cn *conn) ssl(o values) {
 		errorf(`unsupported sslmode %q; only "require" (default), "verify-full", "verify-ca", and "disable" supported`, mode)
 	}
 
+	switch o.Get("tls-renegotiation") {
+	case "RenegotiateNever":
+		tlsConf.Renegotiation = tls.RenegotiateNever
+	case "RenegotiateFreelyAsClient":
+		tlsConf.Renegotiation = tls.RenegotiateFreelyAsClient
+	case "RenegotiateOnceAsClient":
+		tlsConf.Renegotiation = tls.RenegotiateOnceAsClient
+	}
+	delete(o, "tls-renegotiation")
+
 	cn.setupSSLClientCertificates(&tlsConf, o)
 	cn.setupSSLCA(&tlsConf, o)
 

--- a/encode.go
+++ b/encode.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lib/pq/oid"
+	"github.com/sendwithus/pq/oid"
 )
 
 func binaryEncode(parameterStatus *parameterStatus, x interface{}) []byte {

--- a/encode_test.go
+++ b/encode_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lib/pq/oid"
+	"github.com/sendwithus/pq/oid"
 )
 
 func TestScanTimestamp(t *testing.T) {


### PR DESCRIPTION
Hi there, we are using lib/pq to connect to an amazon redshift databases, we've had to disable sslmode because otherwise the connection drops silently when the query returns large amounts of data. Support for this was added in Go 1.7, and here is how we've added the support which works in our use case. I'm completely open to any suggestions on how to better set the value on the tlsConfig struct as I'm not entirely happy with the current implementation.
