### PR TITLE
failing test with parametrised view

### DIFF
--- a/create_view_with_parameters_test.go
+++ b/create_view_with_parameters_test.go
@@ -1,0 +1,32 @@
+package pq
+
+import (
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer txn.Rollback()
+
+	_, err = txn.Exec("CREATE VIEW foo1 AS SELECT 100") // works
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = txn.Exec("CREATE TABLE foo2 AS SELECT $1", 100) // works
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = txn.Exec("CREATE VIEW foo3 AS SELECT $1", 100) // doesn't work
+	if err != nil {
+		t.Fatal(err)
+	}
+	//			Error:      	Received unexpected error:
+	//        	            	pq: got 1 parameters but the statement requires 0
+	//        	Test:       	TestFoo
+}


### PR DESCRIPTION
hi,
I'm expecting that something like the following stmt would work:
`txn.Exec("CREATE VIEW foo3 AS SELECT $1", 100)`

but instead it seems that the $1 is ignored by the driver and it then fails.

in the test I've put the same stmt with the TABLE and it works, is it a bug or I'm missing something?
thanks,
stefano