### PR TITLE
fix NullTime.Scan(value) parsing if value is []uint8

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -590,7 +590,17 @@ type NullTime struct {
 
 // Scan implements the Scanner interface.
 func (nt *NullTime) Scan(value interface{}) error {
-	nt.Time, nt.Valid = value.(time.Time)
+	switch typed := value.(type) {
+	case []uint8:
+		var parse_err error
+		nt.Time, parse_err = ParseTimestamp(nil, string(typed))
+		nt.Valid = parse_err == nil
+		return parse_err
+	case time.Time:
+		nt.Time = typed
+		nt.Valid = true
+		return nil
+	}
 	return nil
 }
 


### PR DESCRIPTION
Recently I found that code with field pq.NullTime works incorrect - it doesn't write right value from DB(DB field TIMESTAMP WITH TIME ZONE, nullable). So if there is a field in DB with date, NullTime parses it like {"Time":"0001-01-01T00:00:00Z","Valid":false}.
After debug I found that interface type of value in NullTime.Scan has []uint8 type, and after casting to string it can be parsed as postgres data with already exist method PasreTimestamp. And previous code doesn't work because []uint8 cannot be casted to time.Time.
I don't know how it worked before(maybe the case in Go version), but in my enviroment: Go1.10.1, Postgres 9.4 && Postgres 9.6 there was a bug that I fixed for my code and created Pull Request.
Changes are backward-compatible. (if value has []uint8 - use ParseTimetamp, if time.Time - just cast as it was).