### PR TITLE
Fix testing

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -23,7 +23,7 @@ A benchmark suite can be run as part of the tests:
 Run a postgres container:
 
 ```
-docker run --expose 5432:5432 postgres
+docker run -p 5432:5432 postgres
 ```
 
 Run tests:

--- a/conn_test.go
+++ b/conn_test.go
@@ -724,7 +724,16 @@ func TestBadConn(t *testing.T) {
 // TestCloseBadConn tests that the underlying connection can be closed with
 // Close after an error.
 func TestCloseBadConn(t *testing.T) {
-	nc, err := net.Dial("tcp", "localhost:5432")
+	host := os.Getenv("PGHOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := os.Getenv("PGPORT")
+	if port == "" {
+		port = "5432"
+	}
+	addr := net.JoinHostPort(host, port)
+	nc, err := net.Dial("tcp", addr)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
TestCloseBadConn did not use `PGHOST` and `PGPORT`. Running tests will failed, if these environment variables exist. Actually, I run tests on Docker machine. It failed.