### PR TITLE
handlePgpass: warn about incorrect .pgpass permissions as psql does

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -177,7 +177,8 @@ func (c *conn) handlePgpass(o values) {
 	}
 	mode := fileinfo.Mode()
 	if mode&(0x77) != 0 {
-		// XXX should warn about incorrect .pgpass permissions as psql does
+		fmt.Fprintf(os.Stderr, "WARNING: password file %q has group or world access; "+
+			"permissions should be u=rw (0600) or less\n", filename)
 		return
 	}
 	file, err := os.Open(filename)


### PR DESCRIPTION
this implements the comment

i got confused today when trying to connect my program to a password-protected database. manually copying the password into the `Connect` string worked, but storing it in `.pgpass` did not. when i checked with psql, i found my error, of course