### PR TITLE
Handle uint64 in NamedValueChecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 
 ### Features
 
-- Add support for NamedValueChecker interface ([#1125]).
+- Add support for NamedValueChecker interface ([#1125], [#1238]).
 
 - Support [`sslnegotiation`] to use SSL without negotiation ([#1180]).
 
@@ -95,6 +95,7 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 [#1226]: https://github.com/lib/pq/pull/1226
 [#1228]: https://github.com/lib/pq/pull/1228
 [#1234]: https://github.com/lib/pq/pull/1234
+[#1238]: https://github.com/lib/pq/pull/1238
 
 
 v1.10.9 (2023-04-26)

--- a/conn_test.go
+++ b/conn_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"reflect"
@@ -2299,4 +2300,28 @@ func TestAuth(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestUint64(t *testing.T) {
+	db := pqtest.MustDB(t)
+
+	pqtest.Exec(t, db, `create temp table tbl (n numeric)`)
+	pqtest.Exec(t, db, `insert into tbl values ($1)`, uint64(math.MaxUint64))
+
+	rows, err := db.Query("select n from tbl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rows.Next() {
+		var i uint64
+		err := rows.Scan(&i)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if i != math.MaxUint64 {
+			t.Fatalf("\nwant: %d\nhave: %d", uint64(math.MaxUint64), i)
+		}
+	}
 }


### PR DESCRIPTION
So that scanning uint64 from e.g. numeric or text columns works.

Fixes #453
Fixes #624