### PR TITLE
Inform user of unsupported scram auth method

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1132,6 +1132,8 @@ func (cn *conn) auth(r *readBuf, o values) {
 		if r.int32() != 0 {
 			errorf("unexpected authentication response: %q", t)
 		}
+	case 10:
+		errorf("Server requests scram authentication method. The pq driver does not support this.")
 	default:
 		errorf("unknown authentication response: %d", code)
 	}


### PR DESCRIPTION
SCRAM-SHA-256 was [introduced](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=818fd4a67d610991757b610755e3065fb99d80a5) as an authentication method into
PostgreSQL 10.

Currently if users connect to a PostgreSQL 10 cluster which has SCRAM authentication enabled (which is not the default) the current error message is:

```
panic: pq: unknown authentication response: 10
```

This change will still cause the connection to fail, but with a more meaningful error message:

```
panic: pq: Server requests scram authentication method. The pq driver does not support this.
```