### PR TITLE
encode: use sql.NullTime instead of custom type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 
 go:
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
   - master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.11.x
   - 1.12.x
+  - 1.13.x
   - master
 
 sudo: true

--- a/encode.go
+++ b/encode.go
@@ -2,7 +2,6 @@ package pq
 
 import (
 	"bytes"
-	"database/sql/driver"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -577,26 +576,4 @@ func encodeBytea(serverVersion int, v []byte) (result []byte) {
 	}
 
 	return result
-}
-
-// NullTime represents a time.Time that may be null. NullTime implements the
-// sql.Scanner interface so it can be used as a scan destination, similar to
-// sql.NullString.
-type NullTime struct {
-	Time  time.Time
-	Valid bool // Valid is true if Time is not NULL
-}
-
-// Scan implements the Scanner interface.
-func (nt *NullTime) Scan(value interface{}) error {
-	nt.Time, nt.Valid = value.(time.Time)
-	return nil
-}
-
-// Value implements the driver Valuer interface.
-func (nt NullTime) Value() (driver.Value, error) {
-	if !nt.Valid {
-		return nil, nil
-	}
-	return nt.Time, nil
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestScanTimestamp(t *testing.T) {
-	var nt NullTime
+	var nt sql.NullTime
 	tn := time.Now()
 	nt.Scan(tn)
 	if !nt.Valid {
@@ -24,7 +24,7 @@ func TestScanTimestamp(t *testing.T) {
 }
 
 func TestScanNilTimestamp(t *testing.T) {
-	var nt NullTime
+	var nt sql.NullTime
 	nt.Scan(nil)
 	if nt.Valid {
 		t.Errorf("Expected Valid=false")


### PR DESCRIPTION
Addressed issue #902.
Pull request breaks backwards compatibility, so may be custom type shouldn't be removed.