### PR TITLE
export ParseArray

### DIFF
--- a/array.go
+++ b/array.go
@@ -341,7 +341,7 @@ func (a GenericArray) Scan(src interface{}) error {
 
 func (a GenericArray) scanBytes(src []byte, dv reflect.Value) error {
 	dtype, assign, del := a.evaluateDestination(dv.Type().Elem())
-	dims, elems, err := parseArray(src, []byte(del))
+	dims, elems, err := ParseArray(src, []byte(del))
 	if err != nil {
 		return err
 	}
@@ -633,13 +633,13 @@ func appendValue(b []byte, v driver.Value) ([]byte, error) {
 	return append(b, encode(nil, v, 0)...), nil
 }
 
-// parseArray extracts the dimensions and elements of an array represented in
+// ParseArray extracts the dimensions and elements of an array represented in
 // text format. Only representations emitted by the backend are supported.
 // Notably, whitespace around brackets and delimiters is significant, and NULL
 // is case-sensitive.
 //
 // See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
-func parseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
+func ParseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
 	var depth, i int
 
 	if len(src) < 1 || src[0] != '{' {
@@ -745,7 +745,7 @@ Close:
 }
 
 func scanLinearArray(src, del []byte, typ string) (elems [][]byte, err error) {
-	dims, elems, err := parseArray(src, del)
+	dims, elems, err := ParseArray(src, del)
 	if err != nil {
 		return nil, err
 	}

--- a/array_test.go
+++ b/array_test.go
@@ -43,7 +43,7 @@ func TestParseArray(t *testing.T) {
 		}},
 		{`{axyzb}`, `xyz`, []int{2}, [][]byte{{'a'}, {'b'}}},
 	} {
-		dims, elems, err := parseArray([]byte(tt.input), []byte(tt.delim))
+		dims, elems, err := ParseArray([]byte(tt.input), []byte(tt.delim))
 
 		if err != nil {
 			t.Fatalf("Expected no error for %q, got %q", tt.input, err)
@@ -77,7 +77,7 @@ func TestParseArrayError(t *testing.T) {
 		{`{""x}`, "unexpected 'x' at offset 3"},
 		{`{{a},{b,c}}`, "multidimensional arrays must have elements with matching dimensions"},
 	} {
-		_, _, err := parseArray([]byte(tt.input), []byte{','})
+		_, _, err := ParseArray([]byte(tt.input), []byte{','})
 
 		if err == nil {
 			t.Fatalf("Expected error for %q, got none", tt.input)


### PR DESCRIPTION
Fixes https://github.com/lib/pq/issues/602

This function is needed for writing custom Scan functions to parse a `JSONB[]` column.