### PR TITLE
avoid excessive array wrapping

### DIFF
--- a/array.go
+++ b/array.go
@@ -60,9 +60,26 @@ func Array(a interface{}) interface {
 		return (*StringArray)(a)
 	case *[][]byte:
 		return (*ByteaArray)(a)
+
+	case *BoolArray:
+		return a
+	case *Float64Array:
+		return a
+	case *Float32Array:
+		return a
+	case *Int64Array:
+		return a
+	case *Int32Array:
+		return a
+	case *StringArray:
+		return a
+	case *ByteaArray:
+		return a
+	case *GenericArray:
+		return a
 	}
 
-	return GenericArray{a}
+	return GenericArray{A: a}
 }
 
 // ArrayDelimiter may be optionally implemented by driver.Valuer or sql.Scanner


### PR DESCRIPTION
`pq.Array` shouldn't wrap values that are already an optimal pq Array type.

```go
x := []string{"a", "b", "c"}
pq.Array(x) // is (*pq.StringArray)
pq.Array(pq.Array(x)) // is (pq.GenericArray)
```

Repro: https://go.dev/play/p/piFLACJYhC2
