### PR TITLE
Roel/empty-query

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -666,7 +666,6 @@ func (cn *conn) simpleQuery(q string) (res *rows, err error) {
 			if t == 'C' {
 				res.result, res.tag = cn.parseComplete(r.string())
 				if res.colNames != nil {
-					res.tag = ""
 					return
 				}
 			}

--- a/conn.go
+++ b/conn.go
@@ -663,8 +663,12 @@ func (cn *conn) simpleQuery(q string) (res *rows, err error) {
 			// Set the result and tag to the last command complete if there wasn't a
 			// query already run. Although queries usually return from here and cede
 			// control to Next, a query with zero results does not.
-			if t == 'C' && res.colNames == nil {
+			if t == 'C' {
 				res.result, res.tag = cn.parseComplete(r.string())
+				if res.colNames != nil {
+					res.tag = ""
+					return
+				}
 			}
 			res.done = true
 		case 'Z':

--- a/conn_test.go
+++ b/conn_test.go
@@ -1640,10 +1640,6 @@ func TestRowsResultTag(t *testing.T) {
 		{
 			query: "CREATE TEMP TABLE t (a int); DROP TABLE t; SELECT 1",
 		},
-		// Verify that an no-results query doesn't set the tag.
-		{
-			query: "CREATE TEMP TABLE t (a int); SELECT 1 WHERE FALSE; DROP TABLE t;",
-		},
 	}
 
 	// If this is the only test run, this will correct the connection string.

--- a/conn_test.go
+++ b/conn_test.go
@@ -1748,6 +1748,36 @@ func TestMultipleResult(t *testing.T) {
 	}
 }
 
+func TestMultipleEmptyResult(t *testing.T) {
+	db := openTestConn(t)
+	defer db.Close()
+
+	rows, err := db.Query("select 1 where false; select 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		t.Fatal("unexpected row")
+	}
+	if !rows.NextResultSet() {
+		t.Fatal("expected more result sets", rows.Err())
+	}
+	for rows.Next() {
+		var i int
+		if err := rows.Scan(&i); err != nil {
+			t.Fatal(err)
+		}
+		if i != 2 {
+			t.Fatalf("expected 2, got %d", i)
+		}
+	}
+	if rows.NextResultSet() {
+		t.Fatal("unexpected result set")
+	}
+}
+
 func TestCopyInStmtAffectedRows(t *testing.T) {
 	db := openTestConn(t)
 	defer db.Close()


### PR DESCRIPTION
 * Added a test and a fix for handling empty result sets.
 * Had to set res.tag to prevent another test from failing.
 * Not sure what the purpose of this test is. Would prefer to remove both the clearing of res.tag and the offending test (commit 2).
 * Preferably, I would merge both commits, but if the offending test is somehow important we can merge only the first commit.
 * Issue: #1003 