### PR TITLE
add support for plan9

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -724,7 +724,17 @@ func TestBadConn(t *testing.T) {
 // TestCloseBadConn tests that the underlying connection can be closed with
 // Close after an error.
 func TestCloseBadConn(t *testing.T) {
-	nc, err := net.Dial("tcp", "localhost:5432")
+	env := parseEnviron(os.Environ())
+	host := env["host"]
+	port := env["port"]
+	if host == "" {
+		host = "localhost"
+	}
+	if port == "" {
+		port = "5432"
+	}
+	addr := host + ":" + port
+	nc, err := net.Dial("tcp", addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/user_plan9.go
+++ b/user_plan9.go
@@ -1,0 +1,24 @@
+// Package pq is a pure Go Postgres driver for the database/sql package.
+
+// +build plan9
+
+package pq
+
+import (
+	"os"
+	"os/user"
+)
+
+func userCurrent() (string, error) {
+	u, err := user.Current()
+	if err == nil {
+		return u.Username, nil
+	}
+
+	name := os.Getenv("user")
+	if name != "" {
+		return name, nil
+	}
+
+	return "", ErrCouldNotDetectUsername
+}


### PR DESCRIPTION
Make this compile (and work) by adding a file user_plan9.go. It's nearly identical to the posix version.

On plan9 the test TestCloseBadConn in conn_test.go was failing. The hardcoded localhost:5432 won't work (postgres isn't available on plan9). The README already encourages you to use environment variables to override database connection parameters, so this patch makes the code look at env vars.