### PR TITLE
Add position to pq.Error.Error()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 
 - Support [`sslnegotiation`] to use SSL without negotiation ([#1180]).
 
+- The `pq.Error.Error()` text  includes the position of the error (if reported
+  by PostgreSQL) and SQLSTATE code ([#1224]):
+
+      pq: column "columndoesntexist" does not exist at column 8 (42703)
+      pq: syntax error at or near ")" at position 2:71 (42601)
+
 - The `pq.Error.ErrorWithDetail()` method prints a more detailed multiline
   message, with the Detail, Hint, and error position (if any) ([#1219]):
 
@@ -81,6 +87,7 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 [#1214]: https://github.com/lib/pq/pull/1214
 [#1219]: https://github.com/lib/pq/pull/1219
 [#1223]: https://github.com/lib/pq/pull/1223
+[#1224]: https://github.com/lib/pq/pull/1224
 
 
 v1.10.9 (2023-04-26)

--- a/conn_test.go
+++ b/conn_test.go
@@ -1888,7 +1888,6 @@ func TestStmtQueryContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			db := pqtest.MustDB(t)
 			defer db.Close()
 
@@ -1950,7 +1949,6 @@ func TestStmtExecContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			db := pqtest.MustDB(t)
 			defer db.Close()
 
@@ -2435,7 +2433,6 @@ func TestAuth(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.conn, func(t *testing.T) {
-				t.Parallel()
 				db, err := pqtest.DB(tt.conn)
 				if err != nil {
 					t.Fatal(err)

--- a/error.go
+++ b/error.go
@@ -485,10 +485,24 @@ func (e *Error) SQLState() string {
 }
 
 func (e *Error) Error() string {
-	if e.Code != "" {
-		return "pq: " + e.Message + " (" + string(e.Code) + ")"
+	msg := e.Message
+	if e.query != "" && e.Position != "" {
+		pos, err := strconv.Atoi(e.Position)
+		if err == nil {
+			lines := strings.Split(e.query, "\n")
+			line, col := posToLine(pos, lines)
+			if len(lines) == 1 {
+				msg += " at column " + strconv.Itoa(col)
+			} else {
+				msg += " at position " + strconv.Itoa(line) + ":" + strconv.Itoa(col)
+			}
+		}
 	}
-	return "pq: " + e.Message
+
+	if e.Code != "" {
+		return "pq: " + msg + " (" + string(e.Code) + ")"
+	}
+	return "pq: " + msg
 }
 
 // ErrorWithDetail returns the error message with detailed information and


### PR DESCRIPTION
#1219 adds more detailed errors, but the regular .Error() can still be pretty useless for queries that are longer than a few lines:

	pq: invalid input syntax for type json (22P02)

This adds the position to the .Error() message:

	pq: invalid input syntax for type json at position 5:8 (22P02)

Or if there's just one line it adds just the column:

	pq: column "columndoesntexist" does not exist at column 8 (42703)

Downside is that it's slower:

        original    BenchmarkError-16  29751604   39 ns/op   48 B/op  1 allocs/op
        e.Position  BenchmarkError-16  16639540   75 ns/op  112 B/op  2 allocs/op
        line:col    BenchmarkError-16   3785821  315 ns/op  304 B/op  3 allocs/op

The alternative is to just add the byte offset in there:

	pq: syntax error at or near ")" at offset 217 (42601)

Which is faster and arguably cleaner, but ~300ns for getting an error message still seems fine to me as pq.Error messages are typically not really in a hot path.