### PR TITLE
Fix string quoting in an example in Array

### DIFF
--- a/array.go
+++ b/array.go
@@ -22,7 +22,7 @@ var typeSQLScanner = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
 //  db.Query(`SELECT * FROM t WHERE id = ANY($1)`, pq.Array([]int{235, 401}))
 //
 //  var x []sql.NullInt64
-//  db.QueryRow('SELECT ARRAY[235, 401]').Scan(pq.Array(&x))
+//  db.QueryRow(`SELECT ARRAY[235, 401]`).Scan(pq.Array(&x))
 //
 // Scanning multi-dimensional arrays is not supported.  Arrays where the lower
 // bound is not one (such as `[0:0]={1}') are not supported.


### PR DESCRIPTION
The current quote is invalid Go code and e.g. lights up in VSCode when you hover to get the docstring