### PR TITLE
feat: support tls-server-end-point channel binding for SCRAM-SHA-256

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -38,6 +38,20 @@ func (b *readBuf) string() string {
 	return string(s)
 }
 
+func (b *readBuf) strings() []string {
+	ss := []string{}
+	for (*b)[0] != 0 {
+		i := bytes.IndexByte(*b, 0)
+		if i < 0 {
+			errorf("invalid message format; expected string terminator")
+		}
+		s := (*b)[:i]
+		*b = (*b)[i+1:]
+		ss = append(ss, string(s))
+	}
+	return ss
+}
+
 func (b *readBuf) next(n int) (v []byte) {
 	v = (*b)[:n]
 	*b = (*b)[n:]

--- a/conn.go
+++ b/conn.go
@@ -1223,8 +1223,16 @@ func (cn *conn) startup(o values) {
 func (cn *conn) auth(r *readBuf, o values) {
 	switch code := r.int32(); code {
 	case 0:
+		if o["channel_binding"] == "required" {
+			errorf("SCRAM-SHA-256 protocol error: channel binding required")
+		}
+
 		// OK
 	case 3:
+		if o["channel_binding"] == "required" {
+			errorf("SCRAM-SHA-256 protocol error: channel binding required")
+		}
+
 		w := cn.writeBuf('p')
 		w.string(o["password"])
 		cn.send(w)
@@ -1238,6 +1246,10 @@ func (cn *conn) auth(r *readBuf, o values) {
 			errorf("unexpected authentication response: %q", t)
 		}
 	case 5:
+		if o["channel_binding"] == "required" {
+			errorf("SCRAM-SHA-256 protocol error: channel binding required")
+		}
+
 		s := string(r.next(4))
 		w := cn.writeBuf('p')
 		w.string("md5" + md5s(md5s(o["password"]+o["user"])+s))
@@ -1252,6 +1264,10 @@ func (cn *conn) auth(r *readBuf, o values) {
 			errorf("unexpected authentication response: %q", t)
 		}
 	case 7: // GSSAPI, startup
+		if o["channel_binding"] == "required" {
+			errorf("SCRAM-SHA-256 protocol error: channel binding required")
+		}
+
 		if newGss == nil {
 			errorf("kerberos error: no GSSAPI provider registered (import github.com/lib/pq/auth/kerberos if you need Kerberos support)")
 		}
@@ -1287,6 +1303,9 @@ func (cn *conn) auth(r *readBuf, o values) {
 		cn.gss = cli
 
 	case 8: // GSSAPI continue
+		if o["channel_binding"] == "required" {
+			errorf("SCRAM-SHA-256 protocol error: channel binding required")
+		}
 
 		if cn.gss == nil {
 			errorf("GSSAPI protocol error")

--- a/conn.go
+++ b/conn.go
@@ -1137,13 +1137,15 @@ func (cn *conn) ssl(o values) error {
 		return err
 	}
 
-	cb, err := tlsServerEndPoint(conn)
-	if err != nil {
-		return err
+	if o["channel_binding"] != "disable" {
+		cb, err := tlsServerEndPoint(conn)
+		if err != nil {
+			return err
+		}
+		cn.tlsServerEndPoint = cb
 	}
 
 	cn.c = conn
-	cn.tlsServerEndPoint = cb
 	return err
 }
 
@@ -1332,6 +1334,10 @@ func (cn *conn) auth(r *readBuf, o values) {
 			selected = "SCRAM-SHA-256"
 		} else {
 			errorf("SCRAM-SHA-256 protocol error")
+		}
+
+		if o["channel_binding"] == "required" && selected != "SCRAM-SHA-256-PLUS" {
+			errorf("SCRAM-SHA-256 protocol error: channel binding required")
 		}
 
 		sc.Step(nil)

--- a/conn.go
+++ b/conn.go
@@ -170,6 +170,9 @@ type conn struct {
 
 	// GSSAPI context
 	gss GSS
+
+	// channel binding data used for SCRAM-SHA-256-PLUS
+	tlsServerEndPoint []byte
 }
 
 type syncErr struct {
@@ -1129,7 +1132,18 @@ func (cn *conn) ssl(o values) error {
 		return ErrSSLNotSupported
 	}
 
-	cn.c, err = upgrade(cn.c)
+	conn, err := upgrade(cn.c)
+	if err != nil {
+		return err
+	}
+
+	cb, err := tlsServerEndPoint(conn)
+	if err != nil {
+		return err
+	}
+
+	cn.c = conn
+	cn.tlsServerEndPoint = cb
 	return err
 }
 
@@ -1289,7 +1303,37 @@ func (cn *conn) auth(r *readBuf, o values) {
 		// from the server..
 
 	case 10:
+		supported := r.strings()
+
+		scramSha256 := false
+		scramSha256Plus := false
+		for _, s := range supported {
+			switch s {
+			case "SCRAM-SHA-256":
+				scramSha256 = true
+			case "SCRAM-SHA-256-PLUS":
+				scramSha256Plus = true
+			}
+		}
+
 		sc := scram.NewClient(sha256.New, o["user"], o["password"])
+
+		// channel binding is supported by the client
+		if cn.tlsServerEndPoint != nil {
+			sc.WithTlsServerEndPoint(cn.tlsServerEndPoint)
+		}
+
+		var selected string
+		// SCRAM-SHA-256-PLUS always takes preference.
+		if cn.tlsServerEndPoint != nil && scramSha256Plus {
+			sc.UseChannelBinding()
+			selected = "SCRAM-SHA-256-PLUS"
+		} else if scramSha256 {
+			selected = "SCRAM-SHA-256"
+		} else {
+			errorf("SCRAM-SHA-256 protocol error")
+		}
+
 		sc.Step(nil)
 		if sc.Err() != nil {
 			errorf("SCRAM-SHA-256 error: %s", sc.Err().Error())
@@ -1297,7 +1341,7 @@ func (cn *conn) auth(r *readBuf, o values) {
 		scOut := sc.Out()
 
 		w := cn.writeBuf('p')
-		w.string("SCRAM-SHA-256")
+		w.string(selected)
 		w.int32(len(scOut))
 		w.bytes(scOut)
 		cn.send(w)

--- a/ssl.go
+++ b/ssl.go
@@ -1,6 +1,7 @@
 package pq
 
 import (
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
@@ -13,7 +14,7 @@ import (
 
 // ssl generates a function to upgrade a net.Conn based on the "sslmode" and
 // related settings. The function is nil when no upgrade should take place.
-func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
+func ssl(o values) (func(net.Conn) (*tls.Conn, error), error) {
 	verifyCaOnly := false
 	tlsConf := tls.Config{}
 	switch mode := o["sslmode"]; mode {
@@ -77,7 +78,7 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 	// also initiates renegotiations and cannot be reconfigured.
 	tlsConf.Renegotiation = tls.RenegotiateFreelyAsClient
 
-	return func(conn net.Conn) (net.Conn, error) {
+	return func(conn net.Conn) (*tls.Conn, error) {
 		client := tls.Client(conn, &tlsConf)
 		if verifyCaOnly {
 			err := sslVerifyCertificateAuthority(client, &tlsConf)
@@ -201,4 +202,29 @@ func sslVerifyCertificateAuthority(client *tls.Conn, tlsConf *tls.Config) error 
 	}
 	_, err = certs[0].Verify(opts)
 	return err
+}
+
+func tlsServerEndPoint(conn *tls.Conn) ([]byte, error) {
+	err := conn.Handshake()
+	if err != nil {
+		return nil, err
+	}
+
+	cert := conn.ConnectionState().PeerCertificates[0]
+
+	// choose the channel binding hash type
+	// Use the same hash type used for the certificate signature, except for MD5 and SHA-1 which
+	// use SHA256
+	hashType := crypto.SHA256
+	switch cert.SignatureAlgorithm {
+	case x509.SHA384WithRSA, x509.ECDSAWithSHA384, x509.SHA384WithRSAPSS:
+		hashType = crypto.SHA384
+	case x509.SHA512WithRSA, x509.ECDSAWithSHA512, x509.SHA512WithRSAPSS:
+		hashType = crypto.SHA512
+	}
+
+	hasher := hashType.New()
+	_, _ = hasher.Write(cert.Raw)
+	data := hasher.Sum(nil)
+	return data, nil
 }


### PR DESCRIPTION
Postgres supports "channel bindings" for SCRAM-SHA-256 authentication. This prevents certain MITM attacks. This authentication is known as "SCRAM-SHA-256-PLUS". 
* https://datatracker.ietf.org/doc/html/rfc5802#section-6
* https://www.postgresql.org/docs/17/sasl-authentication.html#SASL-SCRAM-SHA-256

Postgres supports the "tls-server-end-point" channel binding form which is derived by hashing the raw bytes of the first certificate sent by the server in the TLS handshake. 
* https://datatracker.ietf.org/doc/html/rfc5929#section-4

Postgres also supports "requiring" channel binding. This additionally prevents a MITM sending cleartext the chosen authentication mechanism. 
* https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CHANNEL-BINDING

Related to #1145 