### PR TITLE
Update megacheck to 2017.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - PQGOSSLTESTS=1
     - PQSSLCERTTEST_PATH=$PWD/certs
     - PGHOST=127.0.0.1
-    - MEGACHECK_VERSION=2017.1
+    - MEGACHECK_VERSION=2017.2.1
   matrix:
     - PGVERSION=10
     - PGVERSION=9.6
@@ -46,15 +46,13 @@ script:
   - >
     goimports -d -e $(find -name '*.go') | awk '{ print } END { exit NR == 0 ? 0 : 1 }'
   - go vet ./...
-    # For compatibility with Go 1.5, launch only if megacheck is present,
-    # ignore SA1019 (deprecation warnings) in conn_test.go (we have to use the
-    # deprecated driver.Execer and driver.Queryer interfaces) and S1024
-    # (time.Until) everywhere.
+    # For compatibility with Go 1.5, launch only if megacheck is present.
   - >
-    which megacheck > /dev/null
-    && megacheck -ignore 'github.com/lib/pq/conn_test.go:SA1019 github.com/lib/pq/*.go:S1024' ./...
+    which megacheck > /dev/null && megacheck -go 1.5 ./...
     || echo 'megacheck is not supported, skipping check'
     # For compatibility with Go 1.5, launch only if golint is present.
-  - which golint > /dev/null && golint ./...  || echo 'golint is not supported, skipping check'
+  - >
+    which golint > /dev/null && golint ./...
+    || echo 'golint is not supported, skipping check'
   - PQTEST_BINARY_PARAMETERS=no  go test -race -v ./...
   - PQTEST_BINARY_PARAMETERS=yes go test -race -v ./...


### PR DESCRIPTION
This commit updates the megacheck version to 2017.2.1. No new issues were found. It also replaces explicit checks ignoring with the -go 1.5 flag.