### PR TITLE
Use "user" environment variable instead of "USER" on Plan 9

### DIFF
--- a/internal/pqutil/user_posix.go
+++ b/internal/pqutil/user_posix.go
@@ -5,10 +5,15 @@ package pqutil
 import (
 	"os"
 	"os/user"
+	"runtime"
 )
 
 func User() (string, error) {
-	if n := os.Getenv("USER"); n != "" {
+	env := "USER"
+	if runtime.GOOS == "plan9" {
+		env = "user"
+	}
+	if n := os.Getenv(env); n != "" {
 		return n, nil
 	}
 


### PR DESCRIPTION
Ref: #744