### PR TITLE
Handle nil and NULL values consistently for Array types

### DIFF
--- a/array.go
+++ b/array.go
@@ -70,6 +70,9 @@ func (a *BoolArray) Scan(src interface{}) error {
 		return a.scanBytes(src)
 	case string:
 		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
 	}
 
 	return fmt.Errorf("pq: cannot convert %T to BoolArray", src)
@@ -80,7 +83,7 @@ func (a *BoolArray) scanBytes(src []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(elems) == 0 {
+	if *a != nil && len(elems) == 0 {
 		*a = (*a)[:0]
 	} else {
 		b := make(BoolArray, len(elems))
@@ -141,6 +144,9 @@ func (a *ByteaArray) Scan(src interface{}) error {
 		return a.scanBytes(src)
 	case string:
 		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
 	}
 
 	return fmt.Errorf("pq: cannot convert %T to ByteaArray", src)
@@ -151,7 +157,7 @@ func (a *ByteaArray) scanBytes(src []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(elems) == 0 {
+	if *a != nil && len(elems) == 0 {
 		*a = (*a)[:0]
 	} else {
 		b := make(ByteaArray, len(elems))
@@ -210,6 +216,9 @@ func (a *Float64Array) Scan(src interface{}) error {
 		return a.scanBytes(src)
 	case string:
 		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
 	}
 
 	return fmt.Errorf("pq: cannot convert %T to Float64Array", src)
@@ -220,7 +229,7 @@ func (a *Float64Array) scanBytes(src []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(elems) == 0 {
+	if *a != nil && len(elems) == 0 {
 		*a = (*a)[:0]
 	} else {
 		b := make(Float64Array, len(elems))
@@ -320,6 +329,11 @@ func (a GenericArray) Scan(src interface{}) error {
 		return a.scanBytes(src, dv)
 	case string:
 		return a.scanBytes([]byte(src), dv)
+	case nil:
+		if dv.Kind() == reflect.Slice {
+			dv.Set(reflect.Zero(dv.Type()))
+			return nil
+		}
 	}
 
 	return fmt.Errorf("pq: cannot convert %T to %s", src, dv.Type())
@@ -386,7 +400,13 @@ func (a GenericArray) Value() (driver.Value, error) {
 
 	rv := reflect.ValueOf(a.A)
 
-	if k := rv.Kind(); k != reflect.Array && k != reflect.Slice {
+	switch rv.Kind() {
+	case reflect.Slice:
+		if rv.IsNil() {
+			return nil, nil
+		}
+	case reflect.Array:
+	default:
 		return nil, fmt.Errorf("pq: Unable to convert %T to array", a.A)
 	}
 
@@ -412,6 +432,9 @@ func (a *Int64Array) Scan(src interface{}) error {
 		return a.scanBytes(src)
 	case string:
 		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
 	}
 
 	return fmt.Errorf("pq: cannot convert %T to Int64Array", src)
@@ -422,7 +445,7 @@ func (a *Int64Array) scanBytes(src []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(elems) == 0 {
+	if *a != nil && len(elems) == 0 {
 		*a = (*a)[:0]
 	} else {
 		b := make(Int64Array, len(elems))
@@ -470,6 +493,9 @@ func (a *StringArray) Scan(src interface{}) error {
 		return a.scanBytes(src)
 	case string:
 		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
 	}
 
 	return fmt.Errorf("pq: cannot convert %T to StringArray", src)
@@ -480,7 +506,7 @@ func (a *StringArray) scanBytes(src []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(elems) == 0 {
+	if *a != nil && len(elems) == 0 {
 		*a = (*a)[:0]
 	} else {
 		b := make(StringArray, len(elems))

--- a/array_test.go
+++ b/array_test.go
@@ -171,6 +171,30 @@ func TestBoolArrayScanUnsupported(t *testing.T) {
 	}
 }
 
+func TestBoolArrayScanEmpty(t *testing.T) {
+	var arr BoolArray
+	err := arr.Scan(`{}`)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr == nil || len(arr) != 0 {
+		t.Errorf("Expected empty, got %#v", arr)
+	}
+}
+
+func TestBoolArrayScanNil(t *testing.T) {
+	arr := BoolArray{true, true, true}
+	err := arr.Scan(nil)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr != nil {
+		t.Errorf("Expected nil, got %+v", arr)
+	}
+}
+
 var BoolArrayStringTests = []struct {
 	str string
 	arr BoolArray
@@ -297,6 +321,30 @@ func TestByteaArrayScanUnsupported(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "int to ByteaArray") {
 		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+func TestByteaArrayScanEmpty(t *testing.T) {
+	var arr ByteaArray
+	err := arr.Scan(`{}`)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr == nil || len(arr) != 0 {
+		t.Errorf("Expected empty, got %#v", arr)
+	}
+}
+
+func TestByteaArrayScanNil(t *testing.T) {
+	arr := ByteaArray{{2}, {6}, {0, 0}}
+	err := arr.Scan(nil)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr != nil {
+		t.Errorf("Expected nil, got %+v", arr)
 	}
 }
 
@@ -430,6 +478,30 @@ func TestFloat64ArrayScanUnsupported(t *testing.T) {
 	}
 }
 
+func TestFloat64ArrayScanEmpty(t *testing.T) {
+	var arr Float64Array
+	err := arr.Scan(`{}`)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr == nil || len(arr) != 0 {
+		t.Errorf("Expected empty, got %#v", arr)
+	}
+}
+
+func TestFloat64ArrayScanNil(t *testing.T) {
+	arr := Float64Array{5, 5, 5}
+	err := arr.Scan(nil)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr != nil {
+		t.Errorf("Expected nil, got %+v", arr)
+	}
+}
+
 var Float64ArrayStringTests = []struct {
 	str string
 	arr Float64Array
@@ -557,6 +629,30 @@ func TestInt64ArrayScanUnsupported(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bool to Int64Array") {
 		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
+	}
+}
+
+func TestInt64ArrayScanEmpty(t *testing.T) {
+	var arr Int64Array
+	err := arr.Scan(`{}`)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr == nil || len(arr) != 0 {
+		t.Errorf("Expected empty, got %#v", arr)
+	}
+}
+
+func TestInt64ArrayScanNil(t *testing.T) {
+	arr := Int64Array{5, 5, 5}
+	err := arr.Scan(nil)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr != nil {
+		t.Errorf("Expected nil, got %+v", arr)
 	}
 }
 
@@ -689,6 +785,30 @@ func TestStringArrayScanUnsupported(t *testing.T) {
 	}
 }
 
+func TestStringArrayScanEmpty(t *testing.T) {
+	var arr StringArray
+	err := arr.Scan(`{}`)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr == nil || len(arr) != 0 {
+		t.Errorf("Expected empty, got %#v", arr)
+	}
+}
+
+func TestStringArrayScanNil(t *testing.T) {
+	arr := StringArray{"x", "x", "x"}
+	err := arr.Scan(nil)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if arr != nil {
+		t.Errorf("Expected nil, got %+v", arr)
+	}
+}
+
 var StringArrayStringTests = []struct {
 	str string
 	arr StringArray
@@ -811,6 +931,7 @@ func BenchmarkStringArrayValue(b *testing.B) {
 func TestGenericArrayScanUnsupported(t *testing.T) {
 	var s string
 	var ss []string
+	var nsa [1]sql.NullString
 
 	for _, tt := range []struct {
 		src, dest interface{}
@@ -820,6 +941,7 @@ func TestGenericArrayScanUnsupported(t *testing.T) {
 		{nil, true, "destination bool is not a pointer to array or slice"},
 		{nil, &s, "destination *string is not a pointer to array or slice"},
 		{nil, ss, "destination []string is not a pointer to array or slice"},
+		{nil, &nsa, "<nil> to [1]sql.NullString"},
 		{true, &ss, "bool to []string"},
 		{`{{x}}`, &ss, "multidimensional ARRAY[1][1] is not implemented"},
 		{`{{x},{x}}`, &ss, "multidimensional ARRAY[2][1] is not implemented"},
@@ -859,6 +981,28 @@ func TestGenericArrayScanScannerArrayString(t *testing.T) {
 	}
 	if !reflect.DeepEqual(nsa, expected) {
 		t.Errorf("Expected %v, got %v", expected, nsa)
+	}
+}
+
+func TestGenericArrayScanScannerSliceEmpty(t *testing.T) {
+	var nss []sql.NullString
+
+	if err := (GenericArray{&nss}).Scan(`{}`); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if nss == nil || len(nss) != 0 {
+		t.Errorf("Expected empty, got %#v", nss)
+	}
+}
+
+func TestGenericArrayScanScannerSliceNil(t *testing.T) {
+	nss := []sql.NullString{{String: ``, Valid: true}, {}}
+
+	if err := (GenericArray{&nss}).Scan(nil); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if nss != nil {
+		t.Errorf("Expected nil, got %+v", nss)
 	}
 }
 
@@ -975,6 +1119,22 @@ func TestGenericArrayValue(t *testing.T) {
 	}
 	if result != nil {
 		t.Errorf("Expected nil, got %q", result)
+	}
+
+	for _, tt := range []interface{}{
+		[]bool(nil),
+		[][]int(nil),
+		[]*int(nil),
+		[]sql.NullString(nil),
+	} {
+		result, err := GenericArray{tt}.Value()
+
+		if err != nil {
+			t.Fatalf("Expected no error for %#v, got %v", tt, err)
+		}
+		if result != nil {
+			t.Errorf("Expected nil for %#v, got %q", tt, result)
+		}
 	}
 
 	Tilde := func(v driver.Value) FuncArrayValuer {


### PR DESCRIPTION
`Value()` of a nil slice is NULL, and `Scan()` of NULL sets a slice to nil.

Fixes #540