### PR TITLE
conn#readReadyForQuery(): on error (E) message throw that specific error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1809,6 +1809,10 @@ func (cn *conn) readReadyForQuery() {
 	case 'Z':
 		cn.processReadyForQuery(r)
 		return
+	case 'E':
+		err := parseError(r)
+		cn.err.set(driver.ErrBadConn)
+		panic(err)
 	default:
 		cn.err.set(driver.ErrBadConn)
 		errorf("unexpected message %q; expected ReadyForQuery", t)


### PR DESCRIPTION
not a generic one, so that the application can decide how to handle it. Sure it is an "unexpected message", but not a protocol error:

> A frontend must be prepared to accept ErrorResponse and NoticeResponse
> messages whenever it is expecting any other type of message.

-- https://www.postgresql.org/docs/current/protocol-flow.html

fixes #478