### PR TITLE
Use https for godoc links

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -80,7 +80,7 @@ megacheck_install() {
 }
 
 golint_install() {
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 }
 
 $1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Docs
 
 For detailed documentation and basic usage examples, please see the package
-documentation at <http://godoc.org/github.com/lib/pq>.
+documentation at <https://godoc.org/github.com/lib/pq>.
 
 ## Tests
 

--- a/doc.go
+++ b/doc.go
@@ -239,7 +239,7 @@ for more information).  Note that the channel name will be truncated to 63
 bytes by the PostgreSQL server.
 
 You can find a complete, working example of Listener usage at
-http://godoc.org/github.com/lib/pq/example/listen.
+https://godoc.org/github.com/lib/pq/example/listen.
 
 */
 package pq


### PR DESCRIPTION
Also fix golint import location.

Fixes #791