### PR TITLE
Avoid potential runtime panic in connection initialization

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -161,11 +161,16 @@ func (cn *conn) handlePgpass(o values) {
 	if filename == "" {
 		// XXX this code doesn't work on Windows where the default filename is
 		// XXX %APPDATA%\postgresql\pgpass.conf
-		user, err := user.Current()
-		if err != nil {
-			return
+		// Prefer $HOME over user.Current due to glibc bug: golang.org/issue/13470
+		userHome := os.Getenv("HOME")
+		if userHome == "" {
+			user, err := user.Current()
+			if err != nil {
+				return
+			}
+			userHome = user.HomeDir
 		}
-		filename = filepath.Join(user.HomeDir, ".pgpass")
+		filename = filepath.Join(userHome, ".pgpass")
 	}
 	fileinfo, err := os.Stat(filename)
 	if err != nil {


### PR DESCRIPTION
Attempt to use `$HOME` to find the user's home directory to avoid calling `user.Current`, which can runtime panic due to a known glibc bug. This emulates the fix in https://go-review.googlesource.com/c/oauth2/+/34175, to work around http://golang.org/issue/13470 .