### PR TITLE
Fix build tags for user_other file.

### DIFF
--- a/user_other.go
+++ b/user_other.go
@@ -1,7 +1,11 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
-//go:build js || android || hurd || zos || !solaris || !illumos
-// +build js android hurd zos !solaris !illumos
+// For some reason the current setup with the build tags causes this version of the userCurrent to be defined twice on at least illumos 
+// (thus porbably solaris aswell) to make the exclusion explicit the build tags listed here are an inverted mirror of those used in user_posix
+// user_windows still provides the function on windows NT based platforms. 
+
+//go:build js || android || hurd || zos || !aix || !darwin || !dragonfly || !freebsd || !nacl || !netbsd || !openbsd || !plan9 || !solaris || !rumprun || !illumos
+// +build js android hurd zos !aix !darwin !dragonfly !freebsd !nacl !netbsd !openbsd !plan9 !solaris !rumprun !illumos
 
 package pq
 

--- a/user_other.go
+++ b/user_other.go
@@ -1,7 +1,7 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
-//go:build js || android || hurd || zos
-// +build js android hurd zos
+//go:build js || android || hurd || zos || !solaris || !illumos
+// +build js android hurd zos !solaris !illumos
 
 package pq
 


### PR DESCRIPTION
During the compilation of gitea on illumos I ran into the issue that both `user_posix.go` and `user_other.go` where considered for inclusion by the golang compiler with golang 1.18. 

This PR forces the golang compiler to exclude user_other on all platforms mentioned in user_posix.

Testing on Windows should be done for this PR as I do not own any Windows machine and it is likely that `user_other.go` also conflicts with`user_windows.go`.