### PR TITLE
feat: change the connector dialer

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -322,7 +322,7 @@ func DialOpen(d Dialer, dsn string) (_ driver.Conn, err error) {
 	if err != nil {
 		return nil, err
 	}
-	c.dialer = d
+	c.Dialer(d)
 	return c.open(context.Background())
 }
 

--- a/connector.go
+++ b/connector.go
@@ -27,6 +27,11 @@ func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 	return c.open(ctx)
 }
 
+// Dialer allows change the dialer used to open connections.
+func (c *Connector) Dialer(dialer Dialer) {
+	c.dialer = dialer
+}
+
 // Driver returns the underlying driver of this Connector.
 func (c *Connector) Driver() driver.Driver {
 	return &Driver{}


### PR DESCRIPTION
Add a public method on the connector to change the dialer.

We need this as we would like to use `NewConnector` directly without going through `DialOpen`, which seems to be the only other way to provide a custom dialer and benefit from dsn parsing. 