### PR TITLE
Fixed #887 -- don't nil-ptr-deref when calling RowsAffected on the result of a 0-item CopyIn

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1739,3 +1739,31 @@ func TestMultipleResult(t *testing.T) {
 		t.Fatal("incorrect number of rows returned")
 	}
 }
+
+func TestCopyInStmtAffectedRows(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	_, err := db.Exec("CREATE TEMP TABLE temp (a int)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txn, err := db.BeginTx(context.TODO(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copyStmt, err := txn.Prepare(CopyIn("temp", "a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := copyStmt.Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res.RowsAffected()
+	res.LastInsertId()
+}

--- a/copy.go
+++ b/copy.go
@@ -229,7 +229,7 @@ func (ci *copyin) Exec(v []driver.Value) (r driver.Result, err error) {
 	}
 
 	if len(v) == 0 {
-		return nil, ci.Close()
+		return driver.RowsAffected(0), ci.Close()
 	}
 
 	numValues := len(v)


### PR DESCRIPTION
Fixes #626