### PR TITLE
use build tag to not build ssl_permissions.go on Plan9

### DIFF
--- a/ssl_permissions.go
+++ b/ssl_permissions.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !plan9
+// +build !windows,!plan9
 
 package pq
 

--- a/ssl_plan9.go
+++ b/ssl_plan9.go
@@ -1,0 +1,10 @@
+//go:build plan9
+// +build plan9
+
+package pq
+
+// sslKeyPermissions checks the permissions on user-supplied ssl key files.
+// The key file should have very little access.
+//
+// libpq does not check key file permissions on Plan 9.
+func sslKeyPermissions(string) error { return nil }


### PR DESCRIPTION
That file uses syscall.Stat_t, which is not defined on Plan 9.