### PR TITLE
Add support for NamedValueChecker interface

### DIFF
--- a/array.go
+++ b/array.go
@@ -20,6 +20,7 @@ var typeSQLScanner = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
 //
 // For example:
 //  db.Query(`SELECT * FROM t WHERE id = ANY($1)`, pq.Array([]int{235, 401}))
+//  db.Query(`SELECT * FROM t WHERE id = ANY($1)`, []int{235, 401}) // go1.9+
 //
 //  var x []sql.NullInt64
 //  db.QueryRow('SELECT ARRAY[235, 401]').Scan(pq.Array(&x))

--- a/conn_go19.go
+++ b/conn_go19.go
@@ -1,0 +1,27 @@
+// +build go1.9
+
+package pq
+
+import (
+	"database/sql/driver"
+	"reflect"
+)
+
+func (c *conn) CheckNamedValue(nv *driver.NamedValue) (err error) {
+	if _, ok := nv.Value.(driver.Valuer); ok {
+		// Ignore Valuer, for backward compatiblity with pq.Array()
+		return driver.ErrSkip
+	}
+
+	// Ignoring []byte / []uint8
+	if _, ok := nv.Value.([]uint8); ok {
+		return driver.ErrSkip
+	}
+
+	if k := reflect.ValueOf(nv.Value).Kind(); k == reflect.Array || k == reflect.Slice {
+		nv.Value, err = Array(nv.Value).Value()
+		return err
+	}
+
+	return driver.ErrSkip
+}

--- a/conn_go19_test.go
+++ b/conn_go19_test.go
@@ -1,0 +1,37 @@
+// +build go1.9
+
+package pq
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestArrayArg(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	expected := []int64{245, 231}
+
+	r, err := db.Query("SELECT $1::int[]", expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	if !r.Next() {
+		if r.Err() != nil {
+			t.Fatal(r.Err())
+		}
+		t.Fatal("expected row")
+	}
+
+	var i []int64
+	if err := r.Scan(Array(&i)); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(i, expected) {
+		t.Errorf("expect %v, got %v", expected, i)
+	}
+}


### PR DESCRIPTION
Add support for the new [NamedValueChecker](https://tip.golang.org/pkg/database/sql/driver/#NamedValueChecker) interface available in go 1.9.

This will allow to pass an array or a slice directly as an argument.