### PR TITLE
Allow to change (or disable) the default driver name for registration

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -57,8 +57,19 @@ func (d Driver) Open(name string) (driver.Conn, error) {
 	return Open(name)
 }
 
+// This variable can be replaced with -ldflags like below:
+// go build "-ldflags=-X github.com/lib/pq.driverName=custom"
+var driverName = "postgres"
+
 func init() {
-	sql.Register("postgres", &Driver{})
+	if driverName != "" {
+		sql.Register(driverName, &Driver{})
+	}
+}
+
+// DriverName return default driver name
+func DriverName() string {
+	return driverName
 }
 
 type parameterStatus struct {
@@ -1251,7 +1262,7 @@ func (cn *conn) auth(r *readBuf, o values) {
 			token, err = cli.GetInitTokenFromSpn(spn)
 		} else {
 			// Allow the kerberos service name to be overridden
-			service := "postgres"
+			service := driverName
 			if val, ok := o["krbsrvname"]; ok {
 				service = val
 			}

--- a/conn_test.go
+++ b/conn_test.go
@@ -15,6 +15,16 @@ import (
 	"time"
 )
 
+// This variable can be replaced with -ldflags like below:
+// go test "-ldflags=-X github.com/lib/pq.driverNameTest=custom"
+var driverNameTest string
+
+func init() {
+	if driverNameTest == "" {
+		driverNameTest = driverName
+	}
+}
+
 type Fatalistic interface {
 	Fatal(args ...interface{})
 }
@@ -49,7 +59,7 @@ func testConninfo(conninfo string) string {
 }
 
 func openTestConnConninfo(conninfo string) (*sql.DB, error) {
-	return sql.Open("postgres", testConninfo(conninfo))
+	return sql.Open(driverNameTest, testConninfo(conninfo))
 }
 
 func openTestConn(t Fatalistic) *sql.DB {
@@ -1969,5 +1979,12 @@ func TestStmtExecContext(t *testing.T) {
 				t.Errorf("stmt.QueryContext() got = %v, cancelExpected = %v", err.Error(), tt.cancelExpected)
 			}
 		})
+	}
+}
+
+func TestDriverName(t *testing.T) {
+	dn := DriverName()
+	if dn != driverName {
+		t.Fatalf("DriverName() returned driverName: %v, want: %v", dn, driverName)
 	}
 }

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -359,7 +359,7 @@ func TestSNISupport(t *testing.T) {
 
 			// We are okay to skip this error as we are polling serverErrChan and we'll get an error
 			// or timeout from the server side in case of problems here.
-			db, _ := sql.Open("postgres", connStr)
+			db, _ := sql.Open(driverNameTest, connStr)
 			_, _ = db.Exec("SELECT 1")
 
 			// Check SNI data

--- a/url.go
+++ b/url.go
@@ -35,7 +35,7 @@ func ParseURL(url string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
+	if u.Scheme != driverName && u.Scheme != "postgresql" {
 		return "", fmt.Errorf("invalid connection protocol: %s", u.Scheme)
 	}
 


### PR DESCRIPTION
## Description
A link variable now allows to change or disable the name of the driver that is automatically registered with `database/sql`.
This allows users to give the `postgres` name to another `database/sql` driver.

The implementation is the same as in: https://github.com/go-sql-driver/mysql driver. See https://github.com/go-sql-driver/mysql/blob/af8d7931954ec21a96df9610a99c09c2887f2ee7/driver.go#L92

### Usage
Change the driver name to `custom`:
```
go build "-ldflags=-X github.com/lib/pq.driverName=custom"
```

Disable the automatic driver registration (set `driverName` to an empty string):
```
go build "-ldflags=-X github.com/lib/pq.driverName="
```

In the same way, a variable overridable at link time is also provided to override the driver name used in the test suite. This allows to run our test suite on another driver.
```
go build "-ldflags=-X github.com/lib/pq.driverNameTest=custom"
```

`driverName` is propagated to `driverNameTest` unless `driverNameTest` is explicitely defined.