### PR TITLE
.travis.yml: use Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.11.x
   - 1.12.x
+  - 1.13.x
   - master
 
 sudo: true


### PR DESCRIPTION
It's the most recent version so we should be using it in tests.

Updates \#936.