### PR TITLE
Remove old build tags

### DIFF
--- a/auth/kerberos/krb_unix.go
+++ b/auth/kerberos/krb_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package kerberos
 

--- a/auth/kerberos/krb_windows.go
+++ b/auth/kerberos/krb_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package kerberos
 

--- a/conn.go
+++ b/conn.go
@@ -43,7 +43,8 @@ var (
 
 // Compile time validation that our types implement the expected interfaces
 var (
-	_ driver.Driver = Driver{}
+	_ driver.Driver    = Driver{}
+	_ driver.Validator = &conn{}
 )
 
 // Driver is the Postgres database driver.

--- a/conn_go115.go
+++ b/conn_go115.go
@@ -1,8 +1,0 @@
-//go:build go1.15
-// +build go1.15
-
-package pq
-
-import "database/sql/driver"
-
-var _ driver.Validator = &conn{}

--- a/conn_go19.go
+++ b/conn_go19.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package pq
 

--- a/conn_go19_test.go
+++ b/conn_go19_test.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package pq
 

--- a/connector_example_test.go
+++ b/connector_example_test.go
@@ -1,5 +1,4 @@
 //go:build go1.10
-// +build go1.10
 
 package pq_test
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,5 +1,4 @@
 //go:build go1.10
-// +build go1.10
 
 package pq
 

--- a/go19_test.go
+++ b/go19_test.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package pq
 

--- a/notice.go
+++ b/notice.go
@@ -1,5 +1,4 @@
 //go:build go1.10
-// +build go1.10
 
 package pq
 

--- a/notice_example_test.go
+++ b/notice_example_test.go
@@ -1,5 +1,4 @@
 //go:build go1.10
-// +build go1.10
 
 package pq_test
 

--- a/notice_test.go
+++ b/notice_test.go
@@ -1,5 +1,4 @@
 //go:build go1.10
-// +build go1.10
 
 package pq
 

--- a/oid/gen.go
+++ b/oid/gen.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Generate the table of OID values
 // Run with 'go run gen.go'.

--- a/ssl_permissions.go
+++ b/ssl_permissions.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package pq
 

--- a/ssl_permissions_test.go
+++ b/ssl_permissions_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package pq
 

--- a/ssl_test_go20minus.go
+++ b/ssl_test_go20minus.go
@@ -1,5 +1,4 @@
 //go:build !go1.20
-// +build !go1.20
 
 package pq
 

--- a/ssl_test_go20plus.go
+++ b/ssl_test_go20plus.go
@@ -1,5 +1,4 @@
 //go:build go1.20
-// +build go1.20
 
 package pq
 

--- a/ssl_windows.go
+++ b/ssl_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package pq
 

--- a/user_other.go
+++ b/user_other.go
@@ -1,7 +1,6 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
 //go:build js || android || hurd || zos || wasip1
-// +build js android hurd zos wasip1
 
 package pq
 

--- a/user_posix.go
+++ b/user_posix.go
@@ -1,7 +1,6 @@
 // Package pq is a pure Go Postgres driver for the database/sql package.
 
 //go:build aix || darwin || dragonfly || freebsd || (linux && !android) || nacl || netbsd || openbsd || plan9 || solaris || rumprun || illumos
-// +build aix darwin dragonfly freebsd linux,!android nacl netbsd openbsd plan9 solaris rumprun illumos
 
 package pq
 


### PR DESCRIPTION
Keep most of the files for old Go versions for now, to avoid merge conflicts with open PRs.