### PR TITLE
Use pointer receiver on pq.Error.Error()

### DIFF
--- a/error.go
+++ b/error.go
@@ -449,7 +449,7 @@ func (err *Error) Get(k byte) (v string) {
 	return ""
 }
 
-func (err Error) Error() string {
+func (err *Error) Error() string {
 	return "pq: " + err.Message
 }
 


### PR DESCRIPTION
The library returns *pq.Error and not pq.Error.

By using a value receiver, the library was documenting that consumers
should expect returned error values to contain pq.Error.

While *pq.Error implements all methods on pq.Error, *pq.Error is not
assignable to pq.Error and so you can't type assert an error value into
pq.Error if it actually contains *pq.Error.

In particular, this is a problem with errors.As. The following if
condition will always return false.

    var pqe pq.Error
    if errors.As(err, &pqe) {
      // Never reached as *pq.Error is not assignable to pqe.
      ...
    }