### PR TITLE
encode: fix TimeTZ with second offsets

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -200,11 +200,17 @@ func appendEscapedText(buf []byte, text string) []byte {
 func mustParse(f string, typ oid.Oid, s []byte) time.Time {
 	str := string(s)
 
-	// check for a 30-minute-offset timezone
-	if (typ == oid.T_timestamptz || typ == oid.T_timetz) &&
-		str[len(str)-3] == ':' {
-		f += ":00"
+	// Check for a minute and second offset in the timezone.
+	if typ == oid.T_timestamptz || typ == oid.T_timetz {
+		for i := 3; i <= 6; i += 3 {
+			if str[len(str)-i] == ':' {
+				f += ":00"
+				continue
+			}
+			break
+		}
 	}
+
 	// Special case for 24:00 time.
 	// Unfortunately, golang does not parse 24:00 as a proper time.
 	// In this case, we want to try "round to the next day", to differentiate.

--- a/encode_test.go
+++ b/encode_test.go
@@ -59,6 +59,8 @@ var timeTests = []struct {
 		time.FixedZone("", -(7*60*60+42*60)))},
 	{"2001-02-03 04:05:06-07:30:09", time.Date(2001, time.February, 3, 4, 5, 6, 0,
 		time.FixedZone("", -(7*60*60+30*60+9)))},
+	{"2001-02-03 04:05:06+07:30:09", time.Date(2001, time.February, 3, 4, 5, 6, 0,
+		time.FixedZone("", +(7*60*60+30*60+9)))},
 	{"2001-02-03 04:05:06+07", time.Date(2001, time.February, 3, 4, 5, 6, 0,
 		time.FixedZone("", 7*60*60))},
 	{"0011-02-03 04:05:06 BC", time.Date(-10, time.February, 3, 4, 5, 6, 0, time.FixedZone("", 0))},
@@ -251,6 +253,8 @@ func TestTimeWithTimezone(t *testing.T) {
 	}{
 		{"11:59:59+00:00", time.Date(0, 1, 1, 11, 59, 59, 0, time.UTC)},
 		{"11:59:59+04:00", time.Date(0, 1, 1, 11, 59, 59, 0, time.FixedZone("+04", 4*60*60))},
+		{"11:59:59+04:01:02", time.Date(0, 1, 1, 11, 59, 59, 0, time.FixedZone("+04:01:02", 4*60*60+1*60+2))},
+		{"11:59:59-04:01:02", time.Date(0, 1, 1, 11, 59, 59, 0, time.FixedZone("-04:01:02", -(4*60*60+1*60+2)))},
 		{"24:00+00", time.Date(0, 1, 2, 0, 0, 0, 0, time.UTC)},
 		{"24:00Z", time.Date(0, 1, 2, 0, 0, 0, 0, time.UTC)},
 		{"24:00-04:00", time.Date(0, 1, 2, 0, 0, 0, 0, time.FixedZone("-04", -4*60*60))},


### PR DESCRIPTION
lib/pq previously did not work with TimeTZ offsets with second offsets.
Rectify this by modifying the parse format string as appropriate.

Refs: #65066