### PR TITLE
Match HOME lookups with libpq

### DIFF
--- a/ssl_test.go
+++ b/ssl_test.go
@@ -424,3 +424,14 @@ func mockPostgresSSL(listener net.Listener, errChan chan error, nameChan chan st
 
 	nameChan <- sniHost
 }
+
+func TestUnreadableHome(t *testing.T) {
+	// Ignore HOME being unset or not a directory
+	for _, h := range []string{"", "/dev/null"} {
+		os.Setenv("HOME", h)
+		err := sslClientCertificates(&tls.Config{}, values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This matches selection of the HOME directory with what libpq does:

- Prefer $HOME on non-windows systems.
- Use %APPDATA% on Windows
- Don't use .postgresql subdirectory on Windows.
- Ignore ENOTDIR errors.

Fixes #395
Fixes #609