### PR TITLE
Use and respect the passfile connection parameter

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -233,11 +233,8 @@ func (cn *conn) handlePgpass(o values) {
 	if _, ok := o["password"]; ok {
 		return
 	}
-	// Get passfile from the options, if empty, get it from envvar
+	// Get passfile from the options
 	filename := o["passfile"]
-	if filename == "" {
-		filename = os.Getenv("PGPASSFILE")
-	}
 	if filename == "" {
 		// XXX this code doesn't work on Windows where the default filename is
 		// XXX %APPDATA%\postgresql\pgpass.conf
@@ -2042,6 +2039,8 @@ func parseEnviron(env []string) (out map[string]string) {
 			accrue("user")
 		case "PGPASSWORD":
 			accrue("password")
+		case "PGPASSFILE":
+			accrue("passfile")
 		case "PGSERVICE", "PGSERVICEFILE", "PGREALM":
 			unsupported()
 		case "PGOPTIONS":

--- a/conn.go
+++ b/conn.go
@@ -233,7 +233,11 @@ func (cn *conn) handlePgpass(o values) {
 	if _, ok := o["password"]; ok {
 		return
 	}
-	filename := os.Getenv("PGPASSFILE")
+	// Get passfile from the options, if empty, get it from envvar
+	filename := o["passfile"]
+	if filename == "" {
+		filename = os.Getenv("PGPASSFILE")
+	}
 	if filename == "" {
 		// XXX this code doesn't work on Windows where the default filename is
 		// XXX %APPDATA%\postgresql\pgpass.conf

--- a/conn_test.go
+++ b/conn_test.go
@@ -189,6 +189,7 @@ localhost:*:*:*:pass_C
 	if err != nil {
 		t.Fatalf("Unexpected error writing pgpass file %#v", err)
 	}
+	defer os.Remove(pgpassFile)
 	pgpass.Close()
 
 	assertPassword := func(extra values, expected string) {
@@ -221,8 +222,11 @@ localhost:*:*:*:pass_C
 	// localhost also matches the default "" and UNIX sockets
 	assertPassword(values{"host": "", "user": "some_user"}, "pass_C")
 	assertPassword(values{"host": "/tmp", "user": "some_user"}, "pass_C")
+	// passfile connection parameter takes precedence
+	os.Setenv("PGPASSFILE", "/tmp")
+	assertPassword(values{"host": "server", "dbname": "some_db", "user": "some_user", "passfile": pgpassFile}, "pass_A")
+
 	// cleanup
-	os.Remove(pgpassFile)
 	os.Setenv("PGPASSFILE", "")
 }
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"os"
 	"testing"
 )
 
@@ -65,4 +66,22 @@ func TestNewConnector_Driver(t *testing.T) {
 		t.Fatal(err)
 	}
 	txn.Rollback()
+}
+
+func TestNewConnector_Environ(t *testing.T) {
+	name := ""
+	os.Setenv("PGPASSFILE", "/tmp/.pgpass")
+	defer os.Unsetenv("PGPASSFILE")
+	c, err := NewConnector(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, expected := range map[string]string{
+		"passfile": "/tmp/.pgpass",
+	} {
+		if got := c.opts[key]; got != expected {
+			t.Fatalf("Getting values from environment variables, for %v expected %s got %s", key, expected, got)
+		}
+	}
+
 }


### PR DESCRIPTION
The postgres documentation[1] regarding the password file, states
that:

password file to use can be specified using the connection parameter
passfile or the environment variable PGPASSFILE.

The current implementation of lib/pq only respects the environment
variable PGPASSFILE. This is not correct, but also limiting, as
the PGPASSFILE is global and we might want to use different files
for different clients in the same program.

Fixing that is easy, by just checking the parameter passfile first,
and if not, pull the value from PGPASSFILE.

[1] https://www.postgresql.org/docs/current/libpq-pgpass.html

How to test
-----------

Start a postgres
```
docker run --name libpq-postgres \
    --net host \
    -e POSTGRES_DB=pqgotest \
    -e POSTGRES_USER=$(whoami) \
    -e POSTGRES_HOST_AUTH_METHOD="trust" \
    -d postgres
```

Run the test `go test -run TestPgpass -v .`