### PR TITLE
Test authentication

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -1,0 +1,67 @@
+package pq
+
+// PGError is an interface used by previous versions of pq.
+//
+// Deprecated: use the Error type. This is never used.
+type PGError interface {
+	Error() string
+	Fatal() bool
+	Get(k byte) (v string)
+}
+
+// Get implements the legacy PGError interface.
+//
+// Deprecated: new code should use the fields of the Error struct directly.
+func (e *Error) Get(k byte) (v string) {
+	switch k {
+	case 'S':
+		return e.Severity
+	case 'C':
+		return string(e.Code)
+	case 'M':
+		return e.Message
+	case 'D':
+		return e.Detail
+	case 'H':
+		return e.Hint
+	case 'P':
+		return e.Position
+	case 'p':
+		return e.InternalPosition
+	case 'q':
+		return e.InternalQuery
+	case 'W':
+		return e.Where
+	case 's':
+		return e.Schema
+	case 't':
+		return e.Table
+	case 'c':
+		return e.Column
+	case 'd':
+		return e.DataTypeName
+	case 'n':
+		return e.Constraint
+	case 'F':
+		return e.File
+	case 'L':
+		return e.Line
+	case 'R':
+		return e.Routine
+	}
+	return ""
+}
+
+// ParseURL converts a url to a connection string for driver.Open.
+//
+// Example:
+//
+//	"postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full"
+//
+// converts to:
+//
+//	"user=bob password=secret host=1.2.3.4 port=5432 dbname=mydb sslmode=verify-full"
+//
+// Deprecated: directly passing an URL to sql.Open("postgres", "postgres://...")
+// now works, and calling this manually is no longer required.
+func ParseURL(url string) (string, error) { return parseURL(url) }

--- a/error.go
+++ b/error.go
@@ -484,49 +484,6 @@ func (e *Error) SQLState() string {
 	return string(e.Code)
 }
 
-// Get implements the legacy PGError interface.
-//
-// Deprecated: new code should use the fields of the Error struct directly.
-func (e *Error) Get(k byte) (v string) {
-	switch k {
-	case 'S':
-		return e.Severity
-	case 'C':
-		return string(e.Code)
-	case 'M':
-		return e.Message
-	case 'D':
-		return e.Detail
-	case 'H':
-		return e.Hint
-	case 'P':
-		return e.Position
-	case 'p':
-		return e.InternalPosition
-	case 'q':
-		return e.InternalQuery
-	case 'W':
-		return e.Where
-	case 's':
-		return e.Schema
-	case 't':
-		return e.Table
-	case 'c':
-		return e.Column
-	case 'd':
-		return e.DataTypeName
-	case 'n':
-		return e.Constraint
-	case 'F':
-		return e.File
-	case 'L':
-		return e.Line
-	case 'R':
-		return e.Routine
-	}
-	return ""
-}
-
 func (e *Error) Error() string {
 	if e.Code != "" {
 		return "pq: " + e.Message + " (" + string(e.Code) + ")"
@@ -587,22 +544,8 @@ func (e *Error) ErrorWithDetail() string {
 	return b.String()
 }
 
-// PGError is an interface used by previous versions of pq.
-//
-// Deprecated: use the Error type. This is never used.
-type PGError interface {
-	Error() string
-	Fatal() bool
-	Get(k byte) (v string)
-}
-
 func errorf(s string, args ...any) {
 	panic(fmt.Errorf("pq: %s", fmt.Sprintf(s, args...)))
-}
-
-// TODO(ainar-g) Rename to errorf after removing panics.
-func fmterrorf(s string, args ...any) error {
-	return fmt.Errorf("pq: %s", fmt.Sprintf(s, args...))
 }
 
 func errRecoverNoErrBadConn(err *error) {

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -1,0 +1,104 @@
+// From src/include/libpq/protocol.h, PostgreSQL 18.1
+
+package proto
+
+import "strconv"
+
+// RequestCode is a request codes sent by the frontend.
+type RequestCode byte
+
+// These are the request codes sent by the frontend.
+const (
+	Bind                = RequestCode('B')
+	Close               = RequestCode('C')
+	Describe            = RequestCode('D')
+	Execute             = RequestCode('E')
+	FunctionCall        = RequestCode('F')
+	Flush               = RequestCode('H')
+	Parse               = RequestCode('P')
+	Query               = RequestCode('Q')
+	Sync                = RequestCode('S')
+	Terminate           = RequestCode('X')
+	CopyFail            = RequestCode('f')
+	GSSResponse         = RequestCode('p')
+	PasswordMessage     = RequestCode('p')
+	SASLInitialResponse = RequestCode('p')
+	SASLResponse        = RequestCode('p')
+)
+
+// ResponseCode is a response codes sent by the backend.
+type ResponseCode byte
+
+// These are the response codes sent by the backend.
+const (
+	ParseComplete            = ResponseCode('1')
+	BindComplete             = ResponseCode('2')
+	CloseComplete            = ResponseCode('3')
+	NotificationResponse     = ResponseCode('A')
+	CommandComplete          = ResponseCode('C')
+	DataRow                  = ResponseCode('D')
+	ErrorResponse            = ResponseCode('E')
+	CopyInResponse           = ResponseCode('G')
+	CopyOutResponse          = ResponseCode('H')
+	EmptyQueryResponse       = ResponseCode('I')
+	BackendKeyData           = ResponseCode('K')
+	NoticeResponse           = ResponseCode('N')
+	AuthenticationRequest    = ResponseCode('R')
+	ParameterStatus          = ResponseCode('S')
+	RowDescription           = ResponseCode('T')
+	FunctionCallResponse     = ResponseCode('V')
+	CopyBothResponse         = ResponseCode('W')
+	ReadyForQuery            = ResponseCode('Z')
+	NoData                   = ResponseCode('n')
+	PortalSuspended          = ResponseCode('s')
+	ParameterDescription     = ResponseCode('t')
+	NegotiateProtocolVersion = ResponseCode('v')
+)
+
+// These are the codes sent by both the frontend and backend.
+// #define PqMsg_CopyDone				'c'
+// #define PqMsg_CopyData				'd'
+
+// These are the codes sent by parallel workers to leader processes.
+// #define PqMsg_Progress              'P'
+
+// AuthCode are authentication request codes sent by the backend.
+type AuthCode int32
+
+// These are the authentication request codes sent by the backend.
+const (
+	AuthReqOk       = AuthCode(0)  // User is authenticated
+	AuthReqKrb4     = AuthCode(1)  // Kerberos V4. Not supported any more.
+	AuthReqKrb5     = AuthCode(2)  // Kerberos V5. Not supported any more.
+	AuthReqPassword = AuthCode(3)  // Password
+	AuthReqCrypt    = AuthCode(4)  // crypt password. Not supported any more.
+	AuthReqMD5      = AuthCode(5)  // md5 password
+	_               = AuthCode(6)  // 6 is available.  It was used for SCM creds, not supported any more.
+	AuthReqGSS      = AuthCode(7)  // GSSAPI without wrap()
+	AuthReqGSSCont  = AuthCode(8)  // Continue GSS exchanges
+	AuthReqSSPI     = AuthCode(9)  // SSPI negotiate without wrap()
+	AuthReqSASL     = AuthCode(10) // Begin SASL authentication
+	AuthReqSASLCont = AuthCode(11) // Continue SASL authentication
+	AuthReqSASLFin  = AuthCode(12) // Final SASL message
+)
+
+func (a AuthCode) String() string {
+	s, ok := map[AuthCode]string{
+		AuthReqOk:       "ok",
+		AuthReqKrb4:     "krb4",
+		AuthReqKrb5:     "krb5",
+		AuthReqPassword: "password",
+		AuthReqCrypt:    "crypt",
+		AuthReqMD5:      "md5",
+		AuthReqGSS:      "GDD",
+		AuthReqGSSCont:  "GSSCont",
+		AuthReqSSPI:     "SSPI",
+		AuthReqSASL:     "SASL",
+		AuthReqSASLCont: "SASLCont",
+		AuthReqSASLFin:  "SASLFin",
+	}[a]
+	if !ok {
+		s = "<unknown>"
+	}
+	return s + " (" + strconv.Itoa(int(a)) + ")"
+}

--- a/notify.go
+++ b/notify.go
@@ -99,19 +99,13 @@ var errListenerConnClosed = errors.New("pq: ListenerConn has been closed")
 // ListenerConn is a low-level interface for waiting for notifications.  You
 // should use Listener instead.
 type ListenerConn struct {
-	// guards cn and err
-	connectionLock sync.Mutex
-	cn             *conn
-	err            error
-
-	connState int32
-
-	// the sending goroutine will be holding this lock
-	senderLock sync.Mutex
-
+	connectionLock   sync.Mutex // guards cn and err
+	senderLock       sync.Mutex // the sending goroutine will be holding this lock
+	cn               *conn
+	err              error
+	connState        int32
 	notificationChan chan<- *Notification
-
-	replyChan chan message
+	replyChan        chan message
 }
 
 // NewListenerConn creates a new ListenerConn. Use NewListener instead.

--- a/notify_test.go
+++ b/notify_test.go
@@ -302,9 +302,6 @@ func TestNotifyExtra(t *testing.T) {
 func newTestListenerTimeout(t *testing.T, min time.Duration, max time.Duration) (*Listener, <-chan ListenerEventType) {
 	t.Helper()
 
-	// Called for the side-effect of setting the environment.
-	pqtest.DSN("")
-
 	var (
 		ch = make(chan ListenerEventType, 16)
 		l  = NewListener("", min, max, func(t ListenerEventType, err error) { ch <- t })

--- a/ssl.go
+++ b/ssl.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -49,7 +50,7 @@ func ssl(o values) (func(net.Conn) (net.Conn, error), error) {
 	case "disable":
 		return nil, nil
 	default:
-		return nil, fmterrorf(`unsupported sslmode %q; only "require" (default), "verify-full", "verify-ca", and "disable" supported`, mode)
+		return nil, fmt.Errorf(`pq: unsupported sslmode %q; only "require" (default), "verify-full", "verify-ca", and "disable" supported`, mode)
 	}
 
 	// Set Server Name Indication (SNI), if enabled by connection parameters.
@@ -181,7 +182,7 @@ func sslCertificateAuthority(tlsConf *tls.Config, o values) error {
 		}
 
 		if !tlsConf.RootCAs.AppendCertsFromPEM(cert) {
-			return fmterrorf("couldn't parse pem in sslrootcert")
+			return errors.New("pq: couldn't parse pem in sslrootcert")
 		}
 	}
 

--- a/testdata/init/docker-entrypoint-initdb.d/10-hba.sh
+++ b/testdata/init/docker-entrypoint-initdb.d/10-hba.sh
@@ -2,11 +2,15 @@
 set -eu
 
 cat <<EOF >"$PGDATA/pg_hba.conf"
-local     all         all                               trust
-host      all         postgres    all                   trust
-hostnossl all         pqgossltest all                   reject
-hostnossl all         pqgosslcert all                   reject
-hostssl   all         pqgossltest all                   trust
-hostssl   all         pqgosslcert all                   cert
-host      all         all         all                   trust
+# TYPE     DATABASE  USER         ADDRESS  METHOD
+local      all       all                   trust
+host       all       pqgomd5      all      md5
+host       all       pqgopassword all      password
+host       all       pqgoscram    all      scram-sha-256
+host       all       postgres     all      trust
+hostnossl  all       pqgossltest  all      reject
+hostnossl  all       pqgosslcert  all      reject
+hostssl    all       pqgossltest  all      trust
+hostssl    all       pqgosslcert  all      cert
+host       all       all          all      trust
 EOF

--- a/testdata/init/docker-entrypoint-initdb.d/20-config.sql
+++ b/testdata/init/docker-entrypoint-initdb.d/20-config.sql
@@ -3,5 +3,11 @@ alter system set ssl_ca_file   = '/ssl/root.crt';
 alter system set ssl_cert_file = '/ssl/server.crt';
 alter system set ssl_key_file  = '/ssl/server.key';
 
-create role pqgossltest with login nocreatedb nocreaterole nosuperuser;
-create role pqgosslcert with login nocreatedb nocreaterole nosuperuser;
+create role pqgossltest  with login nocreatedb nocreaterole nosuperuser;
+create role pqgosslcert  with login nocreatedb nocreaterole nosuperuser;
+create role pqgopassword with login nocreatedb nocreaterole nosuperuser password 'wordpass';
+create role pqgoscram    with login nocreatedb nocreaterole nosuperuser password 'wordpass';
+create role pqgomd5      with login nocreatedb nocreaterole nosuperuser password 'wordpass';
+-- md5 is deprecated and PostgreSQL will automatically treat md5 as scram in
+-- most places, but we want to force it for the purpose of testing.
+update pg_authid set rolpassword = 'md5' || md5('wordpasspqgomd5') where rolname = 'pqgomd5';

--- a/url.go
+++ b/url.go
@@ -8,19 +8,7 @@ import (
 	"strings"
 )
 
-// ParseURL converts a url to a connection string for driver.Open.
-//
-// Example:
-//
-//	"postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full"
-//
-// converts to:
-//
-//	"user=bob password=secret host=1.2.3.4 port=5432 dbname=mydb sslmode=verify-full"
-//
-// Deprecated: directly passing an URL to sql.Open("postgres", "postgres://...")
-// now works, and calling this manually is no longer required.
-func ParseURL(url string) (string, error) {
+func parseURL(url string) (string, error) {
 	u, err := neturl.Parse(url)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Add some basic tests for authentication, as that was previously untested. GSS/Kerberos is not yet tested.

Print a nicer "pq: unsupported authentication method: SSPI (9)" when people try to use SSPI. "pq: unknown authentication response: 9" was rather confusing.

Add a new internal/proto package with constants for the PostgreSQL protocol.

Also add pqtest.Exec() and pqtest.Query() to make writing tests a bit easier. Not used in this PR, but wrote them for debugging some other issues and might as well commit it here.