### PR TITLE
Implement database/sql/driver.DriverContext

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -45,6 +45,7 @@ var (
 // Compile time validation that our types implement the expected interfaces
 var (
 	_ driver.Driver             = Driver{}
+	_ driver.DriverContext      = Driver{}
 	_ driver.ConnBeginTx        = (*conn)(nil)
 	_ driver.ConnPrepareContext = (*conn)(nil)
 	_ driver.Execer             = (*conn)(nil) //lint:ignore SA1019 x
@@ -78,6 +79,15 @@ type Driver struct{}
 // library.
 func (d Driver) Open(name string) (driver.Conn, error) {
 	return Open(name)
+}
+
+// OpenConnector sets up a new Connector, ready to create connections. name is a
+// connection string. Most users should only use it through database/sql package
+// from the standard library.
+//
+// Implements [database/sql/driver.DriverContext].
+func (d Driver) OpenConnector(name string) (driver.Connector, error) {
+	return NewConnector(name)
 }
 
 type parameterStatus struct {

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,6 +1,7 @@
 package pq
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/lib/pq/internal/pqtest"
@@ -10,6 +11,14 @@ import (
 func init() { pqtest.DSN("") }
 
 const cancelErrorCode ErrorCode = "57014"
+
+func errCanceled(err error) bool {
+	pgErr := new(Error)
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == cancelErrorCode
+}
 
 // pqError converts an error to *pq.Error, calling t.Fatal() if the error is nil
 // or if this fails.


### PR DESCRIPTION
In order to fully instrument SQL operations (including new conns) by wrapping this driver with something like [`github.com/luna-duclos/instrumentedsql`](https://godoc.org/github.com/luna-duclos/instrumentedsql), this driver needs to implement [`database/sql/driver.DriverContext`](https://godoc.org/database/sql/driver#DriverContext).

Now it does.