### PR TITLE
wasip1: compile user_posix.go on GOOS=wasip1

### DIFF
--- a/user_posix.go
+++ b/user_posix.go
@@ -1,7 +1,7 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
-//go:build aix || darwin || dragonfly || freebsd || (linux && !android) || nacl || netbsd || openbsd || plan9 || solaris || rumprun || illumos
-// +build aix darwin dragonfly freebsd linux,!android nacl netbsd openbsd plan9 solaris rumprun illumos
+//go:build aix || darwin || dragonfly || freebsd || (linux && !android) || nacl || netbsd || openbsd || plan9 || solaris || rumprun || illumos || wasip1
+// +build aix darwin dragonfly freebsd linux,!android nacl netbsd openbsd plan9 solaris rumprun illumos wasip1
 
 package pq
 


### PR DESCRIPTION
Hello!

The upcoming Go 1.21 is going to a new port named `wasip1`. At this time `lib/pq` fails to compile for this new target due to the `user_*.go` build tags. See the draft release notes for details https://tip.golang.org/doc/go1.21#wasip1

With this PR, I would like to suggest that we add the `wasip1` tag to `user_posix.go` so the file gets included in Go programs compiled with `GOOS=wasip1`, which then defines the missing `userCurrent` function.

Please let me know if you have any questions!