### PR TITLE
Skip TestCloseBadConn if PGHOST is a Unix-domain socket.

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -728,6 +728,9 @@ func TestCloseBadConn(t *testing.T) {
 	if host == "" {
 		host = "localhost"
 	}
+	if host[0] == '/' {
+		t.Skip("cannot test bad connection close with a Unix-domain PGHOST")
+	}
 	port := os.Getenv("PGPORT")
 	if port == "" {
 		port = "5432"


### PR DESCRIPTION
The test fails to dial, since $PGHOST:$PGPOST would not be a valid address to connect to.