### PR TITLE
fix(conn): properly inspect interfaces for nil values

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -14,6 +14,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -1265,6 +1266,17 @@ func (st *stmt) exec(v []driver.Value) {
 			if x == nil {
 				w.int32(-1)
 			} else {
+				// Check if v is a nil interface value(covers nil slices)
+				rv := reflect.ValueOf(x)
+
+				switch rv.Kind() {
+				case reflect.Slice, reflect.Interface:
+					if rv.IsNil() {
+						w.int32(-1)
+						continue
+					}
+				}
+
 				b := encode(&cn.parameterStatus, x, st.paramTyps[i])
 				w.int32(len(b))
 				w.bytes(b)


### PR DESCRIPTION
Fixes #773 by further inspecting arguments to check if they are nil interfaces or slices.

Sending a nil byte slice use to not work because it was a nil value of type `[]byte` which `!= nil` hence it would really send an empty byte slice. This prevented you from setting columns to null unless you had a different path to send an explicit nil which also had no type(confusing and a pain to implement). Checking interface values equal nil is a common bug in go which usually requires using the reflect package to further inspect the interface's actual value is nil since the typing usually isn't.


This does slightly slow down writes theoretically but it should be worth it for such a common use case and standard feature of sending nil.
