### PR TITLE
TLS fixes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -3,15 +3,12 @@ package pq
 import (
 	"bufio"
 	"crypto/md5"
-	"crypto/tls"
-	"crypto/x509"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -990,41 +987,11 @@ func (cn *conn) recv1() (t byte, r *readBuf) {
 }
 
 func (cn *conn) ssl(o values) {
-	verifyCaOnly := false
-	tlsConf := tls.Config{}
-	switch mode := o.Get("sslmode"); mode {
-	// "require" is the default.
-	case "", "require":
-		// We must skip TLS's own verification since it requires full
-		// verification since Go 1.3.
-		tlsConf.InsecureSkipVerify = true
-
-		// From http://www.postgresql.org/docs/current/static/libpq-ssl.html:
-		// Note: For backwards compatibility with earlier versions of PostgreSQL, if a
-		// root CA file exists, the behavior of sslmode=require will be the same as
-		// that of verify-ca, meaning the server certificate is validated against the
-		// CA. Relying on this behavior is discouraged, and applications that need
-		// certificate validation should always use verify-ca or verify-full.
-		if _, err := os.Stat(o.Get("sslrootcert")); err == nil {
-			verifyCaOnly = true
-		} else {
-			o.Set("sslrootcert", "")
-		}
-	case "verify-ca":
-		// We must skip TLS's own verification since it requires full
-		// verification since Go 1.3.
-		tlsConf.InsecureSkipVerify = true
-		verifyCaOnly = true
-	case "verify-full":
-		tlsConf.ServerName = o.Get("host")
-	case "disable":
+	upgrade := ssl(o)
+	if upgrade == nil {
+		// Nothing to do
 		return
-	default:
-		errorf(`unsupported sslmode %q; only "require" (default), "verify-full", "verify-ca", and "disable" supported`, mode)
 	}
-
-	cn.setupSSLClientCertificates(&tlsConf, o)
-	cn.setupSSLCA(&tlsConf, o)
 
 	w := cn.writeBuf(0)
 	w.int32(80877103)
@@ -1040,114 +1007,7 @@ func (cn *conn) ssl(o values) {
 		panic(ErrSSLNotSupported)
 	}
 
-	client := tls.Client(cn.c, &tlsConf)
-	if verifyCaOnly {
-		cn.verifyCA(client, &tlsConf)
-	}
-	cn.c = client
-}
-
-// verifyCA carries out a TLS handshake to the server and verifies the
-// presented certificate against the effective CA, i.e. the one specified in
-// sslrootcert or the system CA if sslrootcert was not specified.
-func (cn *conn) verifyCA(client *tls.Conn, tlsConf *tls.Config) {
-	err := client.Handshake()
-	if err != nil {
-		panic(err)
-	}
-	certs := client.ConnectionState().PeerCertificates
-	opts := x509.VerifyOptions{
-		DNSName:       client.ConnectionState().ServerName,
-		Intermediates: x509.NewCertPool(),
-		Roots:         tlsConf.RootCAs,
-	}
-	for i, cert := range certs {
-		if i == 0 {
-			continue
-		}
-		opts.Intermediates.AddCert(cert)
-	}
-	_, err = certs[0].Verify(opts)
-	if err != nil {
-		panic(err)
-	}
-}
-
-// This function sets up SSL client certificates based on either the "sslkey"
-// and "sslcert" settings (possibly set via the environment variables PGSSLKEY
-// and PGSSLCERT, respectively), or if they aren't set, from the .postgresql
-// directory in the user's home directory.  If the file paths are set
-// explicitly, the files must exist.  The key file must also not be
-// world-readable, or this function will panic with
-// ErrSSLKeyHasWorldPermissions.
-func (cn *conn) setupSSLClientCertificates(tlsConf *tls.Config, o values) {
-	var missingOk bool
-
-	sslkey := o.Get("sslkey")
-	sslcert := o.Get("sslcert")
-	if sslkey != "" && sslcert != "" {
-		// If the user has set an sslkey and sslcert, they *must* exist.
-		missingOk = false
-	} else {
-		// Automatically load certificates from ~/.postgresql.
-		user, err := user.Current()
-		if err != nil {
-			// user.Current() might fail when cross-compiling.  We have to
-			// ignore the error and continue without client certificates, since
-			// we wouldn't know where to load them from.
-			return
-		}
-
-		sslkey = filepath.Join(user.HomeDir, ".postgresql", "postgresql.key")
-		sslcert = filepath.Join(user.HomeDir, ".postgresql", "postgresql.crt")
-		missingOk = true
-	}
-
-	// Check that both files exist, and report the error or stop, depending on
-	// which behaviour we want.  Note that we don't do any more extensive
-	// checks than this (such as checking that the paths aren't directories);
-	// LoadX509KeyPair() will take care of the rest.
-	keyfinfo, err := os.Stat(sslkey)
-	if err != nil && missingOk {
-		return
-	} else if err != nil {
-		panic(err)
-	}
-	_, err = os.Stat(sslcert)
-	if err != nil && missingOk {
-		return
-	} else if err != nil {
-		panic(err)
-	}
-
-	// If we got this far, the key file must also have the correct permissions
-	kmode := keyfinfo.Mode()
-	if kmode != kmode&0600 {
-		panic(ErrSSLKeyHasWorldPermissions)
-	}
-
-	cert, err := tls.LoadX509KeyPair(sslcert, sslkey)
-	if err != nil {
-		panic(err)
-	}
-	tlsConf.Certificates = []tls.Certificate{cert}
-}
-
-// Sets up RootCAs in the TLS configuration if sslrootcert is set.
-func (cn *conn) setupSSLCA(tlsConf *tls.Config, o values) {
-	if sslrootcert := o.Get("sslrootcert"); sslrootcert != "" {
-		tlsConf.RootCAs = x509.NewCertPool()
-
-		cert, err := ioutil.ReadFile(sslrootcert)
-		if err != nil {
-			panic(err)
-		}
-
-		ok := tlsConf.RootCAs.AppendCertsFromPEM(cert)
-		if !ok {
-			errorf("couldn't parse pem in sslrootcert")
-		}
-	}
+	cn.c = upgrade(cn.c)
 }
 
 // isDriverSetting returns true iff a setting is purely for configuring the

--- a/ssl.go
+++ b/ssl.go
@@ -1,0 +1,159 @@
+package pq
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+// ssl generates a function to upgrade a net.Conn based on the "sslmode" and
+// related settings. The function is nil when no upgrade should take place.
+func ssl(o values) func(net.Conn) net.Conn {
+	verifyCaOnly := false
+	tlsConf := tls.Config{}
+	switch mode := o.Get("sslmode"); mode {
+	// "require" is the default.
+	case "", "require":
+		// We must skip TLS's own verification since it requires full
+		// verification since Go 1.3.
+		tlsConf.InsecureSkipVerify = true
+
+		// From http://www.postgresql.org/docs/current/static/libpq-ssl.html:
+		// Note: For backwards compatibility with earlier versions of PostgreSQL, if a
+		// root CA file exists, the behavior of sslmode=require will be the same as
+		// that of verify-ca, meaning the server certificate is validated against the
+		// CA. Relying on this behavior is discouraged, and applications that need
+		// certificate validation should always use verify-ca or verify-full.
+		if _, err := os.Stat(o.Get("sslrootcert")); err == nil {
+			verifyCaOnly = true
+		} else {
+			o.Set("sslrootcert", "")
+		}
+	case "verify-ca":
+		// We must skip TLS's own verification since it requires full
+		// verification since Go 1.3.
+		tlsConf.InsecureSkipVerify = true
+		verifyCaOnly = true
+	case "verify-full":
+		tlsConf.ServerName = o.Get("host")
+	case "disable":
+		return nil
+	default:
+		errorf(`unsupported sslmode %q; only "require" (default), "verify-full", "verify-ca", and "disable" supported`, mode)
+	}
+
+	sslClientCertificates(&tlsConf, o)
+	sslCertificateAuthority(&tlsConf, o)
+
+	return func(conn net.Conn) net.Conn {
+		client := tls.Client(conn, &tlsConf)
+		if verifyCaOnly {
+			sslVerifyCertificateAuthority(client, &tlsConf)
+		}
+		return client
+	}
+}
+
+// sslClientCertificates adds the certificate specified in the "sslcert" and
+// "sslkey" settings, or if they aren't set, from the .postgresql directory
+// in the user's home directory. The configured files must exist and have
+// the correct permissions.
+func sslClientCertificates(tlsConf *tls.Config, o values) {
+	var missingOk bool
+
+	sslkey := o.Get("sslkey")
+	sslcert := o.Get("sslcert")
+	if sslkey != "" && sslcert != "" {
+		// If the user has set an sslkey and sslcert, they *must* exist.
+		missingOk = false
+	} else {
+		// Automatically load certificates from ~/.postgresql.
+		user, err := user.Current()
+		if err != nil {
+			// user.Current() might fail when cross-compiling.  We have to
+			// ignore the error and continue without client certificates, since
+			// we wouldn't know where to load them from.
+			return
+		}
+
+		sslkey = filepath.Join(user.HomeDir, ".postgresql", "postgresql.key")
+		sslcert = filepath.Join(user.HomeDir, ".postgresql", "postgresql.crt")
+		missingOk = true
+	}
+
+	// Check that both files exist, and report the error or stop, depending on
+	// which behaviour we want.  Note that we don't do any more extensive
+	// checks than this (such as checking that the paths aren't directories);
+	// LoadX509KeyPair() will take care of the rest.
+	keyfinfo, err := os.Stat(sslkey)
+	if err != nil && missingOk {
+		return
+	} else if err != nil {
+		panic(err)
+	}
+	_, err = os.Stat(sslcert)
+	if err != nil && missingOk {
+		return
+	} else if err != nil {
+		panic(err)
+	}
+
+	// If we got this far, the key file must also have the correct permissions
+	kmode := keyfinfo.Mode()
+	if kmode != kmode&0600 {
+		panic(ErrSSLKeyHasWorldPermissions)
+	}
+
+	cert, err := tls.LoadX509KeyPair(sslcert, sslkey)
+	if err != nil {
+		panic(err)
+	}
+	tlsConf.Certificates = []tls.Certificate{cert}
+}
+
+// sslCertificateAuthority adds the RootCA specified in the "sslrootcert" setting.
+func sslCertificateAuthority(tlsConf *tls.Config, o values) {
+	if sslrootcert := o.Get("sslrootcert"); sslrootcert != "" {
+		tlsConf.RootCAs = x509.NewCertPool()
+
+		cert, err := ioutil.ReadFile(sslrootcert)
+		if err != nil {
+			panic(err)
+		}
+
+		ok := tlsConf.RootCAs.AppendCertsFromPEM(cert)
+		if !ok {
+			errorf("couldn't parse pem in sslrootcert")
+		}
+	}
+}
+
+// sslVerifyCertificateAuthority carries out a TLS handshake to the server and
+// verifies the presented certificate against the CA, i.e. the one specified in
+// sslrootcert or the system CA if sslrootcert was not specified.
+func sslVerifyCertificateAuthority(client *tls.Conn, tlsConf *tls.Config) {
+	err := client.Handshake()
+	if err != nil {
+		panic(err)
+	}
+	certs := client.ConnectionState().PeerCertificates
+	opts := x509.VerifyOptions{
+		DNSName:       client.ConnectionState().ServerName,
+		Intermediates: x509.NewCertPool(),
+		Roots:         tlsConf.RootCAs,
+	}
+	for i, cert := range certs {
+		if i == 0 {
+			continue
+		}
+		opts.Intermediates.AddCert(cert)
+	}
+	_, err = certs[0].Verify(opts)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/ssl.go
+++ b/ssl.go
@@ -48,6 +48,7 @@ func ssl(o values) func(net.Conn) net.Conn {
 
 	sslClientCertificates(&tlsConf, o)
 	sslCertificateAuthority(&tlsConf, o)
+	sslRenegotiation(&tlsConf)
 
 	return func(conn net.Conn) net.Conn {
 		client := tls.Client(conn, &tlsConf)

--- a/ssl_go1.7.go
+++ b/ssl_go1.7.go
@@ -1,0 +1,14 @@
+// +build go1.7
+
+package pq
+
+import "crypto/tls"
+
+// Accept renegotiation requests initiated by the backend.
+//
+// Renegotiation was deprecated then removed from PostgreSQL 9.5, but
+// the default configuration of older versions has it enabled. Redshift
+// also initiates renegotiations and cannot be reconfigured.
+func sslRenegotiation(conf *tls.Config) {
+	conf.Renegotiation = tls.RenegotiateFreelyAsClient
+}

--- a/ssl_permissions.go
+++ b/ssl_permissions.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package pq
+
+import "os"
+
+// sslCertificatePermissions checks the permissions on user-supplied certificate
+// files. The key file should have very little access.
+//
+// libpq does not check key file permissions on Windows.
+func sslCertificatePermissions(cert, key os.FileInfo) {
+	kmode := key.Mode()
+	if kmode != kmode&0600 {
+		panic(ErrSSLKeyHasWorldPermissions)
+	}
+}

--- a/ssl_renegotiation.go
+++ b/ssl_renegotiation.go
@@ -1,0 +1,8 @@
+// +build !go1.7
+
+package pq
+
+import "crypto/tls"
+
+// Renegotiation is not supported by crypto/tls until Go 1.7.
+func sslRenegotiation(*tls.Config) {}

--- a/ssl_windows.go
+++ b/ssl_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package pq
+
+import "os"
+
+// sslCertificatePermissions checks the permissions on user-supplied certificate
+// files. In libpq, this is a no-op on Windows.
+func sslCertificatePermissions(cert, key os.FileInfo) {}


### PR DESCRIPTION
Moves the `crypto/tls` stuff out of `conn` and adds some files with build flags for #489 and #508.

I don't imagine users will ever want to disable TLS renegotiation, so I opted not to add a driver setting for it. If we do want a setting, then `sslRenegotiation` could change to look much like `sslClientCertificates` and `sslCertificateAuthority`.
