### PR TITLE
Allow to use pq.Array(sliceOfSliceOfBytes)

### DIFF
--- a/array.go
+++ b/array.go
@@ -39,6 +39,8 @@ func Array(a interface{}) interface {
 		return (*Int64Array)(&a)
 	case []string:
 		return (*StringArray)(&a)
+	case [][]byte:
+		return (*ByteaArray)(&a)
 
 	case *[]bool:
 		return (*BoolArray)(a)
@@ -48,6 +50,8 @@ func Array(a interface{}) interface {
 		return (*Int64Array)(a)
 	case *[]string:
 		return (*StringArray)(a)
+	case *[][]byte:
+		return (*ByteaArray)(a)
 	}
 
 	return GenericArray{a}

--- a/array_test.go
+++ b/array_test.go
@@ -109,12 +109,18 @@ func TestArrayScanner(t *testing.T) {
 		t.Errorf("Expected *StringArray, got %T", s)
 	}
 
+	s = Array(&[][]byte{})
+	if _, ok := s.(*ByteaArray); !ok {
+		t.Errorf("Expected *ByteaArray, got %T", s)
+	}
+
 	for _, tt := range []interface{}{
 		&[]sql.Scanner{},
 		&[][]bool{},
 		&[][]float64{},
 		&[][]int64{},
 		&[][]string{},
+		&[][][]byte{},
 	} {
 		s = Array(tt)
 		if _, ok := s.(GenericArray); !ok {


### PR DESCRIPTION
I had some issues today to use `pq.Array(sliceOfSliceOfBytes)` to perform a multiple insertion with a single query to my database. I had to use a loop instead.
 
This code allows me to use `pq.Array` in my query. I'm not 100% sure if it's a bug, a missing feature or if there's a more clever way to do it. 