### PR TITLE
Add more instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,7 @@ documentation at <http://godoc.org/github.com/lib/pq>.
 
 ## Tests
 
-`go test` is used for testing.  A running PostgreSQL server is
-required, with the ability to log in.  The default database to connect
-to test with is "pqgotest," but it can be overridden using environment
-variables.
-
-Example:
-
-	PGHOST=/run/postgresql go test github.com/lib/pq
-
-Optionally, a benchmark suite can be run as part of the tests:
-
-	PGHOST=/run/postgresql go test -bench .
+`go test` is used for testing.  See [TESTS.md](TESTS.md) for more details.
 
 ## Features
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,32 @@
+# Tests
+
+## Running Tests
+
+`go test` is used for testing.  A running PostgreSQL server is required, with
+the ability to log in.  The database to
+connect to test with is "pqgotest," on "localhost" but these can be overridden using
+[environment variables](https://www.postgresql.org/docs/9.3/static/libpq-envars.html).
+
+Example:
+
+	PGHOST=/run/postgresql go test
+
+## Benchmarks
+
+A benchmark suite can be run as part of the tests:
+
+	go test -bench .
+
+## Example setup (Docker)
+
+Run a postgres container:
+
+```
+docker run --expose 5432:5432 postgres
+```
+
+Run tests:
+
+```
+PGHOST=localhost PGPORT=5432 PGUSER=postgres PGSSLMODE=disable PGDATABASE=postgres go test
+```

--- a/TESTS.md
+++ b/TESTS.md
@@ -2,10 +2,11 @@
 
 ## Running Tests
 
-`go test` is used for testing.  A running PostgreSQL server is required, with
-the ability to log in.  The database to
-connect to test with is "pqgotest," on "localhost" but these can be overridden using
-[environment variables](https://www.postgresql.org/docs/9.3/static/libpq-envars.html).
+`go test` is used for testing. A running PostgreSQL
+server is required, with the ability to log in. The
+database to connect to test with is "pqgotest," on
+"localhost" but these can be overridden using [environment
+variables](https://www.postgresql.org/docs/9.3/static/libpq-envars.html).
 
 Example:
 


### PR DESCRIPTION
What
===
Add more instructions for running tests.

Why
===
For those starting out and not familiar with how to get a PostgresSQL
up and running for tests an example would be helpful. This isn't
supposed to define the only way to run the tests, but just provide an
example for those who have less experience and need a helping hand.