### PR TITLE
Add length support for bit and varbit type

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lib/pq/oid"
+	"github.com/pf-qiu/pq/oid"
 )
 
 var (

--- a/buf.go
+++ b/buf.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/lib/pq/oid"
+	"github.com/pf-qiu/pq/oid"
 )
 
 type readBuf []byte

--- a/conn.go
+++ b/conn.go
@@ -19,7 +19,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/lib/pq/oid"
+	"github.com/pf-qiu/pq/oid"
 )
 
 // Common error types

--- a/doc.go
+++ b/doc.go
@@ -7,7 +7,7 @@ using this package directly. For example:
 	import (
 		"database/sql"
 
-		_ "github.com/lib/pq"
+		_ "github.com/pf-qiu/pq"
 	)
 
 	func main() {
@@ -239,7 +239,7 @@ for more information).  Note that the channel name will be truncated to 63
 bytes by the PostgreSQL server.
 
 You can find a complete, working example of Listener usage at
-http://godoc.org/github.com/lib/pq/example/listen.
+http://godoc.org/github.com/pf-qiu/pq/example/listen.
 
 */
 package pq

--- a/encode.go
+++ b/encode.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lib/pq/oid"
+	"github.com/pf-qiu/pq/oid"
 )
 
 func binaryEncode(parameterStatus *parameterStatus, x interface{}) []byte {

--- a/encode_test.go
+++ b/encode_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lib/pq/oid"
+	"github.com/pf-qiu/pq/oid"
 )
 
 func TestScanTimestamp(t *testing.T) {

--- a/example/listen/doc.go
+++ b/example/listen/doc.go
@@ -22,7 +22,7 @@ mechanism to avoid polling the database while waiting for more work to arrive.
         "fmt"
         "time"
 
-        "github.com/lib/pq"
+        "github.com/pf-qiu/pq"
     )
 
     func doWork(db *sql.DB, work int64) {

--- a/hstore/hstore_test.go
+++ b/hstore/hstore_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/lib/pq"
+	_ "github.com/pf-qiu/pq"
 )
 
 type Fatalistic interface {

--- a/oid/gen.go
+++ b/oid/gen.go
@@ -12,7 +12,7 @@ import (
 	"os/exec"
 	"strings"
 
-	_ "github.com/lib/pq"
+	_ "github.com/pf-qiu/pq"
 )
 
 // OID represent a postgres Object Identifier Type.

--- a/rows.go
+++ b/rows.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/lib/pq/oid"
+	"github.com/pf-qiu/pq/oid"
 )
 
 const headerSize = 4
@@ -29,7 +29,7 @@ func (fd fieldDesc) Type() reflect.Type {
 		return reflect.TypeOf(int32(0))
 	case oid.T_int2:
 		return reflect.TypeOf(int16(0))
-	case oid.T_varchar, oid.T_text:
+	case oid.T_varchar, oid.T_text, oid.T_varbit, oid.T_bit:
 		return reflect.TypeOf("")
 	case oid.T_bool:
 		return reflect.TypeOf(false)
@@ -52,6 +52,8 @@ func (fd fieldDesc) Length() (length int64, ok bool) {
 		return math.MaxInt64, true
 	case oid.T_varchar, oid.T_bpchar:
 		return int64(fd.Mod - headerSize), true
+	case oid.T_varbit, oid.T_bit:
+		return int64(fd.Mod), true
 	default:
 		return 0, false
 	}

--- a/rows_test.go
+++ b/rows_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/lib/pq/oid"
+	"github.com/pf-qiu/pq/oid"
 )
 
 func TestDataTypeName(t *testing.T) {
@@ -20,6 +20,8 @@ func TestDataTypeName(t *testing.T) {
 		{oid.T_int2, "INT2"},
 		{oid.T_varchar, "VARCHAR"},
 		{oid.T_text, "TEXT"},
+		{oid.T_bit, "BIT"},
+		{oid.T_varbit, "VARBIT"},
 		{oid.T_bool, "BOOL"},
 		{oid.T_numeric, "NUMERIC"},
 		{oid.T_date, "DATE"},
@@ -48,6 +50,8 @@ func TestDataType(t *testing.T) {
 		{oid.T_int2, reflect.Int16},
 		{oid.T_varchar, reflect.String},
 		{oid.T_text, reflect.String},
+		{oid.T_bit, reflect.String},
+		{oid.T_varbit, reflect.String},
 		{oid.T_bool, reflect.Bool},
 		{oid.T_date, reflect.Struct},
 		{oid.T_time, reflect.Struct},
@@ -77,6 +81,8 @@ func TestDataTypeLength(t *testing.T) {
 		{oid.T_varchar, 65535, 9, 5, true},
 		{oid.T_text, 65535, -1, math.MaxInt64, true},
 		{oid.T_bytea, 65535, -1, math.MaxInt64, true},
+		{oid.T_bit, 0, 10, 10, true},
+		{oid.T_varbit, 0, 10, 10, true},
 	}
 
 	for i, tt := range tts {
@@ -169,13 +175,53 @@ func TestRowsColumnTypes(t *testing.T) {
 				OK:        false,
 			},
 			ScanType: reflect.TypeOf(""),
+		}, {
+			Name:     "bit4",
+			TypeName: "BIT",
+			Length: struct {
+				Len int64
+				OK  bool
+			}{
+				Len: 4,
+				OK:  true,
+			},
+			DecimalSize: struct {
+				Precision int64
+				Scale     int64
+				OK        bool
+			}{
+				Precision: 0,
+				Scale:     0,
+				OK:        false,
+			},
+			ScanType: reflect.TypeOf(""),
+		}, {
+			Name:     "varbit10",
+			TypeName: "VARBIT",
+			Length: struct {
+				Len int64
+				OK  bool
+			}{
+				Len: 10,
+				OK:  true,
+			},
+			DecimalSize: struct {
+				Precision int64
+				Scale     int64
+				OK        bool
+			}{
+				Precision: 0,
+				Scale:     0,
+				OK:        false,
+			},
+			ScanType: reflect.TypeOf(""),
 		},
 	}
 
 	db := openTestConn(t)
 	defer db.Close()
 
-	rows, err := db.Query("SELECT 1 AS a, text 'bar' AS bar, 1.28::numeric(9, 2) AS dec")
+	rows, err := db.Query("SELECT 1 AS a, text 'bar' AS bar, '1111'::bit(4) as bit4, '1111'::varbit(10) as varbit10, 1.28::numeric(9, 2) AS dec")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,8 +230,8 @@ func TestRowsColumnTypes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(columns) != 3 {
-		t.Errorf("expected 3 columns found %d", len(columns))
+	if len(columns) != 5 {
+		t.Errorf("expected 5 columns found %d", len(columns))
 	}
 
 	for i, tt := range columnTypesTests {


### PR DESCRIPTION
ColumnType is the interface to obtain length, precision, scale of
a database column. The lib/pq implementation only support char,
varchar, text, bytea. Bit and varbit support is missing.

Signed-off-by: Huiliang Liu <huliu@pivotal.io>