### PR TITLE
bump supported versions; fix tests

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -70,17 +70,4 @@ postgresql_uninstall() {
 	sudo rm -rf /var/lib/postgresql
 }
 
-megacheck_install() {
-	# Lock megacheck version at $MEGACHECK_VERSION to prevent spontaneous
-	# new error messages in old code.
-	go get -d honnef.co/go/tools/...
-	git -C $GOPATH/src/honnef.co/go/tools/ checkout $MEGACHECK_VERSION
-	go install honnef.co/go/tools/cmd/megacheck
-	megacheck --version
-}
-
-golint_install() {
-	go get golang.org/x/lint/golint
-}
-
 $1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.9.x
-  - 1.10.x
   - 1.11.x
+  - 1.12.x
   - master
 
 sudo: true
@@ -14,16 +13,11 @@ env:
     - PQGOSSLTESTS=1
     - PQSSLCERTTEST_PATH=$PWD/certs
     - PGHOST=127.0.0.1
-    - MEGACHECK_VERSION=2017.2.2
   matrix:
     - PGVERSION=10
     - PGVERSION=9.6
     - PGVERSION=9.5
     - PGVERSION=9.4
-    - PGVERSION=9.3
-    - PGVERSION=9.2
-    - PGVERSION=9.1
-    - PGVERSION=9.0
 
 before_install:
   - ./.travis.sh postgresql_uninstall
@@ -31,9 +25,9 @@ before_install:
   - ./.travis.sh postgresql_install
   - ./.travis.sh postgresql_configure
   - ./.travis.sh client_configure
-  - ./.travis.sh megacheck_install
-  - ./.travis.sh golint_install
   - go get golang.org/x/tools/cmd/goimports
+  - go get golang.org/x/lint/golint
+  - GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@2019.2.1
 
 before_script:
   - createdb pqgotest
@@ -44,7 +38,7 @@ script:
   - >
     goimports -d -e $(find -name '*.go') | awk '{ print } END { exit NR == 0 ? 0 : 1 }'
   - go vet ./...
-  - megacheck -go 1.9 ./...
+  - staticcheck -go 1.11 ./...
   - golint ./...
   - PQTEST_BINARY_PARAMETERS=no  go test -race -v ./...
   - PQTEST_BINARY_PARAMETERS=yes go test -race -v ./...

--- a/conn.go
+++ b/conn.go
@@ -92,6 +92,7 @@ type Dialer interface {
 	DialTimeout(network, address string, timeout time.Duration) (net.Conn, error)
 }
 
+// DialerContext is the context-aware dialer interface.
 type DialerContext interface {
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }

--- a/scram/scram.go
+++ b/scram/scram.go
@@ -22,7 +22,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Pacakage scram implements a SCRAM-{SHA-1,etc} client per RFC5802.
+// Package scram implements a SCRAM-{SHA-1,etc} client per RFC5802.
 //
 // http://tools.ietf.org/html/rfc5802
 //


### PR DESCRIPTION
Our tested support for Go versions is changing to the two latest instead
of three latest. This matches what the Go team supports. If lib/pq
happens to not work in older versions of Go, you must use an earlier
version of lib/pq.

Remove tested support for Go 1.9 and 1.10, add Go 1.12. Remove tested
support for unsupported Postgres versions (< 9.4).

Megacheck was renamed to staticcheck.

Fix two issues found by golint.