### PR TITLE
implement ConnPrepareContext/StmtQueryContext/StmtExecContext interfaces

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1360,6 +1360,10 @@ func (st *stmt) Close() (err error) {
 }
 
 func (st *stmt) Query(v []driver.Value) (r driver.Rows, err error) {
+	return st.query(v)
+}
+
+func (st *stmt) query(v []driver.Value) (r *rows, err error) {
 	if st.cn.getBad() {
 		return nil, driver.ErrBadConn
 	}

--- a/conn_go18.go
+++ b/conn_go18.go
@@ -11,6 +11,10 @@ import (
 	"time"
 )
 
+const (
+	watchCancelDialContextTimeout = time.Second * 10
+)
+
 // Implement the "QueryerContext" interface
 func (cn *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	list := make([]driver.Value, len(args))
@@ -41,6 +45,14 @@ func (cn *conn) ExecContext(ctx context.Context, query string, args []driver.Nam
 	}
 
 	return cn.Exec(query, list)
+}
+
+// Implement the "ConnPrepareContext" interface
+func (cn *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	if finish := cn.watchCancel(ctx); finish != nil {
+		defer finish()
+	}
+	return cn.Prepare(query)
 }
 
 // Implement the "ConnBeginTx" interface
@@ -109,7 +121,7 @@ func (cn *conn) watchCancel(ctx context.Context) func() {
 				// so it must not be used for the additional network
 				// request to cancel the query.
 				// Create a new context to pass into the dial.
-				ctxCancel, cancel := context.WithTimeout(context.Background(), time.Second*10)
+				ctxCancel, cancel := context.WithTimeout(context.Background(), watchCancelDialContextTimeout)
 				defer cancel()
 
 				_ = cn.cancel(ctxCancel)
@@ -171,4 +183,69 @@ func (cn *conn) cancel(ctx context.Context) error {
 		_, err := io.Copy(ioutil.Discard, c)
 		return err
 	}
+}
+
+// Implement the "StmtQueryContext" interface
+func (st *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	list := make([]driver.Value, len(args))
+	for i, nv := range args {
+		list[i] = nv.Value
+	}
+	finish := st.watchCancel(ctx)
+	r, err := st.query(list)
+	if err != nil {
+		if finish != nil {
+			finish()
+		}
+		return nil, err
+	}
+	r.finish = finish
+	return r, nil
+}
+
+// Implement the "StmtExecContext" interface
+func (st *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	list := make([]driver.Value, len(args))
+	for i, nv := range args {
+		list[i] = nv.Value
+	}
+
+	if finish := st.watchCancel(ctx); finish != nil {
+		defer finish()
+	}
+
+	return st.Exec(list)
+}
+
+// watchCancel is implemented on stmt in order to not mark the parent conn as bad
+func (st *stmt) watchCancel(ctx context.Context) func() {
+	if done := ctx.Done(); done != nil {
+		finished := make(chan struct{})
+		go func() {
+			select {
+			case <-done:
+				// At this point the function level context is canceled,
+				// so it must not be used for the additional network
+				// request to cancel the query.
+				// Create a new context to pass into the dial.
+				ctxCancel, cancel := context.WithTimeout(context.Background(), watchCancelDialContextTimeout)
+				defer cancel()
+
+				_ = st.cancel(ctxCancel)
+				finished <- struct{}{}
+			case <-finished:
+			}
+		}()
+		return func() {
+			select {
+			case <-finished:
+			case finished <- struct{}{}:
+			}
+		}
+	}
+	return nil
+}
+
+func (st *stmt) cancel(ctx context.Context) error {
+	return st.cn.cancel(ctx)
 }

--- a/issues_test.go
+++ b/issues_test.go
@@ -1,6 +1,10 @@
 package pq
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
 
 func TestIssue494(t *testing.T) {
 	db := openTestConn(t)
@@ -22,5 +26,35 @@ func TestIssue494(t *testing.T) {
 
 	if _, err := txn.Query("SELECT 1"); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestIssue1046(t *testing.T) {
+	ctxTimeout := time.Second * 2
+
+	db := openTestConn(t)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	stmt, err := db.PrepareContext(ctx, `SELECT pg_sleep(10) AS id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var d []uint8
+	err = stmt.QueryRowContext(ctx).Scan(&d)
+	dl, _ := ctx.Deadline()
+	since := time.Since(dl)
+	if since > ctxTimeout {
+		t.Logf("FAIL %s: query returned after context deadline: %v\n", t.Name(), since)
+		t.Fail()
+	}
+	expectedErr := &Error{Message: "canceling statement due to user request"}
+	if err == nil || err.Error() != expectedErr.Error() {
+		t.Logf("ctx.Err(): [%T]%+v\n", ctx.Err(), ctx.Err())
+		t.Logf("got err: [%T] %+v expected err: [%T] %+v", err, err, expectedErr, expectedErr)
+		t.Fail()
 	}
 }


### PR DESCRIPTION
See #1046 for more context. (pun intended)

This is almost a line for line copy of #921 with test cases (thanks @kylejbrock). Please let me know what else needs to be done to get this merged. 

Also dropped ci testing of unsupported versions (9.5 and 9.4) per pg docs [here](https://www.postgresql.org/docs/) and added ci testing of versions 11, 12, and 13.

closes #921 
closes #1046 
