### PR TITLE
ssl: allow sslinline without client certs

### DIFF
--- a/ssl.go
+++ b/ssl.go
@@ -96,6 +96,11 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 func sslClientCertificates(tlsConf *tls.Config, o values) error {
 	sslinline := o["sslinline"]
 	if sslinline == "true" {
+		// If sslinline is specified and no client certificates are provided, skip them
+		if o["sslcert"] == "" && o["sslkey"] == "" {
+			return nil
+		}
+
 		cert, err := tls.X509KeyPair([]byte(o["sslcert"]), []byte(o["sslkey"]))
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently, when using sslinline=true, client certificates are always attempted to be parsed
even when not provided. This differs from the behaviour when sslinline is not used, where
client certificates are optional and will not be set if not specified.

This change allows connections to be established when sslinline is used but client certificates
are not provided.

A use-case for this would be verifying the database SSL via `verify-ca` and inlining sslrootcert,
while still leaving client certificates unspecified.