### PR TITLE
Check code with megacheck

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -70,4 +70,19 @@ postgresql_uninstall() {
 	sudo rm -rf /var/lib/postgresql
 }
 
+megacheck_install() {
+	# Megacheck is Go 1.6+, so skip if Go 1.5.
+	if [[ "$(go version)" =~ "go1.5" ]]
+	then
+		echo "megacheck not supported, skipping installation"
+		return 0
+	fi
+	# Lock megacheck version at $MEGACHECK_VERSION to prevent spontaneous
+	# new error messages in old code.
+	go get -d honnef.co/go/tools/...
+	git -C $GOPATH/src/honnef.co/go/tools/ checkout $MEGACHECK_VERSION
+	go install honnef.co/go/tools/cmd/megacheck
+	megacheck --version
+}
+
 $1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - PQGOSSLTESTS=1
     - PQSSLCERTTEST_PATH=$PWD/certs
     - PGHOST=127.0.0.1
+    - MEGACHECK_VERSION=2017.1
   matrix:
     - PGVERSION=9.6
     - PGVERSION=9.5
@@ -31,6 +32,7 @@ before_install:
   - ./.travis.sh postgresql_install
   - ./.travis.sh postgresql_configure
   - ./.travis.sh client_configure
+  - ./.travis.sh megacheck_install
   - go get golang.org/x/tools/cmd/goimports
 
 before_script:
@@ -42,5 +44,13 @@ script:
   - >
     goimports -d -e $(find -name '*.go') | awk '{ print } END { exit NR == 0 ? 0 : 1 }'
   - go vet ./...
+    # For compatibility with Go 1.5, launch only if megacheck is present,
+    # ignore SA1019 (deprecation warnings) in conn_test.go (we have to use the
+    # deprecated driver.Execer and driver.Queryer interfaces) and S1024
+    # (time.Until) everywhere.
+  - >
+    which megacheck > /dev/null
+    && megacheck -ignore 'github.com/lib/pq/conn_test.go:SA1019 github.com/lib/pq/*.go:S1024' ./...
+    || echo 'megacheck is not supported, skipping check'
   - PQTEST_BINARY_PARAMETERS=no  go test -race -v ./...
   - PQTEST_BINARY_PARAMETERS=yes go test -race -v ./...

--- a/array_test.go
+++ b/array_test.go
@@ -89,9 +89,7 @@ func TestParseArrayError(t *testing.T) {
 }
 
 func TestArrayScanner(t *testing.T) {
-	var s sql.Scanner
-
-	s = Array(&[]bool{})
+	var s sql.Scanner = Array(&[]bool{})
 	if _, ok := s.(*BoolArray); !ok {
 		t.Errorf("Expected *BoolArray, got %T", s)
 	}
@@ -126,9 +124,7 @@ func TestArrayScanner(t *testing.T) {
 }
 
 func TestArrayValuer(t *testing.T) {
-	var v driver.Valuer
-
-	v = Array([]bool{})
+	var v driver.Valuer = Array([]bool{})
 	if _, ok := v.(*BoolArray); !ok {
 		t.Errorf("Expected *BoolArray, got %T", v)
 	}
@@ -1193,9 +1189,7 @@ func TestGenericArrayValue(t *testing.T) {
 }
 
 func TestGenericArrayValueErrors(t *testing.T) {
-	var v []interface{}
-
-	v = []interface{}{func() {}}
+	v := []interface{}{func() {}}
 	if _, err := (GenericArray{v}).Value(); err == nil {
 		t.Errorf("Expected error for %q, got nil", v)
 	}

--- a/conn.go
+++ b/conn.go
@@ -149,11 +149,7 @@ func (cn *conn) handleDriverSettings(o values) (err error) {
 	if err != nil {
 		return err
 	}
-	err = boolSetting("binary_parameters", &cn.binaryParameters)
-	if err != nil {
-		return err
-	}
-	return nil
+	return boolSetting("binary_parameters", &cn.binaryParameters)
 }
 
 func (cn *conn) handlePgpass(o values) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1207,16 +1207,11 @@ func TestParseComplete(t *testing.T) {
 	tpc("SELECT foo", "", 0, true) // invalid row count
 }
 
-func TestExecerInterface(t *testing.T) {
-	// Gin up a straw man private struct just for the type check
-	cn := &conn{c: nil}
-	var cni interface{} = cn
-
-	_, ok := cni.(driver.Execer)
-	if !ok {
-		t.Fatal("Driver doesn't implement Execer")
-	}
-}
+// Test interface conformance.
+var (
+	_ driver.Execer  = (*conn)(nil)
+	_ driver.Queryer = (*conn)(nil)
+)
 
 func TestNullAfterNonNull(t *testing.T) {
 	db := openTestConn(t)

--- a/copy_test.go
+++ b/copy_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestCopyInStmt(t *testing.T) {
-	var stmt string
-	stmt = CopyIn("table name")
+	stmt := CopyIn("table name")
 	if stmt != `COPY "table name" () FROM STDIN` {
 		t.Fatal(stmt)
 	}
@@ -27,8 +26,7 @@ func TestCopyInStmt(t *testing.T) {
 }
 
 func TestCopyInSchemaStmt(t *testing.T) {
-	var stmt string
-	stmt = CopyInSchema("schema name", "table name")
+	stmt := CopyInSchema("schema name", "table name")
 	if stmt != `COPY "schema name"."table name" () FROM STDIN` {
 		t.Fatal(stmt)
 	}
@@ -226,7 +224,7 @@ func TestCopyInTypes(t *testing.T) {
 	if text != "Héllö\n ☃!\r\t\\" {
 		t.Fatal("unexpected result", text)
 	}
-	if bytes.Compare(blob, []byte{0, 255, 9, 10, 13}) != 0 {
+	if !bytes.Equal(blob, []byte{0, 255, 9, 10, 13}) {
 		t.Fatal("unexpected result", blob)
 	}
 	if nothing.Valid {

--- a/encode_test.go
+++ b/encode_test.go
@@ -267,9 +267,7 @@ func TestTimestampWithOutTimezone(t *testing.T) {
 			t.Fatalf("Could not run query: %v", err)
 		}
 
-		n := r.Next()
-
-		if n != true {
+		if !r.Next() {
 			t.Fatal("Expected at least one row")
 		}
 
@@ -289,8 +287,7 @@ func TestTimestampWithOutTimezone(t *testing.T) {
 				expected, result)
 		}
 
-		n = r.Next()
-		if n != false {
+		if r.Next() {
 			t.Fatal("Expected only one row")
 		}
 	}
@@ -731,8 +728,7 @@ func TestAppendEscapedText(t *testing.T) {
 }
 
 func TestAppendEscapedTextExistingBuffer(t *testing.T) {
-	var buf []byte
-	buf = []byte("123\t")
+	buf := []byte("123\t")
 	if esc := appendEscapedText(buf, "hallo\tescape"); string(esc) != "123\thallo\\tescape" {
 		t.Fatal(string(esc))
 	}

--- a/notify.go
+++ b/notify.go
@@ -639,7 +639,7 @@ func (l *Listener) resync(cn *ListenerConn, notificationChan <-chan *Notificatio
 			// close and then return the error message from the connection, as
 			// per ListenerConn's interface.
 			if err != nil {
-				for _ = range notificationChan {
+				for range notificationChan {
 				}
 				doneChan <- cn.Err()
 				return


### PR DESCRIPTION
Fix everything we can without losing Go 1.5 compatibility. Add
megacheck, locked at 2017.1 release, and enabled for any version of Go
except Go 1.5, to the Travis scripts to check every PR.

Fixes #662.