### PR TITLE
bugfix to infinity timestamp test

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -322,7 +322,7 @@ func TestInfinityTimestamp(t *testing.T) {
 	// try to assert []byte to time.Time
 	for _, q := range tc {
 		err = db.QueryRow(q.Query, q.Param).Scan(&resultT)
-		if !q.ExpectedErrorStrRegexp.MatchString(err.Error()) {
+		if err == nil || !q.ExpectedErrorStrRegexp.MatchString(err.Error()) {
 			t.Errorf("Scanning -/+infinity, expected error to match regexp %q, got %q",
 				q.ExpectedErrorStrRegexp, err)
 		}


### PR DESCRIPTION
Previously, this test would panic the test suite if the server didn't
return any error at all.