### PR TITLE
Add sql.Pinger implementation.

### DIFF
--- a/conn_go18.go
+++ b/conn_go18.go
@@ -83,10 +83,14 @@ func (cn *conn) Ping(ctx context.Context) error {
 
 	rows, err := cn.simpleQuery(`SELECT 'lib/pq ping test';`)
 	if err != nil {
-		return err
+		return driver.ErrBadConn
 	}
 
-	return rows.Close()
+	if err := rows.Close(); err != nil {
+		return driver.ErrBadConn
+	}
+	
+	return nil
 }
 
 func (cn *conn) watchCancel(ctx context.Context) func() {

--- a/conn_go18.go
+++ b/conn_go18.go
@@ -76,6 +76,19 @@ func (cn *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, 
 	return tx, nil
 }
 
+func (cn *conn) Ping(ctx context.Context) error {
+	if finish := cn.watchCancel(ctx); finish != nil {
+		defer finish()
+	}
+
+	rows, err := cn.simpleQuery(`SELECT 'lib/pq ping test';`)
+	if err != nil {
+		return err
+	}
+
+	return rows.Close()
+}
+
 func (cn *conn) watchCancel(ctx context.Context) func() {
 	if done := ctx.Done(); done != nil {
 		finished := make(chan struct{})

--- a/go18_test.go
+++ b/go18_test.go
@@ -317,3 +317,22 @@ func TestTxOptions(t *testing.T) {
 		t.Errorf("Expected error to mention isolation level, got %q", err)
 	}
 }
+
+func TestPing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	db := openTestConn(t)
+	defer db.Close()
+
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatal("expected success")
+	}
+
+	cancel()
+
+	if err := db.PingContext(ctx); err == nil {
+		t.Fatal("expected failure")
+	} else if err.Error() != "context canceled" {
+		t.Fatalf("expected canceled context: got %v", err)
+	}
+}


### PR DESCRIPTION
Executes a query `SELECT 'lib/pq ping test'` against the configured database.

Closes #533.