### PR TITLE
Fix failing builds

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -304,11 +304,9 @@ func TestInfinityTimestamp(t *testing.T) {
 	var err error
 	var resultT time.Time
 
-	expectedErrorStrRegexp, err := regexp.Compile(
+	expectedErrorStrRegexp := regexp.MustCompile(
 		`^sql: Scan error on column index 0(, name "timestamp(tz)?"|): unsupported`)
-	if err != nil {
-		t.Fatal("Error parsing expected error regexp")
-	}
+
 	type testCases []struct {
 		Query                  string
 		Param                  string

--- a/encode_test.go
+++ b/encode_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"strings"
+	"regexp"
 	"testing"
 	"time"
 
@@ -304,24 +304,29 @@ func TestInfinityTimestamp(t *testing.T) {
 	var err error
 	var resultT time.Time
 
-	expectedErrorStrPrefix := `sql: Scan error on column index 0: unsupported`
+	expectedErrorStrRegexp, err := regexp.Compile(
+		`^sql: Scan error on column index 0(, name "timestamp"|): unsupported`)
+	if err != nil {
+		t.Fatal("Error parsing expected error regexp")
+	}
 	type testCases []struct {
-		Query                string
-		Param                string
-		ExpectedErrStrPrefix string
-		ExpectedVal          interface{}
+		Query                  string
+		Param                  string
+		ExpectedErrorStrRegexp *regexp.Regexp
+		ExpectedVal            interface{}
 	}
 	tc := testCases{
-		{"SELECT $1::timestamp", "-infinity", expectedErrorStrPrefix, "-infinity"},
-		{"SELECT $1::timestamptz", "-infinity", expectedErrorStrPrefix, "-infinity"},
-		{"SELECT $1::timestamp", "infinity", expectedErrorStrPrefix, "infinity"},
-		{"SELECT $1::timestamptz", "infinity", expectedErrorStrPrefix, "infinity"},
+		{"SELECT $1::timestamp", "-infinity", expectedErrorStrRegexp, "-infinity"},
+		{"SELECT $1::timestamptz", "-infinity", expectedErrorStrRegexp, "-infinity"},
+		{"SELECT $1::timestamp", "infinity", expectedErrorStrRegexp, "infinity"},
+		{"SELECT $1::timestamptz", "infinity", expectedErrorStrRegexp, "infinity"},
 	}
 	// try to assert []byte to time.Time
 	for _, q := range tc {
 		err = db.QueryRow(q.Query, q.Param).Scan(&resultT)
-		if !strings.HasPrefix(err.Error(), q.ExpectedErrStrPrefix) {
-			t.Errorf("Scanning -/+infinity, expected error to have prefix %q, got %q", q.ExpectedErrStrPrefix, err)
+		if !q.ExpectedErrorStrRegexp.MatchString(err.Error()) {
+			t.Errorf("Scanning -/+infinity, expected error to match regexp %q, got %q",
+				q.ExpectedErrorStrRegexp, err)
 		}
 	}
 	// yield []byte

--- a/encode_test.go
+++ b/encode_test.go
@@ -305,7 +305,7 @@ func TestInfinityTimestamp(t *testing.T) {
 	var resultT time.Time
 
 	expectedErrorStrRegexp, err := regexp.Compile(
-		`^sql: Scan error on column index 0(, name "timestamp"|): unsupported`)
+		`^sql: Scan error on column index 0(, name "timestamp(tz)?"|): unsupported`)
 	if err != nil {
 		t.Fatal("Error parsing expected error regexp")
 	}


### PR DESCRIPTION
Builds are [failing](https://travis-ci.org/lib/pq/jobs/351414509) now because of the following issue: `TestInfinityTimestamp` expects the error message to start with `sql: Scan error on column index 0: unsupported`, but in the latest version of Go, the message is `sql: Scan error on column index 0, name "timestamp": unsupported`.

Please see this commit: https://github.com/golang/go/commit/8da7706bb4dc609689fd69e196ddaa800908c31f

This PR updates `TestInfinityTimestamp` to support both error messages.


