### PR TITLE
Bugfix: use filepath package when connecting to UNIX sockets

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -15,7 +15,6 @@ import (
 	"net"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -437,8 +436,10 @@ func dial(ctx context.Context, d Dialer, o values) (net.Conn, error) {
 func network(o values) (string, string) {
 	host := o["host"]
 
-	if strings.HasPrefix(host, "/") {
-		sockPath := path.Join(host, ".s.PGSQL."+o["port"])
+	// UNIX domain sockets are either represented by an (absolute) file system
+	// path or they live in the abstract name space (starting with an @).
+	if filepath.IsAbs(host) || strings.HasPrefix(host, "@") {
+		sockPath := filepath.Join(host, ".s.PGSQL."+o["port"])
 		return "unix", sockPath
 	}
 


### PR DESCRIPTION
The code before this commit is non-portable: it only works on UNIX systems where path.Join() is close enough to filepath.Join(). However, path.Join() is the wrong choice: UNIX domain sockets are identified via their file system name, so — conceptually and in practice — we need to use the filepath package instead.

This commit fixes connecting to a PostgreSQL database that is listening on a UNIX domain socket on Windows. If you are surprised to see UNIX domain sockets on Windows, they were introduced with Windows 10, i.e. are widely available now: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/

filepath.IsAbs() is equivalent to strings.HasPrefix(s, "/") on UNIX, but also works on Windows, where absolute paths start with e.g. C:\ Similarly, filepath.Join() uses the correct path separator.

related to https://github.com/zombiezen/postgrestest/issues/3