### PR TITLE
Fix connection leak on SSL failure

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -299,6 +299,7 @@ func (c *Connector) open(ctx context.Context) (cn *conn, err error) {
 
 	err = cn.ssl(o)
 	if err != nil {
+		cn.c.Close()
 		return nil, err
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -299,7 +299,9 @@ func (c *Connector) open(ctx context.Context) (cn *conn, err error) {
 
 	err = cn.ssl(o)
 	if err != nil {
-		cn.c.Close()
+		if cn.c != nil {
+			cn.c.Close()
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
When connecting to a server using SSL fails (i.e. with SSL disabled) the connection was never freed.

Fixes #840