### PR TITLE
Enforce integer limits of the Postgres wire protocol

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -3,6 +3,7 @@ package pq
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 
 	"github.com/lib/pq/oid"
 )
@@ -79,12 +80,18 @@ func (b *writeBuf) bytes(v []byte) {
 
 func (b *writeBuf) wrap() []byte {
 	p := b.buf[b.pos:]
+	if len(p) > math.MaxUint32 {
+		panic("message too large")
+	}
 	binary.BigEndian.PutUint32(p, uint32(len(p)))
 	return b.buf
 }
 
 func (b *writeBuf) next(c byte) {
 	p := b.buf[b.pos:]
+	if len(p) > math.MaxUint32 {
+		panic("message too large")
+	}
 	binary.BigEndian.PutUint32(p, uint32(len(p)))
 	b.pos = len(b.buf) + 1
 	b.buf = append(b.buf, c, 0, 0, 0, 0)

--- a/conn.go
+++ b/conn.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"os/user"
@@ -820,6 +821,9 @@ func decideColumnFormats(
 		return colFmts, colFmtDataAllText
 	} else {
 		colFmtData = make([]byte, 2+len(colFmts)*2)
+		if len(colFmts) > math.MaxUint16 {
+			panic("too many columns")
+		}
 		binary.BigEndian.PutUint16(colFmtData, uint16(len(colFmts)))
 		for i, v := range colFmts {
 			binary.BigEndian.PutUint16(colFmtData[2+i*2:], uint16(v))

--- a/copy.go
+++ b/copy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 )
 
@@ -140,6 +141,9 @@ awaitCopyInResponse:
 }
 
 func (ci *copyin) flush(buf []byte) {
+	if len(buf)-1 > math.MaxUint32 {
+		panic("too many columns")
+	}
 	// set message length (without message identifier)
 	binary.BigEndian.PutUint32(buf[1:], uint32(len(buf)-1))
 


### PR DESCRIPTION
## Problem
The Postgres wire protocol has certain fields that contain fixed-size integers, such as the 32-bit message length ([see here](https://www.postgresql.org/docs/current/protocol-message-formats.html)). This library does not check if values fit into these fixed-size fields before writing them to the buffer. This can lead to the truncation of the values being written, causing corrupted messages.

Example: If the message to be sent is `4**32 + 4` bytes long, the length cannot fit into the 4-byte length field. The value written to the buffer will be `\x00\x00\x00\x04`, which gets decoded to `4` by the Postgres database when it receives such a message. Therefore, the Postgres database will think the message has a length of 4 and will try to read the next message after those 4 bytes.

After such a malformed message, the client and the database have different understandings of where messages start and end. In the best case, this causes a connection abort due to a parsing error. In the worst case, this leads to the execution of malicious SQL statements that an attacker has injected into a large payload that ends up in an SQL query.

## Solution
I added size checks that error if the value being written is too large for its field. Since the functions that I changed don't return errors, I had to `panic()` in the error case. I opted for this route because I noticed that other functions do the same ([example 1](https://github.com/lib/pq/blob/3d613208bca2e74f2a20e04126ed30bcb5c4cc27/encode.go#L85), [example 2](https://github.com/lib/pq/blob/3d613208bca2e74f2a20e04126ed30bcb5c4cc27/encode.go#L373)). Please let me know if there's a different error-handling mechanism I should use; then I'll amend the PR.