### PR TITLE
Correctly implement database/sql/driver.Driver for better wrappability

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -38,13 +38,18 @@ var (
 	errNoLastInsertID  = errors.New("no LastInsertId available after the empty statement")
 )
 
+// Compile time validation that our types implement the expected interfaces
+var (
+	_ driver.Driver = Driver{}
+)
+
 // Driver is the Postgres database driver.
 type Driver struct{}
 
 // Open opens a new connection to the database. name is a connection string.
 // Most users should only use it through database/sql package from the standard
 // library.
-func (d *Driver) Open(name string) (driver.Conn, error) {
+func (d Driver) Open(name string) (driver.Conn, error) {
 	return Open(name)
 }
 


### PR DESCRIPTION
I was trying to wrap pq with [instrumentedsql](https://github.com/luna-duclos/instrumentedsql), but it does not implement the `database/sql/driver.Driver` type.

Minimal example:

```
package main

import (
	"database/sql"

	"github.com/lib/pq"
	"github.com/luna-duclos/instrumentedsql"
	instrumentedsqltrace "github.com/luna-duclos/instrumentedsql/opentracing"
)

func main() {
	sql.Register("instrumented-postgres", instrumentedsql.WrapDriver(pq.Driver{}, instrumentedsql.WithTracer(instrumentedsqltrace.NewTracer(false))))
}
```

Compile error:

```
./minimal.go:12:76: cannot use pq.Driver literal (type pq.Driver) as type driver.Driver in argument to instrumentedsql.WrapDriver:
	pq.Driver does not implement driver.Driver (Open method has pointer receiver)
```

This patch aims to address this by changing the pointer receiver to a value receiver.