### PR TITLE
Add deprecation notice

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -264,5 +264,7 @@ When imported, additional connection string parameters are supported:
 	  to form the full SPN: `krbsrvname/host`.
 	* krbspn - GSS (Kerberos) SPN. This takes priority over
 	  `krbsrvname` if present.
+
+Deprecated: This package is effectively in maintenance mode and is not actively developed. Small patches and features are only rarely reviewed and merged. We recommend using jackc/pgx which is actively maintained.
 */
 package pq


### PR DESCRIPTION
It has been a little over 6 six months since the sunset notice was added to this project's README.

Use Go's deprecation so that this notice can be discovered programmatically.

Under staticcheck this triggers [SA1019](https://staticcheck.io/docs/checks#SA1019).