### PR TITLE
Remove go 1.13 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.13.x
   - 1.14.x
   - 1.15.x
   - master


### PR DESCRIPTION
Cockroach is now in 1.15 so we can bump the version.