### PR TITLE
Return rows copied for COPY command

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -49,6 +49,7 @@ type copyin struct {
 	buffer  []byte
 	rowData chan []byte
 	done    chan bool
+	result 	driver.Result
 
 	closed bool
 
@@ -151,6 +152,8 @@ func (ci *copyin) resploop() {
 		switch t {
 		case 'C':
 			// complete
+			res, _ := ci.cn.parseComplete(r.string())
+			ci.setResult(res)
 		case 'N':
 			if n := ci.cn.noticeHandler; n != nil {
 				n(parseError(&r))
@@ -201,6 +204,22 @@ func (ci *copyin) setError(err error) {
 	ci.Unlock()
 }
 
+func (ci *copyin) setResult(result driver.Result) {
+	ci.Lock()
+	ci.result = result
+	ci.Unlock()
+}
+
+func (ci *copyin) getResult() driver.Result {
+	ci.Lock()
+	result := ci.result
+	if result == nil {
+		return driver.RowsAffected(0)
+	}
+	ci.Unlock()
+	return result
+}
+
 func (ci *copyin) NumInput() int {
 	return -1
 }
@@ -231,7 +250,11 @@ func (ci *copyin) Exec(v []driver.Value) (r driver.Result, err error) {
 	}
 
 	if len(v) == 0 {
-		return driver.RowsAffected(0), ci.Close()
+		if err := ci.Close(); err != nil {
+			return driver.RowsAffected(0), err
+		}
+
+		return ci.getResult(), nil
 	}
 
 	numValues := len(v)

--- a/copy.go
+++ b/copy.go
@@ -49,7 +49,7 @@ type copyin struct {
 	buffer  []byte
 	rowData chan []byte
 	done    chan bool
-	result 	driver.Result
+	driver.Result
 
 	closed bool
 
@@ -206,13 +206,13 @@ func (ci *copyin) setError(err error) {
 
 func (ci *copyin) setResult(result driver.Result) {
 	ci.Lock()
-	ci.result = result
+	ci.Result = result
 	ci.Unlock()
 }
 
 func (ci *copyin) getResult() driver.Result {
 	ci.Lock()
-	result := ci.result
+	result := ci.Result
 	if result == nil {
 		return driver.RowsAffected(0)
 	}

--- a/copy_test.go
+++ b/copy_test.go
@@ -73,9 +73,18 @@ func TestCopyInMultipleValues(t *testing.T) {
 		}
 	}
 
-	_, err = stmt.Exec()
+	result, err := stmt.Exec()
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rowsAffected != 500 {
+		t.Fatalf("expected 500 rows affected, not %d", rowsAffected)
 	}
 
 	err = stmt.Close()


### PR DESCRIPTION
Return number of rows copied for COPY command from the CommandComplete postgres message.

Only the final Exec(nil) call will return the driver.Result with rowsAffected.