### PR TITLE
Use evergreen version IDs in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.13.x
-  - 1.14.x
+  - stable
+  - oldstable
   - master
 
 sudo: true


### PR DESCRIPTION
Rather than pinning to specific Go minor releases, use the "stable" and
"oldstable" aliases. These should always point to the most recent patch
releases of the two officially-supported Go minor releases.

This should remove the need for PRs to update the Travis config every
six months.