### PR TITLE
Use bytes.Buffer to read in recvMessage

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1016,17 +1016,12 @@ func (cn *conn) recvMessage(r *readBuf) (byte, error) {
 	// read the type and length of the message that follows
 	t := x[0]
 	n := int(binary.BigEndian.Uint32(x[1:])) - 4
-	var y []byte
-	if n <= len(cn.scratch) {
-		y = cn.scratch[:n]
-	} else {
-		y = make([]byte, n)
-	}
-	_, err = io.ReadFull(cn.buf, y)
+	buf := bytes.NewBuffer(cn.scratch[:0])
+	_, err = io.CopyN(buf, cn.buf, int64(n))
 	if err != nil {
 		return 0, err
 	}
-	*r = y
+	*r = buf.Bytes()
 	return t, nil
 }
 


### PR DESCRIPTION
In our testing we've noticed that attempts to connect to hosts that are not actually PostgreSQL can lead to excessive memory usage and DoS. Instead of allocating a potentially large slice up front, this PR uses a `*bytes.Buffer` to dynamically resize the slice as needed. If EOF is encountered early (like in the example below) then the program avoids allocating extremely large slices.

Here is a small program to reproduce the issue. It easily uses over 9 GB RAM locally and it takes a while for the GC to reclaim the memory.

https://go.dev/play/p/9t07FdtaW9q