### PR TITLE
Add fuzzer

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,9 @@
+package pq
+
+func FuzzOpen(data []byte) int {
+	_, err := Open(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer for the high-level `Open` API.

Fuzzing is a way of testing applications whereby pseudo-random data is passed to a target entry point with the goal of finding bugs and vulnerabilities.

Running the fuzzer locally for about 30 minutes did not reveal any bugs, and any potential crashes will most likely not be of security-relevance, however fuzzing `Open` does hit some parsing routines and this may reveal some bugs in the code base.

I have worked on setting up continuous fuzzing of pq as well through OSS-fuzz and have the integration files ready to upload on the OSS-fuzz side. This will allow the fuzzer to run continuously and look for harder-to-find bugs.  If bugs are found, maintainers get notified via email with a link to a detailed bug report. All that is needed to set up the integration application with OSS-fuzz is at least one maintainers email address.