### PR TITLE
Fix query cancellation collateralizing future queries using the same connection

### DIFF
--- a/conn_go18.go
+++ b/conn_go18.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"sync/atomic"
 	"time"
 )
 
@@ -89,10 +90,21 @@ func (cn *conn) Ping(ctx context.Context) error {
 
 func (cn *conn) watchCancel(ctx context.Context) func() {
 	if done := ctx.Done(); done != nil {
-		finished := make(chan struct{})
+		finished := make(chan struct{}, 1)
 		go func() {
 			select {
 			case <-done:
+				select {
+				case finished <- struct{}{}:
+				default:
+					// We raced with the finish func, let the next query handle this with the
+					// context.
+					return
+				}
+
+				// Set the connection state to bad so it does not get reused.
+				cn.setBad()
+
 				// At this point the function level context is canceled,
 				// so it must not be used for the additional network
 				// request to cancel the query.
@@ -101,13 +113,14 @@ func (cn *conn) watchCancel(ctx context.Context) func() {
 				defer cancel()
 
 				_ = cn.cancel(ctxCancel)
-				finished <- struct{}{}
 			case <-finished:
 			}
 		}()
 		return func() {
 			select {
 			case <-finished:
+				cn.setBad()
+				cn.Close()
 			case finished <- struct{}{}:
 			}
 		}
@@ -123,8 +136,11 @@ func (cn *conn) cancel(ctx context.Context) error {
 	defer c.Close()
 
 	{
+		bad := &atomic.Value{}
+		bad.Store(false)
 		can := conn{
-			c: c,
+			c:   c,
+			bad: bad,
 		}
 		err = can.ssl(cn.opts)
 		if err != nil {

--- a/copy.go
+++ b/copy.go
@@ -176,13 +176,13 @@ func (ci *copyin) resploop() {
 
 func (ci *copyin) setBad() {
 	ci.Lock()
-	ci.cn.bad = true
+	ci.cn.setBad()
 	ci.Unlock()
 }
 
 func (ci *copyin) isBad() bool {
 	ci.Lock()
-	b := ci.cn.bad
+	b := ci.cn.getBad()
 	ci.Unlock()
 	return b
 }

--- a/error.go
+++ b/error.go
@@ -484,7 +484,7 @@ func (cn *conn) errRecover(err *error) {
 	case nil:
 		// Do nothing
 	case runtime.Error:
-		cn.bad = true
+		cn.setBad()
 		panic(v)
 	case *Error:
 		if v.Fatal() {
@@ -493,7 +493,7 @@ func (cn *conn) errRecover(err *error) {
 			*err = v
 		}
 	case *net.OpError:
-		cn.bad = true
+		cn.setBad()
 		*err = v
 	case error:
 		if v == io.EOF || v.(error).Error() == "remote error: handshake failure" {
@@ -503,13 +503,13 @@ func (cn *conn) errRecover(err *error) {
 		}
 
 	default:
-		cn.bad = true
+		cn.setBad()
 		panic(fmt.Sprintf("unknown error: %#v", e))
 	}
 
 	// Any time we return ErrBadConn, we need to remember it since *Tx doesn't
 	// mark the connection bad in database/sql.
 	if *err == driver.ErrBadConn {
-		cn.bad = true
+		cn.setBad()
 	}
 }


### PR DESCRIPTION
This change solves the following issue we were seeing in production:
1. A context would get cancelled due to timeout
2. watchCancel would get triggered, and start to send the cancellation
3. Because the cancellation happens concurrently with the normal query path, and doesn't block the finish() path until its done cancelling the query on the postgres side, this connection could be returned to the pool before getting cancelled
4. This connection then gets reused, and gets collateralized by the previous query's cancel request

The changes I've made to ensure we don't run into this collateral damage:
1. When the context is cancelled, we immediately try to send the finished signal to the finished channel to prevent a race. Either we successfully send this, or the query we tried to cancel finished first. In the latter case, we just return, and let a future query (if one happens) trigger the cancellation.
2. In the former case we set the connection state to bad so it doesn't get reused, and cancel the query.
3. When the finish() function gets called, the querier goroutine closes the connection.

Note: We _probably_ don't need to change `bad` to an atomic variable, but I did just to be safe. 