### PR TITLE
issue/1072 Fix Issue Parsing a timestamp string outputed by the formatter based on a UTC +00 time.Date

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -422,7 +422,7 @@ func ParseTimestamp(currentLocation *time.Location, str string) (time.Time, erro
 
 	if remainderIdx < len(str) && str[remainderIdx] == '.' {
 		fracStart := remainderIdx + 1
-		fracOff := strings.IndexAny(str[fracStart:], "-+ ")
+		fracOff := strings.IndexAny(str[fracStart:], "-+Z ")
 		if fracOff < 0 {
 			fracOff = len(str) - fracStart
 		}
@@ -432,7 +432,7 @@ func ParseTimestamp(currentLocation *time.Location, str string) (time.Time, erro
 		remainderIdx += fracOff + 1
 	}
 	if tzStart := remainderIdx; tzStart < len(str) && (str[tzStart] == '-' || str[tzStart] == '+') {
-		// time zone separator is always '-' or '+' (UTC is +00)
+		// time zone separator is always '-' or '+' or 'Z' (UTC is +00)
 		var tzSign int
 		switch c := str[tzStart]; c {
 		case '-':
@@ -454,7 +454,11 @@ func ParseTimestamp(currentLocation *time.Location, str string) (time.Time, erro
 			remainderIdx += 3
 		}
 		tzOff = tzSign * ((tzHours * 60 * 60) + (tzMin * 60) + tzSec)
+	} else if tzStart < len(str) && str[tzStart] == 'Z' {
+		// time zone Z separator indicates UTC is +00
+		remainderIdx += 1
 	}
+
 	var isoYear int
 
 	if isBC {

--- a/encode_test.go
+++ b/encode_test.go
@@ -828,6 +828,43 @@ func TestAppendEscapedTextExistingBuffer(t *testing.T) {
 	}
 }
 
+var formatAndParseTimestamp = []struct {
+	time     time.Time
+	expected string
+}{
+	{time.Time{}, "0001-01-01 00:00:00Z"},
+	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 0)), "2001-02-03 04:05:06.123456789Z"},
+	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 2*60*60)), "2001-02-03 04:05:06.123456789+02:00"},
+	{time.Date(2001, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", -6*60*60)), "2001-02-03 04:05:06.123456789-06:00"},
+	{time.Date(2001, time.February, 3, 4, 5, 6, 0, time.FixedZone("", -(7*60*60+30*60+9))), "2001-02-03 04:05:06-07:30:09"},
+
+	{time.Date(1, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 0)), "0001-02-03 04:05:06.123456789Z"},
+	{time.Date(1, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 2*60*60)), "0001-02-03 04:05:06.123456789+02:00"},
+	{time.Date(1, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", -6*60*60)), "0001-02-03 04:05:06.123456789-06:00"},
+
+	{time.Date(0, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 0)), "0001-02-03 04:05:06.123456789Z BC"},
+	{time.Date(0, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", 2*60*60)), "0001-02-03 04:05:06.123456789+02:00 BC"},
+	{time.Date(0, time.February, 3, 4, 5, 6, 123456789, time.FixedZone("", -6*60*60)), "0001-02-03 04:05:06.123456789-06:00 BC"},
+
+	{time.Date(1, time.February, 3, 4, 5, 6, 0, time.FixedZone("", -(7*60*60+30*60+9))), "0001-02-03 04:05:06-07:30:09"},
+	{time.Date(0, time.February, 3, 4, 5, 6, 0, time.FixedZone("", -(7*60*60+30*60+9))), "0001-02-03 04:05:06-07:30:09 BC"},
+}
+
+func TestFormatAndParseTimestamp(t *testing.T) {
+	for _, val := range formatAndParseTimestamp {
+		formattedTime := FormatTimestamp(val.time)
+		parsedTime, err := ParseTimestamp(nil, string(formattedTime))
+
+		if err != nil {
+			t.Errorf("invalid parsing, err: %v", err.Error())
+		}
+
+		if val.time.UTC() != parsedTime.UTC() {
+			t.Errorf("invalid parsing from formatted timestamp, got %v; expected %v", parsedTime.String(), val.time.String())
+		}
+	}
+}
+
 func BenchmarkAppendEscapedText(b *testing.B) {
 	longString := ""
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Fix for [issue/1072](https://github.com/lib/pq/issues/1072)
Made sure the `ParseTimestamp` takes into account the 'Z' timezone separator. 

This also happens to fix a problem mentioned in [issue/606](https://github.com/lib/pq/issues/606#issuecomment-641821051)
