### PR TITLE
Fix Listen() hanging indefinitely when listener is closed

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -725,6 +725,9 @@ func (l *Listener) Close() error {
 	}
 	l.isClosed = true
 
+	// Unblock calls to Listen()
+	l.reconnectCond.Broadcast()
+
 	return nil
 }
 


### PR DESCRIPTION
If a Listener is in the middle of reconnecting (eg, because the server name is incorrect) and Listener.Close() is called, any outstanding calls to Listener.Listen() will hang indefinitely as it waits for Listener.reconnectCond.

This simple PR triggers a reconnectCond broadcast at the end of Listener.Close() which unblocks any outstanding calls to Listener.Listen() to allow proper cleanup to occur.