### PR TITLE
fix incorrect error message then number of parameters in query > 65535

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -784,6 +784,10 @@ func (cn *conn) prepareTo(q, stmtName string) *stmt {
 }
 
 func (cn *conn) Prepare(q string) (_ driver.Stmt, err error) {
+	if strings.Contains(q, "$65535") {
+		return nil, errors.New("number of parameters is more then allowed")
+	}
+	
 	if cn.bad {
 		return nil, driver.ErrBadConn
 	}


### PR DESCRIPTION
postgreSQL allowed query with number of parameters equal 65535 or less(https://github.com/postgres/postgres/blob/7559d8ebfa11d98728e816f6b655582ce41150f3/src/interfaces/libpq/fe-exec.c#L1304), now, when where is more parameters in query, further call to readStatementDescribeResponse (https://github.com/lib/pq/conn.go:1749) will return incorrect value of paramTypes variable(
at least the wrong length of that array ). That will rise error in default go library during call to driver: src/database/sql:119 returns incorrect value and rise "sql: expected %d arguments, got %d", want, len(nvargs) error(src/database/sql:201).

I`ve created a small project, which will help to reproduce occurrence of this incorrect error: https://github.com/GlebZabl/golang_postgres_bug
Feel free to contact me, if you will need more information, by eMail(zabludovskiy.gleb@gmail.com) or telegram messenger(@GlebZabl)