### PR TITLE
Don't auto-close on final CopyIn Exec() and don't return invalid Result

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -229,7 +229,7 @@ func (ci *copyin) Exec(v []driver.Value) (r driver.Result, err error) {
 	}
 
 	if len(v) == 0 {
-		return nil, ci.Close()
+		return driver.RowsAffected(0), nil
 	}
 
 	numValues := len(v)

--- a/doc.go
+++ b/doc.go
@@ -152,12 +152,10 @@ Bulk imports
 
 You can perform bulk imports by preparing a statement returned by pq.CopyIn (or
 pq.CopyInSchema) in an explicit transaction (sql.Tx). The returned statement
-handle can then be repeatedly "executed" to copy data into the target table.
-After all data has been processed you should call Exec() once with no arguments
-to flush all buffered data. Any call to Exec() might return an error which
-should be handled appropriately, but because of the internal buffering an error
-returned by Exec() might not be related to the data passed in the call that
-failed.
+handle can then be repeatedly "executed" to copy data into the target table. Any
+call to Exec() might return an error which should be handled appropriately, but
+because of the internal buffering an error returned by Exec() might not be
+related to the data passed in the call that failed.
 
 CopyIn uses COPY FROM internally. It is not possible to COPY outside of an
 explicit transaction in pq.
@@ -179,11 +177,6 @@ Usage example:
 		if err != nil {
 			log.Fatal(err)
 		}
-	}
-
-	_, err = stmt.Exec()
-	if err != nil {
-		log.Fatal(err)
 	}
 
 	err = stmt.Close()


### PR DESCRIPTION
The docs suggest a final empty `stmt.Exec()` at the end of a CopyIn operation
however this is no longer strictly required (as discussed in #444).

This resolves #444 by not auto-closing on an empty `stmt.Exec()` and by fixing
the docs. Code that performs an empty `stmt.Exec()` will continue to work
properly as long as there is an explicit `stmt.Close()` which is already
required by the `database/sql` API anyway.

It also resolves #626 in case any code actually uses the `sql.Result` returned
by an empty `stmt.Exec()`.