### PR TITLE
Fix flaky TestConnPrepareContext

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1828,7 +1828,7 @@ func TestConnPrepareContext(t *testing.T) {
 		{
 			name: "context.WithTimeout exceeded",
 			ctx: func() (context.Context, context.CancelFunc) {
-				return context.WithTimeout(context.Background(), time.Microsecond)
+				return context.WithTimeout(context.Background(), -time.Minute)
 			},
 			sql: "SELECT 1",
 			err: context.DeadlineExceeded,


### PR DESCRIPTION
TestConnPrepareContext checks it receives an context.DeadlineExceeded. However,
the context isn't necessarily always expired. This causes most of the test runs
to fail for me, only occasionally succeeding. This change ensures the context
used in the test is actually context.DeadlineExceeded. The negative duration
causes the context package to return an already canceled context.