### PR TITLE
Reduce writeBuf.string run-time by 87.68%

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -66,7 +66,7 @@ func (b *writeBuf) int16(n int) {
 }
 
 func (b *writeBuf) string(s string) {
-	b.buf = append(b.buf, (s + "\000")...)
+	b.buf = append(append(b.buf, s...), "\000"...)
 }
 
 func (b *writeBuf) byte(c byte) {

--- a/buf.go
+++ b/buf.go
@@ -66,7 +66,7 @@ func (b *writeBuf) int16(n int) {
 }
 
 func (b *writeBuf) string(s string) {
-	b.buf = append(append(b.buf, s...), "\000"...)
+	b.buf = append(append(b.buf, s...), '\000')
 }
 
 func (b *writeBuf) byte(c byte) {

--- a/buf_test.go
+++ b/buf_test.go
@@ -1,0 +1,16 @@
+package pq
+
+import "testing"
+
+func Benchmark_writeBuf_string(b *testing.B) {
+	var buf writeBuf
+	const s = "foo"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		buf.string(s)
+		buf.buf = buf.buf[:0]
+	}
+}


### PR DESCRIPTION
```
name                 old time/op    new time/op    delta
_writeBuf_string-16    14.8ns ± 0%     1.8ns ± 0%  -87.68%  (p=0.000 n=12+15)

name                 old alloc/op   new alloc/op   delta
_writeBuf_string-16     0.00B          0.00B          ~     (all equal)

name                 old allocs/op  new allocs/op  delta
_writeBuf_string-16      0.00           0.00          ~     (all equal)
```