### PR TITLE
Avoid goroutine leak on error in query with context

### DIFF
--- a/conn_go18.go
+++ b/conn_go18.go
@@ -19,6 +19,9 @@ func (cn *conn) QueryContext(ctx context.Context, query string, args []driver.Na
 	finish := cn.watchCancel(ctx)
 	r, err := cn.query(query, list)
 	if err != nil {
+		if finish != nil {
+			finish()
+		}
 		return nil, err
 	}
 	r.finish = finish


### PR DESCRIPTION
Fixes #617. Finish watching the context in case of error, thus preventing a goroutine leak on every failed QueryContext call.