### PR TITLE
Fix issue #731

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -557,6 +557,7 @@ func (cn *conn) begin(mode string) (_ driver.Tx, err error) {
 
 func (cn *conn) closeTxn() {
 	if finish := cn.txnFinish; finish != nil {
+		cn.txnFinish = nil
 		finish()
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -106,7 +106,11 @@ func TestCommitInFailedTransaction(t *testing.T) {
 	db := openTestConn(t)
 	defer db.Close()
 
-	txn, err := db.Begin()
+	// Provide a context with a Done channel to check that the Commit does not hang in that case (https://github.com/lib/pq/issues/731).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	txn, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
One minimal way to fix this. Not sure if it would need to be concurrent-safe instead. (should be safe enough: the golang stdlib sql wrapper takes care of synchronising things)