### PR TITLE
Add QuoteLiteral function

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1466,6 +1466,25 @@ func QuoteIdentifier(name string) string {
 	return `"` + strings.Replace(name, `"`, `""`, -1) + `"`
 }
 
+// QuoteLiteral quotes a string literal to be used as part of an SQL statement.
+// It's useful with SQL statements that don't support parametrization.
+// For example:
+//
+// quoted := pq.QuoteLiteral("secret")
+// err := db.Exec(fmt.Sprintf("CREATE USER foo PASSWORD %s", quoted))
+//
+// Any single quotes and backslashes in value will be escaped. If value contains
+// at least one backslash, "E" prefix will be prepended.
+func QuoteLiteral(value string) string {
+	prefix := ""
+	if strings.Contains(value, `\`) {
+		prefix = "E"
+	}
+	value = strings.Replace(value, "'", "''", -1)
+	value = strings.Replace(value, `\`, `\\`, -1)
+	return prefix + "'" + value + "'"
+}
+
 func md5s(s string) string {
 	h := md5.New()
 	h.Write([]byte(s))

--- a/conn_test.go
+++ b/conn_test.go
@@ -1549,6 +1549,27 @@ func TestQuoteIdentifier(t *testing.T) {
 	}
 }
 
+func TestQuoteLiteral(t *testing.T) {
+	var cases = []struct {
+		input string
+		want  string
+	}{
+		{`foo`, `'foo'`},
+		{`foo'bar`, `'foo''bar'`},
+		{`foo'bar'baz`, `'foo''bar''baz'`},
+		{`foo"bar`, `'foo"bar'`},
+		{`foo\bar`, `E'foo\\bar'`},
+		{`foo\bar'baz`, `E'foo\\bar''baz'`},
+	}
+
+	for _, test := range cases {
+		got := QuoteLiteral(test.input)
+		if got != test.want {
+			t.Errorf("QuoteLiteral(%q) = %v want %v", test.input, got, test.want)
+		}
+	}
+}
+
 func TestRowsResultTag(t *testing.T) {
 	type ResultTag interface {
 		Result() driver.Result


### PR DESCRIPTION
This PR adds `QuoteLiteral` function that can be useful with SQL statements that don't support parametrization. The problem is discussed here: #426.