### PR TITLE
Example should suggest closing the connection pool

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@ using this package directly. For example:
 		if err != nil {
 			log.Fatal(err)
 		}
-
+		defer db.Close()
 		age := 21
 		rows, err := db.Query("SELECT name FROM users WHERE age = $1", age)
 		…


### PR DESCRIPTION
For some people this will be the first example they see when working with `database/sql`. I think it's useful to include a call to `db.Close()`. Wdyt?