### PR TITLE
Fixing bug in handling of server version parsing for Postgresql 10+

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1552,9 +1552,16 @@ func (cn *conn) processParameterStatus(r *readBuf) {
 		var major1 int
 		var major2 int
 		var minor int
-		_, err = fmt.Sscanf(r.string(), "%d.%d.%d", &major1, &major2, &minor)
-		if err == nil {
-			cn.parameterStatus.serverVersion = major1*10000 + major2*100 + minor
+		// if the version string contains at least major1, set the server version
+		n, _ := fmt.Sscanf(r.string(), "%d.%d.%d", &major1, &major2, &minor)
+		if n > 0 {
+			// server version changed to two-part version in 10+, instead of three-part version
+			// details here: https://www.postgresql.org/docs/current/static/libpq-status.html
+			if major1 >= 10 {
+				cn.parameterStatus.serverVersion = major1*10000 + major2
+			} else {
+				cn.parameterStatus.serverVersion = major1*10000 + major2*100 + minor
+			}
 		}
 
 	case "TimeZone":

--- a/conn_test.go
+++ b/conn_test.go
@@ -1657,3 +1657,24 @@ func TestQuickClose(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestParamterStatusServerVersions(t *testing.T) {
+	// test cases derived from libpq status documentation (see section on PQserverVersion)
+	// https://www.postgresql.org/docs/current/static/libpq-status.html
+	versionMap := map[string]int{}
+	versionMap["9.2.0"] = 90200
+	versionMap["10.5"] = 100005
+
+	for versionStr, version := range versionMap {
+		c := &conn{}
+		writer := &writeBuf{}
+		writer.string("server_version")
+		writer.string(versionStr)
+		reader := readBuf(writer.buf)
+		c.processParameterStatus(&reader)
+		expectedVersionNum := version
+		if c.parameterStatus.serverVersion != expectedVersionNum {
+			t.Fatalf("server version num %d does not match expected value %d", c.parameterStatus.serverVersion, expectedVersionNum)
+		}
+	}
+}


### PR DESCRIPTION
Server versioning scheme changed in Postgresql 10+. They've moved to two-part rather than three-part versioning. For example, `10.5` rather than `10.5.0`. They've also changed the calculation of the `server_version_num` integer. Full details can be found in the [libpq status documentation](https://www.postgresql.org/docs/current/static/libpq-status.html).

On the face of it this doesn't seem like a huge deal, but it affects `encoding.go`. In particular the `encodeBytea` function [uses server version check](https://github.com/lib/pq/blob/master/encode.go#L561) to see if it should use hex encoding.