### PR TITLE
Don't reset extra_float_digits

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -197,15 +197,14 @@ localhost:*:*:*:pass_C
 
 	assertPassword := func(extra values, expected string) {
 		o := values{
-			"host":               "localhost",
-			"sslmode":            "disable",
-			"connect_timeout":    "20",
-			"user":               "majid",
-			"port":               "5432",
-			"extra_float_digits": "2",
-			"dbname":             "pqgotest",
-			"client_encoding":    "UTF8",
-			"datestyle":          "ISO, MDY",
+			"host":            "localhost",
+			"sslmode":         "disable",
+			"connect_timeout": "20",
+			"user":            "majid",
+			"port":            "5432",
+			"dbname":          "pqgotest",
+			"client_encoding": "UTF8",
+			"datestyle":       "ISO, MDY",
 		}
 		for k, v := range extra {
 			o[k] = v

--- a/connector.go
+++ b/connector.go
@@ -55,9 +55,6 @@ func NewConnector(dsn string) (*Connector, error) {
 	// * Explicitly passed connection information
 	o["host"] = "localhost"
 	o["port"] = "5432"
-	// N.B.: Extra float digits should be set to 3, but that breaks
-	// Postgres 8.4 and older, where the max is 2.
-	o["extra_float_digits"] = "2"
 	for k, v := range parseEnviron(os.Environ()) {
 		o[k] = v
 	}


### PR DESCRIPTION
In PostgreSQL ≤11 the extra_float_digits parameter controlled how many digits were used for floating point numbers. It was set here to ensure people didn't accidentally needlessly lose precision (in 78a464e it was set to 3. In 5941153 it was changed to 2 as people reported problems on PostgreSQL ≤8.4, see #199).

Since PostgreSQL 12 it will always use maximum precision unless it's set to ≤0. We only support PostgreSQL ≥14 now, so we can just remove it here.

Ref: https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-FLOAT

Fixes #475
Fixes #1150
Fixes #1146