### PR TITLE
Fix #1031: concurrent map writes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -298,7 +298,13 @@ func (c *Connector) open(ctx context.Context) (cn *conn, err error) {
 	// the user.
 	defer errRecoverNoErrBadConn(&err)
 
-	o := c.opts
+	// Create a new values map (copy). This makes it so maps in different
+	// connections do not reference the same underlying data structure, so it
+	// is safe for multiple connections to concurrently write to their opts.
+	o := make(values)
+	for k, v := range c.opts {
+		o[k] = v
+	}
 
 	bad := &atomic.Value{}
 	bad.Store(false)

--- a/conn.go
+++ b/conn.go
@@ -1106,7 +1106,7 @@ func isDriverSetting(key string) bool {
 		return true
 	case "password":
 		return true
-	case "sslmode", "sslcert", "sslkey", "sslrootcert":
+	case "sslmode", "sslcert", "sslkey", "sslrootcert", "sslinline":
 		return true
 	case "fallback_application_name":
 		return true

--- a/ssl.go
+++ b/ssl.go
@@ -59,9 +59,6 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 		return nil, err
 	}
 
-	// This pseudo-parameter is not recognized by the PostgreSQL server, so let's delete it after use.
-	delete(o, "sslinline")
-
 	// Accept renegotiation requests initiated by the backend.
 	//
 	// Renegotiation was deprecated then removed from PostgreSQL 9.5, but
@@ -89,9 +86,6 @@ func sslClientCertificates(tlsConf *tls.Config, o values) error {
 	sslinline := o["sslinline"]
 	if sslinline == "true" {
 		cert, err := tls.X509KeyPair([]byte(o["sslcert"]), []byte(o["sslkey"]))
-		// Clear out these params, in case they were to be sent to the PostgreSQL server by mistake
-		o["sslcert"] = ""
-		o["sslkey"] = ""
 		if err != nil {
 			return err
 		}
@@ -157,8 +151,6 @@ func sslCertificateAuthority(tlsConf *tls.Config, o values) error {
 
 		var cert []byte
 		if sslinline == "true" {
-			// // Clear out this param, in case it were to be sent to the PostgreSQL server by mistake
-			o["sslrootcert"] = ""
 			cert = []byte(sslrootcert)
 		} else {
 			var err error


### PR DESCRIPTION
This PR should fix a concurrent map writes bug by making the opts values map in different connections not reference the same underlying data.
It should also fix the sslinline functionality by not deleting the necessary key(s) but instead not sending them to Postgres, allowing multiple connections to upgrade to SSL.

For more information, see the discussion in issue #1031.