### PR TITLE
Enforce integer limits of the Postgres wire protocol

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -3,6 +3,7 @@ package pq
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 
 	"github.com/lib/pq/oid"
 )
@@ -79,12 +80,18 @@ func (b *writeBuf) bytes(v []byte) {
 
 func (b *writeBuf) wrap() []byte {
 	p := b.buf[b.pos:]
+	if len(p) > math.MaxUint32 {
+		errorf("message too large (%d > math.MaxUint32)", len(p))
+	}
 	binary.BigEndian.PutUint32(p, uint32(len(p)))
 	return b.buf
 }
 
 func (b *writeBuf) next(c byte) {
 	p := b.buf[b.pos:]
+	if len(p) > math.MaxUint32 {
+		errorf("message too large (%d > math.MaxUint32)", len(p))
+	}
 	binary.BigEndian.PutUint32(p, uint32(len(p)))
 	b.pos = len(b.buf) + 1
 	b.buf = append(b.buf, c, 0, 0, 0, 0)

--- a/conn.go
+++ b/conn.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"os/user"
@@ -780,9 +781,7 @@ func (noRows) RowsAffected() (int64, error) {
 
 // Decides which column formats to use for a prepared statement.  The input is
 // an array of type oids, one element per result column.
-func decideColumnFormats(
-	colTyps []fieldDesc, forceText bool,
-) (colFmts []format, colFmtData []byte) {
+func decideColumnFormats(colTyps []fieldDesc, forceText bool) (colFmts []format, colFmtData []byte) {
 	if len(colTyps) == 0 {
 		return nil, colFmtDataAllText
 	}
@@ -822,6 +821,9 @@ func decideColumnFormats(
 		return colFmts, colFmtDataAllText
 	} else {
 		colFmtData = make([]byte, 2+len(colFmts)*2)
+		if len(colFmts) > math.MaxUint16 {
+			errorf("too many columns (%d > math.MaxUint16)", len(colFmts))
+		}
 		binary.BigEndian.PutUint16(colFmtData, uint16(len(colFmts)))
 		for i, v := range colFmts {
 			binary.BigEndian.PutUint16(colFmtData[2+i*2:], uint16(v))

--- a/copy.go
+++ b/copy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 )
 
@@ -140,6 +141,9 @@ awaitCopyInResponse:
 }
 
 func (ci *copyin) flush(buf []byte) {
+	if len(buf)-1 > math.MaxUint32 {
+		panic("too many columns")
+	}
 	// set message length (without message identifier)
 	binary.BigEndian.PutUint32(buf[1:], uint32(len(buf)-1))
 


### PR DESCRIPTION
The Postgres wire protocol has certain fields that contain fixed-size integers, such as the 32-bit message length (see [1]). This library does not check if values fit into these fixed-size fields before writing them to the buffer. This can lead to the truncation of the values being written, causing corrupted messages.

Example: If the message to be sent is 4^32 + 4 bytes long, the length cannot fit into the 4-byte length field. The value written to the buffer will be \x00\x00\x00\x04, which gets decoded to 4 by the Postgres database when it receives such a message. Therefore, the Postgres database will think the message has a length of 4 and will try to read the next message after those 4 bytes.

After such a malformed message, the client and the database have different understandings of where messages start and end. In the best case, this causes a connection abort due to a parsing error. In the worst case, this leads to the execution of malicious SQL statements that an attacker has injected into a large payload that ends up in an SQL query.

[1]: https://www.postgresql.org/docs/current/protocol-message-formats.html

Continued from #1161, since I can't update that as it's a PR from the fork's master branch

Fixes #1153
Fixes #1161