### PR TITLE
Don't panic in SSL code

### DIFF
--- a/conn_go18.go
+++ b/conn_go18.go
@@ -108,7 +108,10 @@ func (cn *conn) cancel() error {
 		can := conn{
 			c: c,
 		}
-		can.ssl(cn.opts)
+		err = can.ssl(cn.opts)
+		if err != nil {
+			return err
+		}
 
 		w := can.writeBuf(0)
 		w.int32(80877102) // cancel request code

--- a/error.go
+++ b/error.go
@@ -460,6 +460,11 @@ func errorf(s string, args ...interface{}) {
 	panic(fmt.Errorf("pq: %s", fmt.Sprintf(s, args...)))
 }
 
+// TODO(ainar-g) Rename to errorf after removing panics.
+func fmterrorf(s string, args ...interface{}) error {
+	return fmt.Errorf("pq: %s", fmt.Sprintf(s, args...))
+}
+
 func errRecoverNoErrBadConn(err *error) {
 	e := recover()
 	if e == nil {


### PR DESCRIPTION
This change removes panics from SSL code. This is a part of the ongoing process of removing panics from lib/pq code.

Refs #681.