### PR TITLE
Mark `net.Conn` failed writes as recoverable when 0 bytes were written.

### DIFF
--- a/error.go
+++ b/error.go
@@ -495,6 +495,9 @@ func (cn *conn) errRecover(err *error) {
 	case *net.OpError:
 		cn.bad = true
 		*err = v
+	case *safeRetryError:
+		cn.bad = true
+		*err = driver.ErrBadConn
 	case error:
 		if v == io.EOF || v.(error).Error() == "remote error: handshake failure" {
 			*err = driver.ErrBadConn


### PR DESCRIPTION
Fixes #723, #870, #897.