### PR TITLE
Test newer PostgreSQL and Go versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,27 +3,21 @@ name: Test
 on: [push, pull_request]
 
 jobs:
+  staticcheck:
+    name:    'staticcheck'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v6'
+      - uses: 'dominikh/staticcheck-action@v1.3.1'
+        with: {version: '2025.1.1'}
+
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        postgres:
-          - '15'
-          - '14'
-          - '13'
-          - '12'
-          - '11'
-          - '10'
-          - '9.6'
-        go:
-          - '1.20'
-          - '1.19'
-          - '1.18'
-          - '1.17'
-          - '1.16'
-          - '1.15'
-          - '1.14'
+        postgres: ['17', '16', '15', '14']
+        go:       ['1.25', '1.18']
     steps:
     - name: setup postgres pre-reqs
       run: |
@@ -174,10 +168,10 @@ jobs:
         docker exec pg createuser -h localhost -U postgres -DRS pqgosslcert
 
     - name: check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: set up go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go }}
       id: go
@@ -193,22 +187,8 @@ jobs:
         PQGOSSLTESTS: 1
         PQSSLCERTTEST_PATH: certs
       run: |
-        PQTEST_BINARY_PARAMETERS=no go test -race -v ./...
-        PQTEST_BINARY_PARAMETERS=yes go test -race -v ./...
-
-    - name: install goimports
-      run: go get golang.org/x/tools/cmd/goimports
-
-    - name: install staticcheck
-      run: |
-        wget https://github.com/dominikh/go-tools/releases/latest/download/staticcheck_linux_amd64.tar.gz -O - | tar -xz staticcheck
-
-    - name: run goimports
-      run: |
-        goimports -d -e . | awk '{ print } END { exit NR == 0 ? 0 : 1 }'
-
-    - name: run staticcheck
-      run: ./staticcheck/staticcheck -go 1.13 ./...
+        PQTEST_BINARY_PARAMETERS=no go test -race ./...
+        PQTEST_BINARY_PARAMETERS=yes go test -race ./...
 
     - name: build
       run: go build -v .

--- a/encode_test.go
+++ b/encode_test.go
@@ -308,7 +308,7 @@ func TestTimestampWithTimeZone(t *testing.T) {
 		// use the full range of the Nanosecond argument
 		refTime := time.Date(2012, 11, 6, 10, 23, 42, 123456000, loc)
 
-		for _, pgTimeZone := range []string{"US/Eastern", "Australia/Darwin"} {
+		for _, pgTimeZone := range []string{"America/New_York", "Australia/Darwin"} {
 			// Switch Postgres's timezone to test different output timestamp formats
 			_, err = tx.Exec(fmt.Sprintf("set time zone '%s'", pgTimeZone))
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/lib/pq
 
-go 1.13
+go 1.18


### PR DESCRIPTION
- Run some newer PostgreSQL versions and remove old EOL PostgreSQL versions. PostgreSQL 18 fails with:

      /init/hba.sh: line 1: /var/lib/postgresql/data/pg_hba.conf: No such file or directory

  Fixing that is for a future PR

- Update the Go versions to test, and set minimum version to 1.18, which seems like a reasonable version to use in 2025 (almost 2026). Only test the first and latest versions, to avoid spawning a million jobs.

- Update staticcheck integration.

- Had to fix the timezone name to make the tests work; US/Eastern is a (deprecated) alias for America/New_York.