### PR TITLE
Stop testing with go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.5.x
   - 1.6.x
   - 1.7.x
   - 1.8.x


### PR DESCRIPTION
The correct fix for this would involve removing all the Go 1.5 stuff in the `script` block, but I'm not going to allocate time to that currently. For now, this should unbreak all of the PR build failures.