### PR TITLE
ssl: only set "sslrootcert" once

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -133,7 +133,7 @@ type conn struct {
 // Handle driver-side settings in parsed connection string.
 func (c *conn) handleDriverSettings(o values) (err error) {
 	boolSetting := func(key string, val *bool) error {
-		if value := o.Get(key); value != "" {
+		if value, ok := o[key]; ok {
 			if value == "yes" {
 				*val = true
 			} else if value == "no" {
@@ -158,8 +158,7 @@ func (c *conn) handleDriverSettings(o values) (err error) {
 
 func (c *conn) handlePgpass(o values) {
 	// if a password was supplied, do not process .pgpass
-	_, ok := o["password"]
-	if ok {
+	if _, ok := o["password"]; ok {
 		return
 	}
 	filename := os.Getenv("PGPASSFILE")
@@ -187,11 +186,11 @@ func (c *conn) handlePgpass(o values) {
 	}
 	defer file.Close()
 	scanner := bufio.NewScanner(io.Reader(file))
-	hostname := o.Get("host")
+	hostname := o["host"]
 	ntw, _ := network(o)
-	port := o.Get("port")
-	db := o.Get("dbname")
-	username := o.Get("user")
+	port := o["port"]
+	db := o["dbname"]
+	username := o["user"]
 	// From: https://github.com/tg/pgpass/blob/master/reader.go
 	getFields := func(s string) []string {
 		fs := make([]string, 0, 5)
@@ -256,13 +255,13 @@ func DialOpen(d Dialer, name string) (_ driver.Conn, err error) {
 	// * Very low precedence defaults applied in every situation
 	// * Environment variables
 	// * Explicitly passed connection information
-	o.Set("host", "localhost")
-	o.Set("port", "5432")
+	o["host"] = "localhost"
+	o["port"] = "5432"
 	// N.B.: Extra float digits should be set to 3, but that breaks
 	// Postgres 8.4 and older, where the max is 2.
-	o.Set("extra_float_digits", "2")
+	o["extra_float_digits"] = "2"
 	for k, v := range parseEnviron(os.Environ()) {
-		o.Set(k, v)
+		o[k] = v
 	}
 
 	if strings.HasPrefix(name, "postgres://") || strings.HasPrefix(name, "postgresql://") {
@@ -277,9 +276,9 @@ func DialOpen(d Dialer, name string) (_ driver.Conn, err error) {
 	}
 
 	// Use the "fallback" application name if necessary
-	if fallback := o.Get("fallback_application_name"); fallback != "" {
-		if !o.Isset("application_name") {
-			o.Set("application_name", fallback)
+	if fallback, ok := o["fallback_application_name"]; ok {
+		if _, ok := o["application_name"]; !ok {
+			o["application_name"] = fallback
 		}
 	}
 
@@ -290,29 +289,29 @@ func DialOpen(d Dialer, name string) (_ driver.Conn, err error) {
 	// parsing its value is not worth it.  Instead, we always explicitly send
 	// client_encoding as a separate run-time parameter, which should override
 	// anything set in options.
-	if enc := o.Get("client_encoding"); enc != "" && !isUTF8(enc) {
+	if enc, ok := o["client_encoding"]; ok && !isUTF8(enc) {
 		return nil, errors.New("client_encoding must be absent or 'UTF8'")
 	}
-	o.Set("client_encoding", "UTF8")
+	o["client_encoding"] = "UTF8"
 	// DateStyle needs a similar treatment.
-	if datestyle := o.Get("datestyle"); datestyle != "" {
+	if datestyle, ok := o["datestyle"]; ok {
 		if datestyle != "ISO, MDY" {
 			panic(fmt.Sprintf("setting datestyle must be absent or %v; got %v",
 				"ISO, MDY", datestyle))
 		}
 	} else {
-		o.Set("datestyle", "ISO, MDY")
+		o["datestyle"] = "ISO, MDY"
 	}
 
 	// If a user is not provided by any other means, the last
 	// resort is to use the current operating system provided user
 	// name.
-	if o.Get("user") == "" {
+	if _, ok := o["user"]; !ok {
 		u, err := userCurrent()
 		if err != nil {
 			return nil, err
 		} else {
-			o.Set("user", u)
+			o["user"] = u
 		}
 	}
 
@@ -335,7 +334,7 @@ func DialOpen(d Dialer, name string) (_ driver.Conn, err error) {
 	cn.startup(o)
 
 	// reset the deadline, in case one was set (see dial)
-	if timeout := o.Get("connect_timeout"); timeout != "" && timeout != "0" {
+	if timeout, ok := o["connect_timeout"]; ok && timeout != "0" {
 		err = cn.c.SetDeadline(time.Time{})
 	}
 	return cn, err
@@ -349,7 +348,7 @@ func dial(d Dialer, o values) (net.Conn, error) {
 	}
 
 	// Zero or not specified means wait indefinitely.
-	if timeout := o.Get("connect_timeout"); timeout != "" && timeout != "0" {
+	if timeout, ok := o["connect_timeout"]; ok && timeout != "0" {
 		seconds, err := strconv.ParseInt(timeout, 10, 0)
 		if err != nil {
 			return nil, fmt.Errorf("invalid value for parameter connect_timeout: %s", err)
@@ -371,30 +370,17 @@ func dial(d Dialer, o values) (net.Conn, error) {
 }
 
 func network(o values) (string, string) {
-	host := o.Get("host")
+	host := o["host"]
 
 	if strings.HasPrefix(host, "/") {
-		sockPath := path.Join(host, ".s.PGSQL."+o.Get("port"))
+		sockPath := path.Join(host, ".s.PGSQL."+o["port"])
 		return "unix", sockPath
 	}
 
-	return "tcp", net.JoinHostPort(host, o.Get("port"))
+	return "tcp", net.JoinHostPort(host, o["port"])
 }
 
 type values map[string]string
-
-func (vs values) Set(k, v string) {
-	vs[k] = v
-}
-
-func (vs values) Get(k string) (v string) {
-	return vs[k]
-}
-
-func (vs values) Isset(k string) bool {
-	_, ok := vs[k]
-	return ok
-}
 
 // scanner implements a tokenizer for libpq-style option strings.
 type scanner struct {
@@ -466,7 +452,7 @@ func parseOpts(name string, o values) error {
 		// Skip any whitespace after the =
 		if r, ok = s.SkipSpaces(); !ok {
 			// If we reach the end here, the last value is just an empty string as per libpq.
-			o.Set(string(keyRunes), "")
+			o[string(keyRunes)] = ""
 			break
 		}
 
@@ -501,7 +487,7 @@ func parseOpts(name string, o values) error {
 			}
 		}
 
-		o.Set(string(keyRunes), string(valRunes))
+		o[string(keyRunes)] = string(valRunes)
 	}
 
 	return nil
@@ -1125,7 +1111,7 @@ func (cn *conn) auth(r *readBuf, o values) {
 		// OK
 	case 3:
 		w := cn.writeBuf('p')
-		w.string(o.Get("password"))
+		w.string(o["password"])
 		cn.send(w)
 
 		t, r := cn.recv()
@@ -1139,7 +1125,7 @@ func (cn *conn) auth(r *readBuf, o values) {
 	case 5:
 		s := string(r.next(4))
 		w := cn.writeBuf('p')
-		w.string("md5" + md5s(md5s(o.Get("password")+o.Get("user"))+s))
+		w.string("md5" + md5s(md5s(o["password"]+o["user"])+s))
 		cn.send(w)
 
 		t, r := cn.recv()

--- a/conn_test.go
+++ b/conn_test.go
@@ -191,7 +191,7 @@ localhost:*:*:*:pass_C
 	pgpass.Close()
 
 	assertPassword := func(extra values, expected string) {
-		o := &values{
+		o := values{
 			"host":               "localhost",
 			"sslmode":            "disable",
 			"connect_timeout":    "20",
@@ -203,11 +203,11 @@ localhost:*:*:*:pass_C
 			"datestyle":          "ISO, MDY",
 		}
 		for k, v := range extra {
-			(*o)[k] = v
+			o[k] = v
 		}
-		(&conn{}).handlePgpass(*o)
-		if o.Get("password") != expected {
-			t.Fatalf("For %v expected %s got %s", extra, expected, o.Get("password"))
+		(&conn{}).handlePgpass(o)
+		if pw := o["password"]; pw != expected {
+			t.Fatalf("For %v expected %s got %s", extra, expected, pw)
 		}
 	}
 	// wrong permissions for the pgpass file means it should be ignored

--- a/ssl_permissions.go
+++ b/ssl_permissions.go
@@ -4,13 +4,17 @@ package pq
 
 import "os"
 
-// sslCertificatePermissions checks the permissions on user-supplied certificate
-// files. The key file should have very little access.
+// sslKeyPermissions checks the permissions on user-supplied ssl key files.
+// The key file should have very little access.
 //
 // libpq does not check key file permissions on Windows.
-func sslCertificatePermissions(cert, key os.FileInfo) {
-	kmode := key.Mode()
-	if kmode != kmode&0600 {
-		panic(ErrSSLKeyHasWorldPermissions)
+func sslKeyPermissions(sslkey string) error {
+	info, err := os.Stat(sslkey)
+	if err != nil {
+		return err
 	}
+	if info.Mode().Perm()&0077 != 0 {
+		return ErrSSLKeyHasWorldPermissions
+	}
+	return nil
 }

--- a/ssl_windows.go
+++ b/ssl_windows.go
@@ -2,8 +2,8 @@
 
 package pq
 
-import "os"
-
-// sslCertificatePermissions checks the permissions on user-supplied certificate
-// files. In libpq, this is a no-op on Windows.
-func sslCertificatePermissions(cert, key os.FileInfo) {}
+// sslKeyPermissions checks the permissions on user-supplied ssl key files.
+// The key file should have very little access.
+//
+// libpq does not check key file permissions on Windows.
+func sslKeyPermissions(string) error { return nil }


### PR DESCRIPTION
Fixes #570, though I have not been able to write a test for this.

Remove methods on `values`. These methods are not a useful abstraction
and only serve to obscure that the underlying structure is a map. Their
presence is particularly inconvenient in that they promote confusing
empty values with the lack of value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lib/pq/573)
<!-- Reviewable:end -->
