### PR TITLE
Fix build in android

### DIFF
--- a/user_posix.go
+++ b/user_posix.go
@@ -1,7 +1,7 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
 //go:build aix || darwin || dragonfly || freebsd || (linux && !android) || nacl || netbsd || openbsd || plan9 || solaris || rumprun || illumos
-// +build aix darwin dragonfly freebsd (linux && !android) nacl netbsd openbsd plan9 solaris rumprun illumos
+// +build aix darwin dragonfly freebsd linux,!android nacl netbsd openbsd plan9 solaris rumprun illumos
 
 package pq
 

--- a/user_posix.go
+++ b/user_posix.go
@@ -1,7 +1,7 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
-//go:build aix || darwin || dragonfly || freebsd || linux || nacl || netbsd || openbsd || plan9 || solaris || rumprun || illumos
-// +build aix darwin dragonfly freebsd linux nacl netbsd openbsd plan9 solaris rumprun illumos
+//go:build aix || darwin || dragonfly || freebsd || (linux && !android) || nacl || netbsd || openbsd || plan9 || solaris || rumprun || illumos
+// +build aix darwin dragonfly freebsd (linux && !android) nacl netbsd openbsd plan9 solaris rumprun illumos
 
 package pq
 


### PR DESCRIPTION
Now build it on android with error:
```text
# github.com/lib/pq
vendor/github.com/lib/pq/user_posix.go:13:6: userCurrent redeclared in this block
	/home/builder/.termux-build/algernon/build/src/github.com/xyproto/algernon/vendor/github.com/lib/pq/user_other.go:8:29: previous declaration

```
Because that GOOS=android implies GOOS=linux see [https://pkg.go.dev/cmd/go#hdr-Build_constraints](https://pkg.go.dev/cmd/go#hdr-Build_constraints)
> Using GOOS=android matches build tags and files as for GOOS=linux in addition to android tags and files.

Fixes #1051 