### PR TITLE
error: add SQLState

### DIFF
--- a/error.go
+++ b/error.go
@@ -402,6 +402,11 @@ func (err *Error) Fatal() bool {
 	return err.Severity == Efatal
 }
 
+// SQLState returns the SQLState of the error.
+func (err *Error) SQLState() string {
+	return string(err.Code)
+}
+
 // Get implements the legacy PGError interface. New code should use the fields
 // of the Error struct directly.
 func (err *Error) Get(k byte) (v string) {

--- a/go18_test.go
+++ b/go18_test.go
@@ -334,3 +334,19 @@ func TestTxOptions(t *testing.T) {
 		t.Errorf("Expected error to mention isolation level, got %q", err)
 	}
 }
+
+func TestErrorSQLState(t *testing.T) {
+	r := readBuf([]byte{67, 52, 48, 48, 48, 49, 0, 0}) // 40001
+	err := parseError(&r)
+	var sqlErr errWithSQLState
+	if !errors.As(err, &sqlErr) {
+		t.Fatal("SQLState interface not satisfied")
+	}
+	if state := err.SQLState(); state != "40001" {
+		t.Fatalf("unexpected SQL state %v", state)
+	}
+}
+
+type errWithSQLState interface {
+	SQLState() string
+}


### PR DESCRIPTION
SQLState is also implemented in pgx.
This change allows to get the SQL state without importing lib/pq, see
for example here:

https://github.com/cockroachdb/cockroach-go/blob/e1659d1d3580897bce4cea1181724872d792ce53/crdb/tx.go#L232

to understand why it is useful