### PR TITLE
Don't generate invalid SQL in CopyIn() if the list of columns is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 
 - Handle ErrorResponse in readReadyForQuery and return proper error ([#1136]).
 
+- CopyIn() and CopyInSchema() now work if the list of columns is empty, in which
+  case it will copy all columns ([#1239]).
+
 - Treat nil []byte in query parameters as nil/NULL rather than `""` ([#838]).
 
 [`sslnegotiation`]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION
@@ -96,6 +99,7 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 [#1228]: https://github.com/lib/pq/pull/1228
 [#1234]: https://github.com/lib/pq/pull/1234
 [#1238]: https://github.com/lib/pq/pull/1238
+[#1239]: https://github.com/lib/pq/pull/1239
 
 
 v1.10.9 (2023-04-26)

--- a/internal/pqtest/pqtest.go
+++ b/internal/pqtest/pqtest.go
@@ -95,6 +95,18 @@ func Begin(t testing.TB, db *sql.DB) *sql.Tx {
 	return tx
 }
 
+// Prepare a new statement, calling t.Fatal() if this fails.
+func Prepare(t testing.TB, db interface {
+	Prepare(string) (*sql.Stmt, error)
+}, q string) *sql.Stmt {
+	t.Helper()
+	stmt, err := db.Prepare(q)
+	if err != nil {
+		t.Fatalf("pqtest.Prepare: %s", err)
+	}
+	return stmt
+}
+
 // Exec calls db.Exec(), calling t.Fatal if this fails.
 func Exec(t testing.TB, db interface {
 	Exec(string, ...any) (sql.Result, error)


### PR DESCRIPTION
Previously it would generate invalid SQL:

	COPY "tbl" () FROM STDI

With this, it will copy all columns:

	COPY "tbl" FROM STDIN

Fixes #388