### PR TITLE
Implement basic support for numeric range types

### DIFF
--- a/ranges/float64range.go
+++ b/ranges/float64range.go
@@ -22,7 +22,7 @@ func (r *Float64Range) Scan(val interface{}) error {
 		r.MaxInclusive = false
 		return nil
 	}
-	minIncl, maxIncl, min, max, err := readFloatRange(val.([]byte))
+	minIn, maxIn, min, max, err := readRange(val.([]byte))
 	if err != nil {
 		return err
 	}
@@ -34,8 +34,8 @@ func (r *Float64Range) Scan(val interface{}) error {
 	if err != nil {
 		return err
 	}
-	r.MinInclusive = minIncl
-	r.MaxInclusive = maxIncl
+	r.MinInclusive = minIn
+	r.MaxInclusive = maxIn
 	return nil
 }
 

--- a/ranges/float64range.go
+++ b/ranges/float64range.go
@@ -1,0 +1,55 @@
+package ranges
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Float64Range represents a range between two float64 values
+type Float64Range struct {
+	Min          float64
+	MinInclusive bool
+	Max          float64
+	MaxInclusive bool
+}
+
+// Scan implements the sql.Scanner interface
+func (r *Float64Range) Scan(val interface{}) error {
+	if val == nil {
+		r.Min = 0
+		r.MinInclusive = false
+		r.Max = 0
+		r.MaxInclusive = false
+		return nil
+	}
+	minIncl, maxIncl, min, max, err := readFloatRange(val.([]byte))
+	if err != nil {
+		return err
+	}
+	r.Min, err = strconv.ParseFloat(string(min), 64)
+	if err != nil {
+		return err
+	}
+	r.Max, err = strconv.ParseFloat(string(max), 64)
+	if err != nil {
+		return err
+	}
+	r.MinInclusive = minIncl
+	r.MaxInclusive = maxIncl
+	return nil
+}
+
+// String returns a string representation of this range
+func (r Float64Range) String() string {
+	var (
+		open  = "("
+		close = ")"
+	)
+	if r.MinInclusive {
+		open = "["
+	}
+	if r.MaxInclusive {
+		close += "]"
+	}
+	return fmt.Sprintf("%s%f, %f%s", open, r.Min, r.Max, close)
+}

--- a/ranges/float64range.go
+++ b/ranges/float64range.go
@@ -51,5 +51,5 @@ func (r Float64Range) String() string {
 	if r.MaxInclusive {
 		close += "]"
 	}
-	return fmt.Sprintf("%s%f, %f%s", open, r.Min, r.Max, close)
+	return fmt.Sprintf("%s%f,%f%s", open, r.Min, r.Max, close)
 }

--- a/ranges/float64range.go
+++ b/ranges/float64range.go
@@ -1,6 +1,7 @@
 package ranges
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"strconv"
 )
@@ -37,6 +38,11 @@ func (r *Float64Range) Scan(val interface{}) error {
 	r.MinInclusive = minIn
 	r.MaxInclusive = maxIn
 	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (r Float64Range) Value() (driver.Value, error) {
+	return []byte(r.String()), nil
 }
 
 // String returns a string representation of this range

--- a/ranges/float64range.go
+++ b/ranges/float64range.go
@@ -49,7 +49,7 @@ func (r Float64Range) String() string {
 		open = "["
 	}
 	if r.MaxInclusive {
-		close += "]"
+		close = "]"
 	}
 	return fmt.Sprintf("%s%f,%f%s", open, r.Min, r.Max, close)
 }

--- a/ranges/float64range_test.go
+++ b/ranges/float64range_test.go
@@ -1,0 +1,18 @@
+package ranges
+
+import (
+	"testing"
+)
+
+func TestFloat64RangeString(t *testing.T) {
+	test := func(min, max float64, minIn, maxIn bool, expect string) {
+		s := Float64Range{min, minIn, max, maxIn}.String()
+		if s != expect {
+			t.Errorf("expected '%s', got '%s'", expect, s)
+		}
+	}
+
+	test(-1.0, 2.1, false, true, "(-1.000000,2.100000]")
+	test(9.99, 0.01, true, true, "[9.990000,0.010000]")
+	test(80.0, 90.0, false, false, "(80.000000,90.000000)")
+}

--- a/ranges/int32range.go
+++ b/ranges/int32range.go
@@ -37,5 +37,5 @@ func (r *Int32Range) Scan(val interface{}) error {
 
 // String returns a string representation of this range
 func (r Int32Range) String() string {
-	return fmt.Sprintf("[%d, %d)", r.Min, r.Max)
+	return fmt.Sprintf("[%d,%d)", r.Min, r.Max)
 }

--- a/ranges/int32range.go
+++ b/ranges/int32range.go
@@ -1,0 +1,41 @@
+package ranges
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// Int32Range represents a range between two int32 values. The minimum value is
+// inclusive and the maximum is exclusive.
+type Int32Range struct {
+	Min int32
+	Max int32
+}
+
+// Scan implements the sql.Scanner interface
+func (r *Int32Range) Scan(val interface{}) error {
+	if val == nil {
+		return errors.New("cannot scan NULL into *Int32Range")
+	}
+	minb, maxb, err := readDiscreteRange(val.([]byte))
+	if err != nil {
+		return err
+	}
+	min, err := strconv.Atoi(string(minb))
+	if err != nil {
+		return err
+	}
+	max, err := strconv.Atoi(string(maxb))
+	if err != nil {
+		return err
+	}
+	r.Min = int32(min)
+	r.Max = int32(max)
+	return nil
+}
+
+// String returns a string representation of this range
+func (r Int32Range) String() string {
+	return fmt.Sprintf("[%d, %d)", r.Min, r.Max)
+}

--- a/ranges/int32range.go
+++ b/ranges/int32range.go
@@ -1,6 +1,7 @@
 package ranges
 
 import (
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"strconv"
@@ -33,6 +34,11 @@ func (r *Int32Range) Scan(val interface{}) error {
 	r.Min = int32(min)
 	r.Max = int32(max)
 	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (r Int32Range) Value() (driver.Value, error) {
+	return []byte(r.String()), nil
 }
 
 // String returns a string representation of this range

--- a/ranges/int32range_test.go
+++ b/ranges/int32range_test.go
@@ -1,0 +1,19 @@
+package ranges
+
+import (
+	"testing"
+)
+
+func TestInt32RangeString(t *testing.T) {
+	test := func(min, max int32, expect string) {
+		s := Int32Range{min, max}.String()
+		if s != expect {
+			t.Errorf("expected '%s', got '%s'", expect, s)
+		}
+	}
+
+	test(0, 2, "[0,2)")
+	test(0, 0, "[0,0)")
+	test(-2, 8, "[-2,8)")
+	test(8, -2, "[8,-2)")
+}

--- a/ranges/int64range.go
+++ b/ranges/int64range.go
@@ -39,5 +39,5 @@ func (r *Int64Range) Scan(val interface{}) error {
 
 // String returns a string representation of this range
 func (r Int64Range) String() string {
-	return fmt.Sprintf("[%d, %d)", r.Min, r.Max)
+	return fmt.Sprintf("[%d,%d)", r.Min, r.Max)
 }

--- a/ranges/int64range.go
+++ b/ranges/int64range.go
@@ -1,6 +1,7 @@
 package ranges
 
 import (
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"strconv"
@@ -35,6 +36,11 @@ func (r *Int64Range) Scan(val interface{}) error {
 		return err
 	}
 	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (r Int64Range) Value() (driver.Value, error) {
+	return []byte(r.String()), nil
 }
 
 // String returns a string representation of this range

--- a/ranges/int64range.go
+++ b/ranges/int64range.go
@@ -6,7 +6,8 @@ import (
 	"strconv"
 )
 
-// Int64Range represents a range between two int64 values
+// Int64Range represents a range between two int64 values. The minimum value is
+// inclusive and the maximum is exclusive.
 type Int64Range struct {
 	Min int64
 	Max int64

--- a/ranges/int64range.go
+++ b/ranges/int64range.go
@@ -1,0 +1,42 @@
+package ranges
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// Int64Range represents a range between two int64 values
+type Int64Range struct {
+	Min int64
+	Max int64
+}
+
+// Scan implements the sql.Scanner interface
+func (r *Int64Range) Scan(val interface{}) error {
+	if val == nil {
+		return errors.New("cannot scan NULL into *Int64Range")
+	}
+	var (
+		err      error
+		min, max []byte
+	)
+	min, max, err = readDiscreteRange(val.([]byte))
+	if err != nil {
+		return err
+	}
+	r.Min, err = strconv.ParseInt(string(min), 10, 64)
+	if err != nil {
+		return err
+	}
+	r.Max, err = strconv.ParseInt(string(max), 10, 64)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// String returns a string representation of this range
+func (r Int64Range) String() string {
+	return fmt.Sprintf("[%d, %d)", r.Min, r.Max)
+}

--- a/ranges/int64range_test.go
+++ b/ranges/int64range_test.go
@@ -1,0 +1,19 @@
+package ranges
+
+import (
+	"testing"
+)
+
+func TestInt64RangeString(t *testing.T) {
+	test := func(min, max int64, expect string) {
+		s := Int64Range{min, max}.String()
+		if s != expect {
+			t.Errorf("expected '%s', got '%s'", expect, s)
+		}
+	}
+
+	test(0, 2, "[0,2)")
+	test(0, 0, "[0,0)")
+	test(-2, 8, "[-2,8)")
+	test(8, -2, "[8,-2)")
+}

--- a/ranges/parsing.go
+++ b/ranges/parsing.go
@@ -1,0 +1,101 @@
+package ranges
+
+import (
+	"fmt"
+)
+
+func readDigits(buf []byte, pos int) ([]byte, int, error) {
+	var s []byte
+	for pos < len(buf) && buf[pos] >= 48 && buf[pos] <= 57 {
+		s = append(s, buf[pos])
+		pos++
+	}
+	if len(s) == 0 {
+		return s, pos, fmt.Errorf("unexpected end of input at position %d", pos)
+	}
+	return s, pos, nil
+}
+
+func readInteger(buf []byte, pos int) ([]byte, int, error) {
+	var s []byte
+	if pos < len(buf) && buf[pos] == '-' {
+		s = append(s, '-')
+		pos++
+	}
+	digs, pos, err := readDigits(buf, pos)
+	if err != nil {
+		return nil, pos, err
+	}
+	return append(s, digs...), pos, nil
+}
+
+func readFloat(buf []byte, pos int) ([]byte, int, error) {
+	s, pos, err := readInteger(buf, pos)
+	if err != nil {
+		return nil, pos, err
+	}
+
+	if pos < len(buf) && buf[pos] == '.' {
+		var digs []byte
+
+		s = append(s, '.')
+		pos++
+
+		digs, pos, err = readDigits(buf, pos)
+		if err != nil {
+			return nil, pos, err
+		}
+		s = append(s, digs...)
+	}
+
+	return s, pos, nil
+}
+
+func readSeparator(buf []byte, pos int) (int, error) {
+	if pos >= len(buf) {
+		return pos, fmt.Errorf("unexpected end of input at position %d", pos)
+	}
+	if buf[pos] != ',' {
+		return pos, fmt.Errorf("unexpected character '%c' at position %d", buf[pos], pos)
+	}
+	return pos + 1, nil
+}
+
+func readRangeBound(buf []byte, pos int, incl, excl byte) (bool, int, error) {
+	if pos >= len(buf) {
+		return false, 0, fmt.Errorf("unexpected end of input at position %d", pos)
+	}
+	switch buf[pos] {
+	case incl:
+		return true, pos + 1, nil
+	case excl:
+		return false, pos + 1, nil
+	default:
+		return false, pos, fmt.Errorf("unexpected character '%c' at position %d", buf[pos], pos)
+	}
+}
+
+func readFloatRange(buf []byte) (minIncl bool, maxIncl bool, min []byte, max []byte, err error) {
+	var pos int
+	minIncl, pos, err = readRangeBound(buf, pos, '[', '(')
+	if err != nil {
+		return
+	}
+	min, pos, err = readFloat(buf, pos)
+	if err != nil {
+		return
+	}
+	pos, err = readSeparator(buf, pos)
+	if err != nil {
+		return
+	}
+	max, pos, err = readFloat(buf, pos)
+	if err != nil {
+		return
+	}
+	maxIncl, pos, err = readRangeBound(buf, pos, ']', ')')
+	if err != nil {
+		return
+	}
+	return
+}

--- a/ranges/parsing.go
+++ b/ranges/parsing.go
@@ -33,11 +33,11 @@ func readNumber(buf []byte, pos int) ([]byte, int, error) {
 	return s, pos, nil
 }
 
-func readSeparator(buf []byte, pos int) (int, error) {
+func readByte(buf []byte, pos int, expect byte) (int, error) {
 	if pos >= len(buf) {
 		return pos, fmt.Errorf("unexpected end of input at position %d", pos)
 	}
-	if buf[pos] != ',' {
+	if buf[pos] != expect {
 		return pos, fmt.Errorf("unexpected character '%c' at position %d", buf[pos], pos)
 	}
 	return pos + 1, nil
@@ -67,7 +67,7 @@ func readRange(buf []byte) (minIncl bool, maxIncl bool, min []byte, max []byte, 
 	if err != nil {
 		return
 	}
-	pos, err = readSeparator(buf, pos)
+	pos, err = readByte(buf, pos, ',')
 	if err != nil {
 		return
 	}
@@ -76,6 +76,31 @@ func readRange(buf []byte) (minIncl bool, maxIncl bool, min []byte, max []byte, 
 		return
 	}
 	maxIncl, pos, err = readRangeBound(buf, pos, ']', ')')
+	if err != nil {
+		return
+	}
+	return
+}
+
+func readDiscreteRange(buf []byte) (min []byte, max []byte, err error) {
+	var pos int
+	pos, err = readByte(buf, pos, '[')
+	if err != nil {
+		return
+	}
+	min, pos, err = readNumber(buf, pos)
+	if err != nil {
+		return
+	}
+	pos, err = readByte(buf, pos, ',')
+	if err != nil {
+		return
+	}
+	max, pos, err = readNumber(buf, pos)
+	if err != nil {
+		return
+	}
+	pos, err = readByte(buf, pos, ')')
 	if err != nil {
 		return
 	}

--- a/ranges/parsing_test.go
+++ b/ranges/parsing_test.go
@@ -1,0 +1,39 @@
+package ranges
+
+import (
+	"testing"
+)
+
+func TestReadFloatRange(t *testing.T) {
+	cases := []struct {
+		Input string
+		MinIn bool
+		MaxIn bool
+		Min   string
+		Max   string
+	}{
+		{"[-1.23,98.0]", true, true, "-1.23", "98.0"},
+		{"(1,2]", false, true, "1", "2"},
+		{"[0,0.0]", true, true, "0", "0.0"},
+		{"(1.29,-0.5)", false, false, "1.29", "-0.5"},
+	}
+
+	for _, tc := range cases {
+		minIn, maxIn, min, max, err := readFloatRange([]byte(tc.Input))
+		if err != nil {
+			t.Fatalf("unexpected error: " + err.Error())
+		}
+		if minIn != tc.MinIn {
+			t.Fatalf("expected min to be inclusive=%t, got %t", tc.MinIn, minIn)
+		}
+		if maxIn != tc.MaxIn {
+			t.Fatalf("expected max to be inclusive=%t, got %t", tc.MaxIn, maxIn)
+		}
+		if string(min) != tc.Min {
+			t.Fatalf("expected min to be '%s', got '%s'", tc.Min, min)
+		}
+		if string(max) != tc.Max {
+			t.Fatalf("expected max to be '%s', got '%s'", tc.Max, max)
+		}
+	}
+}

--- a/ranges/parsing_test.go
+++ b/ranges/parsing_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestReadFloatRange(t *testing.T) {
+func TestReadRange(t *testing.T) {
 	cases := []struct {
 		Input string
 		MinIn bool
@@ -19,7 +19,7 @@ func TestReadFloatRange(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		minIn, maxIn, min, max, err := readFloatRange([]byte(tc.Input))
+		minIn, maxIn, min, max, err := readRange([]byte(tc.Input))
 		if err != nil {
 			t.Fatalf("unexpected error: " + err.Error())
 		}


### PR DESCRIPTION
- The `Int32Range` and `Int64Range` can be used for reading/writing `int4range` and `int8range` values, respectively
- The `Float64Range` is useful for reading/writing `numrange` values, when possible loss of precision is not of concern.

I'm not yet sure what would be a good way of handling the `numrange` type. Maybe by treating the min/max values as strings?