### PR TITLE
Show position in syntax errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -621,7 +621,7 @@ func (cn *conn) simpleExec(q string) (res driver.Result, commandTag string, err 
 }
 
 func (cn *conn) simpleQuery(q string) (res *rows, err error) {
-	defer cn.errRecover(&err)
+	defer cn.errRecoverWithQuery(&err, q)
 
 	b := cn.writeBuf('Q')
 	b.string(q)
@@ -763,7 +763,7 @@ func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
 	if cn.bad {
 		return nil, driver.ErrBadConn
 	}
-	defer cn.errRecover(&err)
+	defer cn.errRecoverWithQuery(&err, q)
 
 	if len(q) >= 4 && strings.EqualFold(q[:4], "COPY") {
 		return cn.prepareCopyIn(q)
@@ -794,7 +794,7 @@ func (cn *conn) Query(query string, args []driver.Value) (_ driver.Rows, err err
 	if cn.bad {
 		return nil, driver.ErrBadConn
 	}
-	defer cn.errRecover(&err)
+	defer cn.errRecoverWithQuery(&err, query)
 
 	// Check to see if we can use the "simpleQuery" interface, which is
 	// *much* faster than going through prepare/exec
@@ -828,7 +828,7 @@ func (cn *conn) Exec(query string, args []driver.Value) (res driver.Result, err 
 	if cn.bad {
 		return nil, driver.ErrBadConn
 	}
-	defer cn.errRecover(&err)
+	defer cn.errRecoverWithQuery(&err, query)
 
 	// Check to see if we can use the "simpleExec" interface, which is
 	// *much* faster than going through prepare/exec

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,68 @@
+package pq
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSyntaxErrorFormatting(t *testing.T) {
+	for _, tt := range []struct {
+		err      Error
+		expected string
+	}{
+		// Single line
+		{Error{Message: "test", Position: "8", originalQuery: "SELECT *;"},
+			"pq: test\nLINE 1: SELECT *;\n               ^"},
+
+		// Syntax error in first line
+		{Error{Message: "test", Position: "1", originalQuery: "SELECT\n *;"},
+			"pq: test\nLINE 1: SELECT\n        ^"},
+
+		// Syntax error in last line
+		{Error{Message: "test", Position: "9", originalQuery: "SELECT\n *;"},
+			"pq: test\nLINE 2:  *;\n         ^"},
+
+		// Bad input: position non-positive
+		{Error{Message: "test", Position: "0", originalQuery: "SELECT\n *;"},
+			Error{Message: "test", Position: "0", originalQuery: "SELECT\n *;"}.normalError()},
+
+		// Bad input: position after end of string
+		{Error{Message: "test", Position: "11", originalQuery: "SELECT\n *;"},
+			Error{Message: "test", Position: "11", originalQuery: "SELECT\n *;"}.normalError()},
+		{Error{Message: "test", Position: "not a number", originalQuery: "SELECT\n *;"},
+			Error{Message: "test", Position: "not a number", originalQuery: "SELECT\n *;"}.normalError()},
+	} {
+		actual := tt.err.syntaxError()
+		if tt.expected != actual {
+			t.Errorf("bad message, expected %#v, got %#v", tt.expected, actual)
+		}
+	}
+}
+
+func TestSyntaxErrorHandlingWithQuery(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	_, err := db.Query("SELECT *;")
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasSuffix(err.Error(), "   ^") {
+		t.Errorf("syntax error not formatted as such. got %#v", err.Error())
+	}
+}
+
+func TestSyntaxErrorHandlingWithPrepare(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	_, err := db.Prepare("SELECT *;")
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasSuffix(err.Error(), "   ^") {
+		t.Errorf("syntax error not formatted as such. got %#v", err.Error())
+	}
+}


### PR DESCRIPTION
We now format them like psql, e.g.:

    pq: syntax error at or near "FROM"
    LINE 1: SELECT * FROM FROM items;
                          ^

Closes #194