### PR TITLE
Patch for saving Table OID and Attribute Number

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1955,7 +1955,8 @@ func parseStatementRowDescribe(r *readBuf) (colNames []string, colTyps []fieldDe
 	colTyps = make([]fieldDesc, n)
 	for i := range colNames {
 		colNames[i] = r.string()
-		r.next(6)
+		colTyps[i].TableOID = r.oid()
+		colTyps[i].AtribNr = r.int16()
 		colTyps[i].OID = r.oid()
 		colTyps[i].Len = r.int16()
 		colTyps[i].Mod = r.int32()
@@ -1972,7 +1973,8 @@ func parsePortalRowDescribe(r *readBuf) rowsHeader {
 	colTyps := make([]fieldDesc, n)
 	for i := range colNames {
 		colNames[i] = r.string()
-		r.next(6)
+		colTyps[i].TableOID = r.oid()
+		colTyps[i].AtribNr = r.int16()
 		colTyps[i].OID = r.oid()
 		colTyps[i].Len = r.int16()
 		colTyps[i].Mod = r.int32()

--- a/rows.go
+++ b/rows.go
@@ -11,8 +11,16 @@ import (
 const headerSize = 4
 
 type fieldDesc struct {
+	
+	//If the field can be identified as a column of a specific table, the object ID of the table; otherwise zero.
+	TableOID oid.Oid
+	
+	//If the field can be identified as a column of a specific table, the attribute number of the column; otherwise zero.
+	AtribNr int
+	
 	// The object ID of the data type.
 	OID oid.Oid
+	
 	// The data type size (see pg_type.typlen).
 	// Note that negative values denote variable-width types.
 	Len int


### PR DESCRIPTION
When columns are renamed in sql queries, tracking the original table and column is not possible in the current implementation.

Example:
```
SELECT users.user_names AS username, posts.text AS post_text from users
LEFT INNER JOIN posts ON posts.user_id = users.id
```
In this query the original table will not be accessible, despite postgres acctually returning that information.

This patch adds two propertys to the fieldDesc struct and code to parse those fields from the postgres response.
Originally mentioned in https://github.com/lib/pq/issues/363