### PR TITLE
Update readme godoc link to use pkg.go.dev instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pq - A pure Go postgres driver for Go's database/sql package
 
-[![GoDoc](https://godoc.org/github.com/lib/pq?status.svg)](https://godoc.org/github.com/lib/pq)
+[![GoDoc](https://godoc.org/github.com/lib/pq?status.svg)](https://pkg.go.dev/github.com/lib/pq?tab=doc)
 [![Build Status](https://travis-ci.org/lib/pq.svg?branch=master)](https://travis-ci.org/lib/pq)
 
 ## Install
@@ -10,7 +10,7 @@
 ## Docs
 
 For detailed documentation and basic usage examples, please see the package
-documentation at <https://godoc.org/github.com/lib/pq>.
+documentation at <https://pkg.go.dev/github.com/lib/pq?tab=doc>.
 
 ## Tests
 


### PR DESCRIPTION
godoc is deprecated and pkg.go.dev should be used instead.