### PR TITLE
Fix: prevent unexpected connection info string

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -455,6 +455,9 @@ func parseOpts(name string, o values) error {
 						return fmt.Errorf(`missing character after backslash`)
 					}
 				}
+				if r == '=' {
+					return fmt.Errorf(`missing character after "=" in %q connection info string`, string(keyRunes))
+				}
 				valRunes = append(valRunes, r)
 
 				if r, ok = s.Next(); !ok {

--- a/conn.go
+++ b/conn.go
@@ -455,9 +455,6 @@ func parseOpts(name string, o values) error {
 						return fmt.Errorf(`missing character after backslash`)
 					}
 				}
-				if r == '=' {
-					return fmt.Errorf(`missing character after "=" in %q connection info string`, string(keyRunes))
-				}
 				valRunes = append(valRunes, r)
 
 				if r, ok = s.Next(); !ok {
@@ -482,10 +479,40 @@ func parseOpts(name string, o values) error {
 			}
 		}
 
-		o[string(keyRunes)] = string(valRunes)
+		if exist, valRunesKey, valRunesVal := checkEqualInVal(valRunes); exist {
+			o[string(valRunesKey)] = string(valRunesVal)
+			o[string(keyRunes)] = ""
+		} else {
+			o[string(keyRunes)] = string(valRunes)
+		}
 	}
 
 	return nil
+}
+
+// checkEqualInVal check if valRunes contains "=" or not
+func checkEqualInVal(valRunes []rune) (bool, []rune, []rune) {
+	var valRunesKey, valRunesVal []rune
+	equalExist := false
+
+	for i := 0; i < len(valRunes); i++ {
+		if valRunes[i] == '=' {
+			equalExist = true
+			// To skip '='
+			i = i + 1
+		}
+
+		if equalExist {
+			valRunesVal = append(valRunesVal, valRunes[i])
+		} else {
+			valRunesKey = append(valRunesKey, valRunes[i])
+		}
+	}
+
+	if equalExist == false {
+		valRunesKey = []rune{}
+	}
+	return equalExist, valRunesKey, valRunesVal
 }
 
 func (cn *conn) isInTransaction() bool {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1409,7 +1409,7 @@ func TestParseOpts(t *testing.T) {
 		{"dbname=hello user=   ", values{"dbname": "hello", "user": ""}, true},
 
 		// The parser ignores spaces after = and interprets the next set of non-whitespace characters as the value.
-		{"user= password=foo", values{"user": "password=foo"}, true},
+		{"user= password=foo", values{"password": "foo", "user": ""}, true},
 
 		// Backslash escapes next char
 		{`user=a\ \'\\b`, values{"user": `a '\b`}, true},


### PR DESCRIPTION
I manage the database connection info as a toml file, and my connection code is something like

```
[psql]
  dbname = "my_database"
  host   = "localhost"
  port   = 5432
  user   = "keijun"
  pass   = ""
  blacklist = ["schema_migrations"]
  sslmode= "disable"
```

```
type Config struct {
	Psql psqlConfig
}

type psqlConfig struct {
	Dbname string `toml:"dbname"`
	Host   string `toml:"host"`
	Port   int    `toml:"port"`
	User   string `toml:"user"`
	Pass   string `toml:"pass"`
}

var config Config
_, err = toml.DecodeFile("./sqlboiler.toml", &config)

psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
	config.Psql.Host, config.Psql.Port, config.Psql.User, config.Psql.Pass, config.Psql.Dbname,
)

DB, err = sql.Open("postgres", psqlInfo)
rows, err := DB.Query(`SELECT * FROM users`)

```

However, if the password info was not provided or "", the driver give me a error.

```
panic: pq: database "keijun" does not exist
```

I know this is because password is blank and following part (in this case "dbname") is handled as a password value, and insted of that, the username was used as a database name.

this is a expected behaive as I could see from the test code, like
```
{"user= password=foo", values{"user": "password=foo"}, true},
```
but I thought checking if the value contains "=" and if so, add new key is better and make this PR.

This is my first time to make PR so maybe I am saying stupid things, so if you find anything strange please let me know, thanks in advance
