### PR TITLE
Add PQGO_DEBUG to print server communication to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
            12 | );
                 ^
 
+- Add `PQGO_DEBUG=1` print the communication with PostgreSQL to stderr, to aid
+  in debugging, testing, and bug reports ([#1223]).
+
 ### Fixes
 
 - Match HOME directory lookup logic with libpq: prefer $HOME over /etc/passwd,
@@ -77,6 +80,7 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 [#1212]: https://github.com/lib/pq/pull/1212
 [#1214]: https://github.com/lib/pq/pull/1214
 [#1219]: https://github.com/lib/pq/pull/1219
+[#1223]: https://github.com/lib/pq/pull/1223
 
 
 v1.10.9 (2023-04-26)

--- a/README.md
+++ b/README.md
@@ -65,3 +65,28 @@ and pgpool with:
 
     docker compose up -d pgpool pg18
     PGPORT=7432 go test ./...
+
+You can use PQGO_DEBUG=1 to make the driver print the communication with
+PostgreSQL to stderr; this works anywhere (test or applications) and can be
+useful to debug protocol problems.
+
+For example:
+
+    % PQGO_DEBUG=1 go test -run TestSimpleQuery
+    CLIENT → Startup                 69  "\x00\x03\x00\x00database\x00pqgo\x00user [..]"
+    SERVER ← (R) AuthRequest          4  "\x00\x00\x00\x00"
+    SERVER ← (S) ParamStatus         19  "in_hot_standby\x00off\x00"
+    [..]
+    SERVER ← (Z) ReadyForQuery        1  "I"
+             START conn.query
+             START conn.simpleQuery
+    CLIENT → (Q) Query                9  "select 1\x00"
+    SERVER ← (T) RowDescription      29  "\x00\x01?column?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17\x00\x04\xff\xff\xff\xff\x00\x00"
+    SERVER ← (D) DataRow              7  "\x00\x01\x00\x00\x00\x011"
+             END conn.simpleQuery
+             END conn.query
+    SERVER ← (C) CommandComplete      9  "SELECT 1\x00"
+    SERVER ← (Z) ReadyForQuery        1  "I"
+    CLIENT → (X) Terminate            0  ""
+    PASS
+    ok      github.com/lib/pq       0.010s

--- a/conn_test.go
+++ b/conn_test.go
@@ -1241,27 +1241,6 @@ func TestXactMultiStmt(t *testing.T) {
 	}
 }
 
-func TestParseEnviron(t *testing.T) {
-	tests := []struct {
-		in   []string
-		want map[string]string
-	}{
-		{[]string{"PGDATABASE=hello", "PGUSER=goodbye"},
-			map[string]string{"dbname": "hello", "user": "goodbye"}},
-		{[]string{"PGDATESTYLE=ISO, MDY"},
-			map[string]string{"datestyle": "ISO, MDY"}},
-		{[]string{"PGCONNECT_TIMEOUT=30"},
-			map[string]string{"connect_timeout": "30"}},
-	}
-
-	for i, tt := range tests {
-		results := parseEnviron(tt.in)
-		if !reflect.DeepEqual(tt.want, results) {
-			t.Errorf("%d: want: %#v Got: %#v", i, tt.want, results)
-		}
-	}
-}
-
 func TestParseComplete(t *testing.T) {
 	tpc := func(commandTag string, command string, affectedRows int64, shouldFail bool) {
 		defer func() {
@@ -1549,30 +1528,6 @@ func TestRuntimeParameters(t *testing.T) {
 				t.Fatalf("\nhave: %v\nwant: %v", have, tt.want)
 			}
 		})
-	}
-}
-
-func TestIsUTF8(t *testing.T) {
-	var cases = []struct {
-		name string
-		want bool
-	}{
-		{"unicode", true},
-		{"utf-8", true},
-		{"utf_8", true},
-		{"UTF-8", true},
-		{"UTF8", true},
-		{"utf8", true},
-		{"u n ic_ode", true},
-		{"ut_f%8", true},
-		{"ubf8", false},
-		{"punycode", false},
-	}
-
-	for _, test := range cases {
-		if g := isUTF8(test.name); g != test.want {
-			t.Errorf("isUTF8(%q) = %v want %v", test.name, g, test.want)
-		}
 	}
 }
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -83,4 +84,49 @@ func TestNewConnector_Environ(t *testing.T) {
 		}
 	}
 
+}
+
+func TestParseEnviron(t *testing.T) {
+	tests := []struct {
+		in   []string
+		want map[string]string
+	}{
+		{[]string{"PGDATABASE=hello", "PGUSER=goodbye"},
+			map[string]string{"dbname": "hello", "user": "goodbye"}},
+		{[]string{"PGDATESTYLE=ISO, MDY"},
+			map[string]string{"datestyle": "ISO, MDY"}},
+		{[]string{"PGCONNECT_TIMEOUT=30"},
+			map[string]string{"connect_timeout": "30"}},
+	}
+
+	for i, tt := range tests {
+		results := parseEnviron(tt.in)
+		if !reflect.DeepEqual(tt.want, results) {
+			t.Errorf("%d: want: %#v Got: %#v", i, tt.want, results)
+		}
+	}
+}
+
+func TestIsUTF8(t *testing.T) {
+	var cases = []struct {
+		name string
+		want bool
+	}{
+		{"unicode", true},
+		{"utf-8", true},
+		{"utf_8", true},
+		{"UTF-8", true},
+		{"UTF8", true},
+		{"utf8", true},
+		{"u n ic_ode", true},
+		{"ut_f%8", true},
+		{"ubf8", false},
+		{"punycode", false},
+	}
+
+	for _, test := range cases {
+		if g := isUTF8(test.name); g != test.want {
+			t.Errorf("isUTF8(%q) = %v want %v", test.name, g, test.want)
+		}
+	}
 }

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -2,7 +2,10 @@
 
 package proto
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 // RequestCode is a request codes sent by the frontend.
 type RequestCode byte
@@ -25,6 +28,35 @@ const (
 	SASLInitialResponse = RequestCode('p')
 	SASLResponse        = RequestCode('p')
 )
+
+func (r RequestCode) String() string {
+	s, ok := map[RequestCode]string{
+		Bind:         "Bind",
+		Close:        "Close",
+		Describe:     "Describe",
+		Execute:      "Execute",
+		FunctionCall: "FunctionCall",
+		Flush:        "Flush",
+		Parse:        "Parse",
+		Query:        "Query",
+		Sync:         "Sync",
+		Terminate:    "Terminate",
+		CopyFail:     "CopyFail",
+		// These are all the same :-/
+		//GSSResponse:  "GSSResponse",
+		PasswordMessage: "PasswordMessage",
+		//SASLInitialResponse: "SASLInitialResponse",
+		//SASLResponse:        "SASLResponse",
+	}[r]
+	if !ok {
+		s = "<unknown>"
+	}
+	c := string(r)
+	if r <= 0x1f || r == 0x7f {
+		c = fmt.Sprintf("0x%x", string(r))
+	}
+	return "(" + c + ") " + s
+}
 
 // ResponseCode is a response codes sent by the backend.
 type ResponseCode byte
@@ -54,6 +86,41 @@ const (
 	ParameterDescription     = ResponseCode('t')
 	NegotiateProtocolVersion = ResponseCode('v')
 )
+
+func (r ResponseCode) String() string {
+	s, ok := map[ResponseCode]string{
+		ParseComplete:            "ParseComplete",
+		BindComplete:             "BindComplete",
+		CloseComplete:            "CloseComplete",
+		NotificationResponse:     "NotificationResponse",
+		CommandComplete:          "CommandComplete",
+		DataRow:                  "DataRow",
+		ErrorResponse:            "ErrorResponse",
+		CopyInResponse:           "CopyInResponse",
+		CopyOutResponse:          "CopyOutResponse",
+		EmptyQueryResponse:       "EmptyQueryResponse",
+		BackendKeyData:           "BackendKeyData",
+		NoticeResponse:           "NoticeResponse",
+		AuthenticationRequest:    "AuthRequest",
+		ParameterStatus:          "ParamStatus",
+		RowDescription:           "RowDescription",
+		FunctionCallResponse:     "FunctionCallResponse",
+		CopyBothResponse:         "CopyBothResponse",
+		ReadyForQuery:            "ReadyForQuery",
+		NoData:                   "NoData",
+		PortalSuspended:          "PortalSuspended",
+		ParameterDescription:     "ParamDescription",
+		NegotiateProtocolVersion: "NegotiateProtocolVersion",
+	}[r]
+	if !ok {
+		s = "<unknown>"
+	}
+	c := string(r)
+	if r <= 0x1f || r == 0x7f {
+		c = fmt.Sprintf("0x%x", string(r))
+	}
+	return "(" + c + ") " + s
+}
 
 // These are the codes sent by both the frontend and backend.
 // #define PqMsg_CopyDone				'c'


### PR DESCRIPTION
This can be pretty useful to debug protocol issues and see what's going on. For example:

    % PQGO_DEBUG=1 go test -run TestSimpleQuery
    CLIENT → Startup                 69  "\x00\x03\x00\x00database\x00pqgo\x00user [..]"
    SERVER ← (R) AuthRequest          4  "\x00\x00\x00\x00"
    SERVER ← (S) ParamStatus         19  "in_hot_standby\x00off\x00"
    [..]
    SERVER ← (Z) ReadyForQuery        1  "I"
             START conn.query
             START conn.simpleQuery
    CLIENT → (Q) Query                9  "select 1\x00"
    SERVER ← (T) RowDescription      29  "\x00\x01?column?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17\x00\x04\xff\xff\xff\xff\x00\x00"
    SERVER ← (D) DataRow              7  "\x00\x01\x00\x00\x00\x011"
             END conn.simpleQuery
             END conn.query
    SERVER ← (C) CommandComplete      9  "SELECT 1\x00"
    SERVER ← (Z) ReadyForQuery        1  "I"
    CLIENT → (X) Terminate            0  ""
    PASS
    ok      github.com/lib/pq       0.010s

This works everywhere and is checked once on startup, so that people can do things like:

	PQGO_DEBUG=1 my-app

Which can be useful for some bug reports.

Also move some of this connection string parsing stuff from conn.go to connector.go. Makes rather more sense to put it there.