### PR TITLE
Support for SCRAM-SHA-256 authentication

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -15,21 +15,27 @@ pgdg_repository() {
 }
 
 postgresql_configure() {
+	if [ "$PGVERSION" = "10" ] || [ "$PGVERSION" = "11" ]; then
+		read -r -d eoscram SCRAM <<-scram
+		host      all         pqgomd5u1   all                   md5
+		host      all         pqgomd5u2   all                   scram-sha-256
+		host      all         pqgoscramu1 all                   md5
+		host      all         pqgoscramu2 all                   scram-sha-256
+		eoscram
+		scram
+	fi
 	sudo tee /etc/postgresql/$PGVERSION/main/pg_hba.conf > /dev/null <<-config
 		local     all         all                               trust
 		hostnossl all         pqgossltest 127.0.0.1/32          reject
 		hostnossl all         pqgosslcert 127.0.0.1/32          reject
 		hostssl   all         pqgossltest 127.0.0.1/32          trust
 		hostssl   all         pqgosslcert 127.0.0.1/32          cert
+		$SCRAM
 		host      all         all         127.0.0.1/32          trust
 		hostnossl all         pqgossltest ::1/128               reject
 		hostnossl all         pqgosslcert ::1/128               reject
 		hostssl   all         pqgossltest ::1/128               trust
 		hostssl   all         pqgosslcert ::1/128               cert
-		host      all         pqgomd5u1   all                   md5
-		host      all         pqgomd5u2   all                   scram-sha-256
-		host      all         pqgoscramu1 all                   md5
-		host      all         pqgoscramu2 all                   scram-sha-256
 		host      all         all         ::1/128               trust
 	config
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -15,6 +15,7 @@ pgdg_repository() {
 }
 
 postgresql_configure() {
+	SCRAM=
 	if [ "$PGVERSION" = "10" ] || [ "$PGVERSION" = "11" ]; then
 		read -r -d eoscram SCRAM <<-scram
 		host      all         pqgomd5u1   all                   md5

--- a/.travis.sh
+++ b/.travis.sh
@@ -26,6 +26,10 @@ postgresql_configure() {
 		hostnossl all         pqgosslcert ::1/128               reject
 		hostssl   all         pqgossltest ::1/128               trust
 		hostssl   all         pqgosslcert ::1/128               cert
+		host      all         pqgomd5u1   all                   md5
+		host      all         pqgomd5u2   all                   scram-sha-256
+		host      all         pqgoscramu1 all                   md5
+		host      all         pqgoscramu2 all                   scram-sha-256
 		host      all         all         ::1/128               trust
 	config
 

--- a/conn.go
+++ b/conn.go
@@ -1163,6 +1163,12 @@ func (cn *conn) auth(r *readBuf, o values) {
 		if r.int32() != 0 {
 			errorf("unexpected authentication response: %q", t)
 		}
+	case 10:
+		s := r.string()
+		if s != "SCRAM-SHA-256" {
+			errorf("unknown sasl mechanism: %q", s)
+		}
+		cn.doScramAuth(o["password"])
 	default:
 		errorf("unknown authentication response: %d", code)
 	}

--- a/scram.go
+++ b/scram.go
@@ -168,15 +168,15 @@ func makeNonce() string {
 	return base64.StdEncoding.EncodeToString(data)
 }
 
-func computeClientProof(salted_password []byte, auth_message []byte) string {
+func computeClientProof(sp, am []byte) string {
 	// ClientKey       := HMAC(SaltedPassword, "Client Key")
 	// StoredKey       := H(ClientKey)
 	// ClientSignature := HMAC(StoredKey, AuthMessage)
 	// ClientProof     := ClientKey XOR ClientSignature
 
-	ck := computeHMAC(salted_password, []byte("Client Key"))
+	ck := computeHMAC(sp, []byte("Client Key"))
 	sk := sha256.Sum256(ck)
-	cs := computeHMAC(sk[:], auth_message)
+	cs := computeHMAC(sk[:], am)
 	proof := make([]byte, len(cs))
 	for i := 0; i < len(cs); i++ {
 		proof[i] = ck[i] ^ cs[i]
@@ -184,12 +184,12 @@ func computeClientProof(salted_password []byte, auth_message []byte) string {
 	return base64.StdEncoding.EncodeToString(proof)
 }
 
-func computeServerSignature(salted_password []byte, auth_message []byte) string {
+func computeServerSignature(sp, am []byte) string {
 	// ServerKey       := HMAC(SaltedPassword, "Server Key")
 	// ServerSignature := HMAC(ServerKey, AuthMessage)
 
-	sk := computeHMAC(salted_password, []byte("Server Key"))
-	ss := computeHMAC(sk, auth_message)
+	sk := computeHMAC(sp, []byte("Server Key"))
+	ss := computeHMAC(sk, am)
 	return base64.StdEncoding.EncodeToString(ss)
 }
 

--- a/scram.go
+++ b/scram.go
@@ -1,0 +1,200 @@
+package pq
+
+// This file provides support for authentication based on the SCRAM-SHA-256
+// SASL mechanism available in PostgreSQL v10 and above. Most of the comments
+// in this file refer to terms from RFC 5802. Also refer RFC 3454 for the
+// stringprep algorithm and RFC 4013 for the SASLprep profile of this algorithm.
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/xdg-go/stringprep"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+func (cn *conn) doScramAuth(password string) {
+	s := scramCtx{cn: cn, password: password}
+	s.step1() // C: n,,n=,r=nonce
+	s.step2() // S: r=nonce,s=salt,i=iters
+	s.step3() // C: c=biws,r=nonce,p=proof
+	s.step4() // S: v=verifier
+}
+
+//------------------------------------------------------------------------------
+
+type scramCtx struct {
+	cn       *conn
+	password string
+	cnonce   string // client's nonce
+	sfm      string // server-first-message
+	fnonce   string // full nonce (client || server)
+	salt     []byte
+	iters    int    // iteration count
+	sp       []byte // salted password
+	am       []byte // auth message
+}
+
+// step1: client sends a nonce to the server
+func (s *scramCtx) step1() {
+	// make a client nonce
+	s.cnonce = makeNonce()
+
+	// make "client-first-message"
+	msg := []byte("n,,n=,r=" + s.cnonce)
+
+	// send it to postgres
+	w := s.cn.writeBuf('p')
+	w.string("SCRAM-SHA-256")
+	w.int32(len(msg))
+	w.bytes(msg)
+	s.cn.send(w)
+}
+
+// step2: server sends nonce, salt and iteration count
+func (s *scramCtx) step2() {
+	// receive postgres reply
+	t, r := s.cn.recv()
+	if t != 'R' {
+		errorf("unexpected password response: %q", t)
+	}
+	if r.int32() != 11 {
+		errorf("unexpected authentication response: %q", t)
+	}
+
+	// parse the "server-first-message"
+	s.sfm = string(*r)
+	parts := strings.Split(s.sfm, ",")
+	if len(parts) != 3 || !strings.HasPrefix(parts[0], "r=") ||
+		!strings.HasPrefix(parts[1], "s=") || !strings.HasPrefix(parts[2], "i=") {
+		errorf("invalid SCRAM server-first-message from server")
+	}
+
+	// r=<client nonce || server nonce>
+	s.fnonce = parts[0][2:]
+	if len(s.fnonce) == len(s.cnonce) || !strings.HasPrefix(s.fnonce, s.cnonce) {
+		errorf("invalid SCRAM nonce from server")
+	}
+
+	// s=<salt>
+	var err error
+	s.salt, err = base64.StdEncoding.DecodeString(parts[1][2:])
+	if err != nil {
+		errorf("invalid SCRAM salt from server: %v", err)
+	}
+
+	// i=<iterations>
+	s.iters, err = strconv.Atoi(parts[2][2:])
+	if err != nil {
+		errorf("invalid SCRAM iteration count from server: %v", err)
+	}
+	if s.iters <= 0 {
+		errorf("invalid SCRAM iteration count (%d) from server", s.iters)
+	}
+}
+
+// step3: client sends full nonce and client proof
+func (s *scramCtx) step3() {
+	// client-final-message-without-proof
+	cfmwo := "c=biws,r=" + s.fnonce // "biws" = base64("n,,")
+
+	// Normalize(password)
+	np, err := stringprep.SASLprep.Prepare(s.password)
+	if err != nil {
+		// As per RFC 4013, we should fail here, with:
+		//errorf("unsupported characters in password: %v", err)
+		// However, Postgres will successfully authenticate even if the
+		// characters in the password do not fit the 4013 profile. See
+		// test case TestSCRAMStrangePasswords in scram_test.go.
+		np = s.password
+	}
+
+	// SaltedPassword  := Hi(Normalize(password), salt, i)
+	s.sp = pbkdf2.Key([]byte(np), s.salt, s.iters, 32, sha256.New)
+
+	// AuthMessage     := client-first-message-bare + "," +
+	//                    server-first-message + "," +
+	//                    client-final-message-without-proof
+	s.am = []byte("n=,r=" + s.cnonce + "," + s.sfm + "," + cfmwo)
+
+	// make client proof
+	cp := computeClientProof(s.sp, s.am)
+
+	// client-final-message = client-final-message-without-proof "," proof
+	cfm := []byte(fmt.Sprintf("%s,p=%s", cfmwo, cp))
+
+	// send it to postgres
+	w := s.cn.writeBuf('p')
+	w.bytes(cfm)
+	s.cn.send(w)
+}
+
+// step4: server sends signature
+func (s *scramCtx) step4() {
+	t, r := s.cn.recv()
+	if t != 'R' {
+		errorf("unexpected password response: %q", t)
+	}
+	if v := r.int32(); v != 12 {
+		errorf("unexpected authentication response: %q", v)
+	}
+
+	// server-final-message
+	sfm := string(*r)
+	if !strings.HasPrefix(sfm, "v=") {
+		errorf("invalid SCRAM server-final-message from server")
+	}
+
+	// compute the required server signature, and compare
+	reqd := computeServerSignature(s.sp, s.am)
+	if subtle.ConstantTimeCompare([]byte(reqd), []byte(sfm[2:])) != 1 {
+		errorf("invalid SCRAM ServerSignature from server")
+	}
+}
+
+//------------------------------------------------------------------------------
+
+func makeNonce() string {
+	data := make([]byte, 24)
+	if _, err := rand.Read(data); err != nil {
+		errorf("failed to read random data: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+func computeClientProof(salted_password []byte, auth_message []byte) string {
+	// ClientKey       := HMAC(SaltedPassword, "Client Key")
+	// StoredKey       := H(ClientKey)
+	// ClientSignature := HMAC(StoredKey, AuthMessage)
+	// ClientProof     := ClientKey XOR ClientSignature
+
+	ck := computeHMAC(salted_password, []byte("Client Key"))
+	sk := sha256.Sum256(ck)
+	cs := computeHMAC(sk[:], auth_message)
+	proof := make([]byte, len(cs))
+	for i := 0; i < len(cs); i++ {
+		proof[i] = ck[i] ^ cs[i]
+	}
+	return base64.StdEncoding.EncodeToString(proof)
+}
+
+func computeServerSignature(salted_password []byte, auth_message []byte) string {
+	// ServerKey       := HMAC(SaltedPassword, "Server Key")
+	// ServerSignature := HMAC(ServerKey, AuthMessage)
+
+	sk := computeHMAC(salted_password, []byte("Server Key"))
+	ss := computeHMAC(sk, auth_message)
+	return base64.StdEncoding.EncodeToString(ss)
+}
+
+func computeHMAC(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	return mac.Sum(nil)
+}

--- a/scram_test.go
+++ b/scram_test.go
@@ -5,9 +5,13 @@ import "testing"
 // Create the users if required. The *md5* users have MD5 verifiers in
 // pg_authid, and *scram* users have SCRAM-SHA-256. pg_hba.conf is configured
 // (in .travis.sh) to authenticate *1 users with md5 and *2 with scram.
-func checkSCRAMSetup(t *testing.T) {
+func checkSCRAMSetup(t *testing.T) bool {
 	db := openTestConn(t)
 	defer db.Close()
+	if getServerVersion(t, db) < 100000 {
+		// skip the test if the postgres version is less than 10
+		return false
+	}
 	_, err := db.Exec(`
 		DROP USER IF EXISTS pqgomd5u1, pqgomd5u2, pqgoscramu1, pqgoscramu2;
 		SET password_encryption='md5';
@@ -20,10 +24,13 @@ func checkSCRAMSetup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return true
 }
 
 func testSCRAMSuccessCase(t *testing.T, conninfo string) {
-	checkSCRAMSetup(t)
+	if !checkSCRAMSetup(t) {
+		return
+	}
 	db, err := openTestConnConninfo(conninfo)
 	if err != nil {
 		t.Fatal(err)
@@ -42,14 +49,16 @@ func TestSCRAMBothScram(t *testing.T) {
 
 // user has SCRAM verifier, pg_hba picks md5 (should pass)
 func TestSCRAMUserScramServerMD5(t *testing.T) {
-	checkSCRAMSetup(t)
 	testSCRAMSuccessCase(t, `user=pqgoscramu1 password=se%r-*tpΣβ`)
 }
 
-// user has MD5 verifier, pg_hba picks scram (should fail)
+// user has MD5 verifier, pg_hba picks scram (should fail because
+// "user does not have a valid SCRAM identifier")
 func TestSCRAMUserMD5ServerScram(t *testing.T) {
-	checkSCRAMSetup(t)
-	db, err := openTestConnConninfo(`user=pqgomd5u2 password=incorrect`)
+	if !checkSCRAMSetup(t) {
+		return
+	}
+	db, err := openTestConnConninfo(`user=pqgomd5u2 password=se%r-*tpΣβ`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +77,9 @@ func TestSCRAMNoScram(t *testing.T) {
 
 // user has SCRAM verifier, pg_hba picks scram, but wrong password
 func TestSCRAMWrongPass(t *testing.T) {
-	checkSCRAMSetup(t)
+	if !checkSCRAMSetup(t) {
+		return
+	}
 	db, err := openTestConnConninfo(`user=pqgoscramu2 password=incorrect`)
 	if err != nil {
 		t.Fatal(err)
@@ -84,6 +95,11 @@ func TestSCRAMWrongPass(t *testing.T) {
 // allows it.
 func TestSCRAMStrangePasswords(t *testing.T) {
 	db := openTestConn(t)
+	if getServerVersion(t, db) < 100000 {
+		// skip the test if the postgres version is less than 10
+		db.Close()
+		return
+	}
 	_, err := db.Exec(`
 		DROP USER IF EXISTS pqgoscramu2;
 		SET password_encryption='scram-sha-256';

--- a/scram_test.go
+++ b/scram_test.go
@@ -104,4 +104,3 @@ func TestSCRAMStrangePasswords(t *testing.T) {
 	}
 	db2.Close()
 }
-

--- a/scram_test.go
+++ b/scram_test.go
@@ -1,0 +1,107 @@
+package pq
+
+import "testing"
+
+// Create the users if required. The *md5* users have MD5 verifiers in
+// pg_authid, and *scram* users have SCRAM-SHA-256. pg_hba.conf is configured
+// (in .travis.sh) to authenticate *1 users with md5 and *2 with scram.
+func checkSCRAMSetup(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+	_, err := db.Exec(`
+		DROP USER IF EXISTS pqgomd5u1, pqgomd5u2, pqgoscramu1, pqgoscramu2;
+		SET password_encryption='md5';
+		CREATE USER pqgomd5u1 PASSWORD 'se%r-*tpΣβ';
+		CREATE USER pqgomd5u2 PASSWORD 'se%r-*tpΣβ';
+		SET password_encryption='scram-sha-256';
+		CREATE USER pqgoscramu1 PASSWORD 'se%r-*tpΣβ';
+		CREATE USER pqgoscramu2 PASSWORD 'se%r-*tpΣβ';
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testSCRAMSuccessCase(t *testing.T, conninfo string) {
+	checkSCRAMSetup(t)
+	db, err := openTestConnConninfo(conninfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dummy int
+	if err := db.QueryRow("SELECT 1").Scan(&dummy); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+}
+
+// user has SCRAM verifier, pg_hba picks scram
+func TestSCRAMBothScram(t *testing.T) {
+	testSCRAMSuccessCase(t, `user=pqgoscramu2 password=se%r-*tpΣβ`)
+}
+
+// user has SCRAM verifier, pg_hba picks md5 (should pass)
+func TestSCRAMUserScramServerMD5(t *testing.T) {
+	checkSCRAMSetup(t)
+	testSCRAMSuccessCase(t, `user=pqgoscramu1 password=se%r-*tpΣβ`)
+}
+
+// user has MD5 verifier, pg_hba picks scram (should fail)
+func TestSCRAMUserMD5ServerScram(t *testing.T) {
+	checkSCRAMSetup(t)
+	db, err := openTestConnConninfo(`user=pqgomd5u2 password=incorrect`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dummy int
+	if err := db.QueryRow("SELECT 1").Scan(&dummy); err == nil {
+		t.Fatalf("auth should have failed")
+	}
+	db.Close()
+}
+
+// user has MD5 verifier, pg_hba picks md5 (should succeed, but no scram
+// involved)
+func TestSCRAMNoScram(t *testing.T) {
+	testSCRAMSuccessCase(t, `user=pqgomd5u1 password=se%r-*tpΣβ`)
+}
+
+// user has SCRAM verifier, pg_hba picks scram, but wrong password
+func TestSCRAMWrongPass(t *testing.T) {
+	checkSCRAMSetup(t)
+	db, err := openTestConnConninfo(`user=pqgoscramu2 password=incorrect`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dummy int
+	if err := db.QueryRow("SELECT 1").Scan(&dummy); err == nil {
+		t.Fatalf("auth should have failed")
+	}
+	db.Close()
+}
+
+// this password fails the RFC 4013 profile, but postgres (and therefore lib/pq)
+// allows it.
+func TestSCRAMStrangePasswords(t *testing.T) {
+	db := openTestConn(t)
+	_, err := db.Exec(`
+		DROP USER IF EXISTS pqgoscramu2;
+		SET password_encryption='scram-sha-256';
+		CREATE USER pqgoscramu2 PASSWORD 'a😄b';
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	db2, err := openTestConnConninfo(`user=pqgoscramu2 password=a😄b`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dummy int
+	if err := db2.QueryRow("SELECT 1").Scan(&dummy); err != nil {
+		t.Fatal(err)
+	}
+	db2.Close()
+}
+


### PR DESCRIPTION
This pull request add support for SCRAM authentication.

The code in scram.go is an implementation of RFC 5802 and similar to the canonical C implementation at https://github.com/postgres/postgres/blob/master/src/interfaces/libpq/fe-auth-scram.c.

### Testing

The test code in scram_test.go tests users with md5 and scram verifiers against md5 and scram matches in pg_hba.conf. To test locally, first update your local pg_hba.conf with the changes in .travis.sh.

### Dependencies

The code introduces two new dependencies, `github.com/xdg-go/stringprep` for stringprep of the password and `golang.org/x/crypto/pbkdf2` for key derivation.

[Edit: added note about dependencies]