### PR TITLE
feature: inbuilt support for for int32/float32/[]byte slices in pq.Array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.test
 *~
 *.swp
+.idea
+.vscode


### PR DESCRIPTION
Inbuilt support for scanner and valuer in pq.Array for`int32` or `float32` or `[]byte` added, as described in issue #875 