### PR TITLE
fix concurrent map write when using unix sockets

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -335,10 +335,6 @@ func (c *Connector) open(ctx context.Context) (cn *conn, err error) {
 
 func dial(ctx context.Context, d Dialer, o values) (net.Conn, error) {
 	network, address := network(o)
-	// SSL is not necessary or supported over UNIX domain sockets
-	if network == "unix" {
-		o["sslmode"] = "disable"
-	}
 
 	// Zero or not specified means wait indefinitely.
 	if timeout, ok := o["connect_timeout"]; ok && timeout != "0" {

--- a/connector.go
+++ b/connector.go
@@ -106,5 +106,10 @@ func NewConnector(dsn string) (*Connector, error) {
 		o["user"] = u
 	}
 
+	// SSL is not necessary or supported over UNIX domain sockets
+	if network, _ := network(o); network == "unix" {
+		o["sslmode"] = "disable"
+	}
+
 	return &Connector{opts: o, dialer: defaultDialer{}}, nil
 }


### PR DESCRIPTION
`opts` being mutated in `dial` may cause a concurrent write panic when
many connections are created in parallel. Moving this to `NewConnector`
where mutations are safe.

fixes #948