### PR TITLE
Add multihost connstring support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ env:
     - PGVERSION=9.5
     - PGVERSION=9.4
     - PGVERSION=9.3
-    - PGVERSION=9.2
-    - PGVERSION=9.1
-    - PGVERSION=9.0
 
 before_install:
   - ./.travis.sh postgresql_uninstall

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ before_install:
   - ./.travis.sh postgresql_uninstall
   - ./.travis.sh pgdg_repository
   - ./.travis.sh postgresql_install
-  - ./.travis.sh postgresql_configure
+  - ./.travis.sh postgresql_configure primary
+  - ./.travis.sh postgresql_configure secondary
   - ./.travis.sh client_configure
   - ./.travis.sh megacheck_install
   - ./.travis.sh golint_install

--- a/url.go
+++ b/url.go
@@ -55,12 +55,21 @@ func ParseURL(url string) (string, error) {
 		accrue("password", v)
 	}
 
-	if host, port, err := net.SplitHostPort(u.Host); err != nil {
-		accrue("host", u.Host)
-	} else {
-		accrue("host", host)
-		accrue("port", port)
+	// handle non-standard "host1:port1,host2:port2" format
+	// (for feature parity with libpq >= 10)
+	hostports := strings.Split(u.Host, ",")
+	hosts := make([]string, 0, len(hostports))
+	ports := make([]string, 0, len(hostports))
+	for _, hostport := range hostports {
+		if host, port, err := net.SplitHostPort(hostport); err != nil {
+			hosts = append(hosts, hostport)
+		} else {
+			hosts = append(hosts, host)
+			ports = append(ports, port)
+		}
 	}
+	accrue("host", strings.Join(hosts, ","))
+	accrue("port", strings.Join(ports, ","))
 
 	if u.Path != "" {
 		accrue("dbname", u.Path[1:])

--- a/url_test.go
+++ b/url_test.go
@@ -64,3 +64,41 @@ func TestMinimalURL(t *testing.T) {
 		t.Fatalf("expected blank connection string, got: %q", cs)
 	}
 }
+
+func TestParseURLMultipleHosts(t *testing.T) {
+	expected := "host=host1,host2"
+	str, err := ParseURL("postgres://host1,host2/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if str != expected {
+		t.Fatalf("unexpected result from ParseURL:\n+ %v\n- %v", str, expected)
+	}
+}
+
+func TestParseURLMultipleHostsMultiplePorts(t *testing.T) {
+	expected := "host=host1,host2 port=15432,25432"
+	str, err := ParseURL("postgres://host1:15432,host2:25432/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if str != expected {
+		t.Fatalf("unexpected result from ParseURL:\n+ %v\n- %v", str, expected)
+	}
+}
+
+func TestParseURLMultipleHostsSinglePort(t *testing.T) {
+	expected := "host=host1,host2 port=5432"
+	for _, input := range []string{"postgres://host1,host2:5432/", "postgres://host1:5432,host2/"} {
+		str, err := ParseURL(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if str != expected {
+			t.Fatalf("unexpected result from ParseURL:\n+ %v\n- %v", str, expected)
+		}
+	}
+}


### PR DESCRIPTION
This PR is a first attempt at supporting the newer multi-host features of libpq 10.
It adds support for providing multiple hosts in the connstring (either URL or `key=value` form) and also for the `target_session_attrs` connection parameter.

It includes a few noteworthy changes, which could use some further scrutiny:

1. expanded the travis setup script to also set up a secondary node in replication mode.
2. dropped testing for [unsupported postgres versions](https://www.postgresql.org/support/versioning/). This was needed to keep the primary/secondary testing setup simple, since older versions lack `pg_basebackup`. This decision can be revisited, if testing for older versions is still deemed necessary (or the patch can be split into a separate PR)
3. analogously to [libpq](https://github.com/postgres/postgres/blob/REL_10_1/src/interfaces/libpq/fe-connect.c#L1861), we loop over the different hosts to attempt connections. We accumulate errors and return a new `errorSlice`, which also implements the `error` interface. To keep backwards compatibility for people expecting specific error types, a special case for `len(hosts)==1` was added.
4. for each connection attempt, if the client requested it, we check if the server is in `read-write` mode. For this, we also follow [libpq's example](https://github.com/postgres/postgres/blob/REL_10_1/src/interfaces/libpq/fe-connect.c#L2992) and execute a `simpleQuery` during connection establishment, checking the output of `SHOW transaction_read_only`.
5. lastly, the `TestOpenURL` test was changed to *not* start a transaction, instead executing a `SHOW server_version`. This is needed for testing connections to the secondary node.

PTAL

fixes #683