### PR TITLE
Set SNI for TSL connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1127,7 +1127,7 @@ func isDriverSetting(key string) bool {
 		return true
 	case "password":
 		return true
-	case "sslmode", "sslcert", "sslkey", "sslrootcert", "sslinline":
+	case "sslmode", "sslcert", "sslkey", "sslrootcert", "sslinline", "sslsni":
 		return true
 	case "fallback_application_name":
 		return true
@@ -2020,6 +2020,8 @@ func parseEnviron(env []string) (out map[string]string) {
 			accrue("sslkey")
 		case "PGSSLROOTCERT":
 			accrue("sslrootcert")
+		case "PGSSLSNI":
+			accrue("sslsni")
 		case "PGREQUIRESSL", "PGSSLCRL":
 			unsupported()
 		case "PGREQUIREPEER":


### PR DESCRIPTION
This allows an SNI-aware proxy to route connections. Patch adds a new
connection option (`sslsni`) for opting out of the SNI, to have the same
behavior as `libpq` does. See more in `sslsni` sections at
<https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS>.