### PR TITLE
allow ssl over UNIX domain sockets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,16 @@ jobs:
       fail-fast: false
       matrix:
         postgres:
+          - '15'
+          - '14'
           - '13'
           - '12'
           - '11'
-          - '10'
-          - '9.6'
         go:
+          - '1.20'
+          - '1.19'
+          - '1.18'
           - '1.17'
-          - '1.16'
-          - '1.15'
-          - '1.14'
     steps:
     - name: setup postgres pre-reqs
       run: |
@@ -169,10 +169,10 @@ jobs:
         docker exec pg createuser -h localhost -U postgres -DRS pqgosslcert
 
     - name: check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: set up go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go }}
       id: go

--- a/connector.go
+++ b/connector.go
@@ -111,10 +111,5 @@ func NewConnector(dsn string) (*Connector, error) {
 		o["user"] = u
 	}
 
-	// SSL is not necessary or supported over UNIX domain sockets
-	if network, _ := network(o); network == "unix" {
-		o["sslmode"] = "disable"
-	}
-
 	return &Connector{opts: o, dialer: defaultDialer{}}, nil
 }

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -86,6 +87,10 @@ func TestSSLVerifyFull(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+	// in Go 1.20 the error is wrapped in tls.CertificateVerificationError
+	if errWrapped := errors.Unwrap(err); errWrapped != nil {
+		err = errWrapped
+	}
 	_, ok := err.(x509.UnknownAuthorityError)
 	if !ok {
 		_, ok := err.(x509.HostnameError)
@@ -100,6 +105,9 @@ func TestSSLVerifyFull(t *testing.T) {
 	_, err = openSSLConn(t, rootCert+"host=127.0.0.1 sslmode=verify-full user=pqgossltest")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+	if errWrapped := errors.Unwrap(err); errWrapped != nil {
+		err = errWrapped
 	}
 	_, ok = err.(x509.HostnameError)
 	if !ok {


### PR DESCRIPTION
It is not supported in Postgres 9.6

https://www.postgresql.org/docs/9.6/runtime-config-connection.html

>  SSL communication is only possible with TCP/IP connections.

but it is supported in Postgres 10 and above

https://www.postgresql.org/docs/10/runtime-config-connection.html

Here are the supported Postgres versions:

https://www.postgresql.org/support/versioning/