### PR TITLE
Fix build for illumos and solaris

### DIFF
--- a/user_other.go
+++ b/user_other.go
@@ -1,6 +1,6 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
-// +build js android hurd illumos zos
+// +build js android hurd zos
 
 package pq
 

--- a/user_posix.go
+++ b/user_posix.go
@@ -1,6 +1,6 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
-// +build aix darwin dragonfly freebsd linux nacl netbsd openbsd plan9 solaris rumprun
+// +build aix darwin dragonfly freebsd linux nacl netbsd openbsd plan9 solaris rumprun illumos
 
 package pq
 


### PR DESCRIPTION
From Go 1.13, the illumos build tag implies the solaris build tag (but it's better use both to clarify)