### PR TITLE
feat: support sslnegotiation flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 
 ### Features
 
-- Add support for NamedValueChecker interface ([#1125])
+- Add support for NamedValueChecker interface ([#1125]).
+
+- Support [`sslnegotiation`] to use SSL without negotiation ([#1180]).
 
 - The `pq.Error.ErrorWithDetail()` method prints a more detailed multiline
   message, with the Detail, Hint, and error position (if any) ([#1219]):
@@ -55,6 +57,7 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 
 - Treat nil []byte in query parameters as nil/NULL rather than `""` ([#838]).
 
+[`sslnegotiation`]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION
 [#595]: https://github.com/lib/pq/pull/595
 [#745]: https://github.com/lib/pq/pull/745
 [#743]: https://github.com/lib/pq/pull/743
@@ -68,6 +71,7 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 [#1161]: https://github.com/lib/pq/pull/1161
 [#1166]: https://github.com/lib/pq/pull/1166
 [#1179]: https://github.com/lib/pq/pull/1179
+[#1180]: https://github.com/lib/pq/pull/1180
 [#1184]: https://github.com/lib/pq/pull/1184
 [#1211]: https://github.com/lib/pq/pull/1211
 [#1212]: https://github.com/lib/pq/pull/1212

--- a/doc.go
+++ b/doc.go
@@ -55,6 +55,7 @@ supported:
   - sslkey - Key file location. The file must contain PEM encoded data.
   - sslrootcert - The location of the root certificate file. The file
     must contain PEM encoded data.
+  - sslnegotiation - when set to "direct" it will use SSL without negotiation (PostgreSQL ≥17 only).
 
 Valid values for sslmode are:
 

--- a/ssl.go
+++ b/ssl.go
@@ -211,3 +211,12 @@ func sslVerifyCertificateAuthority(client *tls.Conn, tlsConf *tls.Config) error 
 	_, err = certs[0].Verify(opts)
 	return err
 }
+
+// sslnegotiation returns true if we should negotiate SSL.
+// returns false if there should be no negotiation and we should upgrade immediately.
+func sslnegotiation(o values) bool {
+	if v, ok := o["sslnegotiation"]; ok && v == "direct" {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
postgres 17 added support for "sslnegotiation=direct". This allows skipping the ssl negotiation handshake.

https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION

The implementation is simple. If `sslnegotiation=direct`, do not run the ssl negotiation. I have tested this against a known postgres provider that supports this connection mode and it works fine according to my wireshark inspection.

Something to consider: should we return an error if `sslnegotiation` is not one of `"postgres"` or `"direct"`?