### PR TITLE
Fix deadlock in Listener.resync

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -637,7 +637,7 @@ func (l *Listener) disconnectCleanup() error {
 // after the connection has been established.
 func (l *Listener) resync(cn *ListenerConn, notificationChan <-chan *Notification) error {
 	doneChan := make(chan error)
-	go func() {
+	go func(notificationChan <-chan *Notification) {
 		for channel := range l.channels {
 			// If we got a response, return that error to our caller as it's
 			// going to be more descriptive than cn.Err().
@@ -658,7 +658,7 @@ func (l *Listener) resync(cn *ListenerConn, notificationChan <-chan *Notificatio
 			}
 		}
 		doneChan <- nil
-	}()
+	}(notificationChan)
 
 	// Ignore notifications while synchronization is going on to avoid
 	// deadlocks.  We have to send a nil notification over Notify anyway as


### PR DESCRIPTION
Listener.resync can execute in a fashion where notificationChan equals nil in the anonymous inner function. This leads to a deadlock if the function tries to range over notificationChan.

Fixes #699