### PR TITLE
Handle ErrorResponse in readReadyForQuery()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,15 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 
 - Accept `PGGSSLIB` and `PGKRBSRVNAME` environment variables ([#1143]).
 
+- Handle ErrorResponse in readReadyForQuery and return proper error ([#1136]).
+
 [#595]: https://github.com/lib/pq/pull/595
 [#745]: https://github.com/lib/pq/pull/745
 [#949]: https://github.com/lib/pq/pull/949
 [#1125]: https://github.com/lib/pq/pull/1125
 [#1129]: https://github.com/lib/pq/pull/1129
 [#1133]: https://github.com/lib/pq/pull/1133
+[#1136]: https://github.com/lib/pq/pull/1136
 [#1143]: https://github.com/lib/pq/pull/1143
 [#1161]: https://github.com/lib/pq/pull/1161
 [#1166]: https://github.com/lib/pq/pull/1166

--- a/conn.go
+++ b/conn.go
@@ -1840,6 +1840,10 @@ func (cn *conn) readReadyForQuery() {
 	case 'Z':
 		cn.processReadyForQuery(r)
 		return
+	case 'E':
+		err := parseError(r, "")
+		cn.err.set(driver.ErrBadConn)
+		panic(err)
 	default:
 		cn.err.set(driver.ErrBadConn)
 		errorf("unexpected message %q; expected ReadyForQuery", t)
@@ -1866,11 +1870,7 @@ func (cn *conn) readParseResponse() {
 	}
 }
 
-func (cn *conn) readStatementDescribeResponse() (
-	paramTyps []oid.Oid,
-	colNames []string,
-	colTyps []fieldDesc,
-) {
+func (cn *conn) readStatementDescribeResponse() (paramTyps []oid.Oid, colNames []string, colTyps []fieldDesc) {
 	for {
 		t, r := cn.recv1()
 		switch t {


### PR DESCRIPTION
From https://www.postgresql.org/docs/current/protocol-flow.html :

> A frontend must be prepared to accept ErrorResponse and NoticeResponse
> messages whenever it is expecting any other type of message.

From #1136