### PR TITLE
Support inline SSL certificates

### DIFF
--- a/ssl.go
+++ b/ssl.go
@@ -59,6 +59,9 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 		return nil, err
 	}
 
+	// This pseudo-parameter is not recognized by the PostgreSQL server, so let's delete it after use.
+	delete(o, "sslinline")
+
 	// Accept renegotiation requests initiated by the backend.
 	//
 	// Renegotiation was deprecated then removed from PostgreSQL 9.5, but
@@ -83,6 +86,20 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 // in the user's home directory. The configured files must exist and have
 // the correct permissions.
 func sslClientCertificates(tlsConf *tls.Config, o values) error {
+	sslinline := o["sslinline"]
+	if "true" == sslinline {
+		cert, err := tls.X509KeyPair([]byte(o["sslcert"]), []byte(o["sslkey"]))
+		// Clear out these params, in case they were to be sent to the PostgreSQL server by mistake
+		o["sslcert"] = ""
+		o["sslkey"] = ""
+		if err != nil {
+			return err
+		}
+		tlsConf.Certificates = []tls.Certificate{cert}
+		return nil
+	}
+
+
 	// user.Current() might fail when cross-compiling. We have to ignore the
 	// error and continue without home directory defaults, since we wouldn't
 	// know from where to load them.
@@ -137,9 +154,19 @@ func sslCertificateAuthority(tlsConf *tls.Config, o values) error {
 	if sslrootcert := o["sslrootcert"]; len(sslrootcert) > 0 {
 		tlsConf.RootCAs = x509.NewCertPool()
 
-		cert, err := ioutil.ReadFile(sslrootcert)
-		if err != nil {
-			return err
+		sslinline := o["sslinline"]
+
+		var cert []byte
+		if "true" == sslinline {
+			// // Clear out this param, in case it were to be sent to the PostgreSQL server by mistake
+			o["sslrootcert"] = ""
+			cert = []byte(sslrootcert)
+		} else {
+			var err error
+			cert, err = ioutil.ReadFile(sslrootcert)
+			if err != nil {
+				return err
+			}
 		}
 
 		if !tlsConf.RootCAs.AppendCertsFromPEM(cert) {

--- a/ssl.go
+++ b/ssl.go
@@ -99,7 +99,6 @@ func sslClientCertificates(tlsConf *tls.Config, o values) error {
 		return nil
 	}
 
-
 	// user.Current() might fail when cross-compiling. We have to ignore the
 	// error and continue without home directory defaults, since we wouldn't
 	// know from where to load them.

--- a/ssl.go
+++ b/ssl.go
@@ -87,7 +87,7 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 // the correct permissions.
 func sslClientCertificates(tlsConf *tls.Config, o values) error {
 	sslinline := o["sslinline"]
-	if "true" == sslinline {
+	if sslinline == "true" {
 		cert, err := tls.X509KeyPair([]byte(o["sslcert"]), []byte(o["sslkey"]))
 		// Clear out these params, in case they were to be sent to the PostgreSQL server by mistake
 		o["sslcert"] = ""
@@ -156,7 +156,7 @@ func sslCertificateAuthority(tlsConf *tls.Config, o values) error {
 		sslinline := o["sslinline"]
 
 		var cert []byte
-		if "true" == sslinline {
+		if sslinline == "true" {
 			// // Clear out this param, in case it were to be sent to the PostgreSQL server by mistake
 			o["sslrootcert"] = ""
 			cert = []byte(sslrootcert)

--- a/url.go
+++ b/url.go
@@ -40,10 +40,10 @@ func ParseURL(url string) (string, error) {
 	}
 
 	var kvs []string
-	escaper := strings.NewReplacer(` `, `\ `, `'`, `\'`, `\`, `\\`)
+	escaper := strings.NewReplacer(`'`, `\'`, `\`, `\\`)
 	accrue := func(k, v string) {
 		if v != "" {
-			kvs = append(kvs, k+"="+escaper.Replace(v))
+			kvs = append(kvs, k+"='"+escaper.Replace(v)+"'")
 		}
 	}
 

--- a/url_test.go
+++ b/url_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestSimpleParseURL(t *testing.T) {
-	expected := "host=hostname.remote"
+	expected := "host='hostname.remote'"
 	str, err := ParseURL("postgres://hostname.remote")
 	if err != nil {
 		t.Fatal(err)
@@ -17,7 +17,7 @@ func TestSimpleParseURL(t *testing.T) {
 }
 
 func TestIPv6LoopbackParseURL(t *testing.T) {
-	expected := "host=::1 port=1234"
+	expected := "host='::1' port='1234'"
 	str, err := ParseURL("postgres://[::1]:1234")
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +29,7 @@ func TestIPv6LoopbackParseURL(t *testing.T) {
 }
 
 func TestFullParseURL(t *testing.T) {
-	expected := `dbname=database host=hostname.remote password=top\ secret port=1234 user=username`
+	expected := `dbname='database' host='hostname.remote' password='top secret' port='1234' user='username'`
 	str, err := ParseURL("postgres://username:top%20secret@hostname.remote:1234/database")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
> Presently, pq only supports SSL connections by
loading PEM certificates from files on disk.
There are some situations (for example integration
with HashiCorp Vault) where it's not so feasible
to load certificates from a file system, but better
to store them in-memory.
>
>This patch lets you set ?sslinline=true in the
connection string, which changes the behavior of
the paramters sslrootcert, sslcert and sslkey, so
they contain the contents of the certificates
directly, instead of file names pointing to the
certificates on disk.

What do you think about a change like this?
My specific use case is adding SSL support to [Vault](https://www.vaultproject.io/)'s integration with PostgreSQL - today it can only communicate over a plaintext socket. However, Vault doesn't store secrets/certificates directly on disk, but rather on an encrypted, distributed, pluggable backend system, which is the reason for this feature request: Vault can read the certificates from wherever they are stored, and pass them into pq via the connection string.