### PR TITLE
Document limitations of URL parsing

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -216,14 +216,31 @@ type Config struct {
 // not allow run-time parameters in the connection string, instead requiring you
 // to supply them in the options parameter.
 //
-// pq supports both key=value type connection strings and postgres:// URL style
-// connection strings. For key=value strings, use single quotes for values that
-// contain whitespace or empty values. A backslash will escape the next
-// character:
+// # key=value connection strings
+//
+// For key=value strings, use single quotes for values that contain whitespace
+// or empty values. A backslash will escape the next character:
 //
 //	"user=pqgo password='with spaces'"
 //	"user=''"
 //	"user=space\ man password='it\'s valid'"
+//
+// # URL connection strings
+//
+// pq supports URL-style postgres:// or postgresql:// connection strings in the
+// form:
+//
+//	postgres[ql]://[user[:pwd]@][net-location][:port][/dbname][?param1=value1&...]
+//
+// Go's [net/url.Parse] is more strict than PostgreSQL's URL parser and will
+// (correctly) reject %2F in the host part. This means that unix-socket URLs:
+//
+//	postgres://[user[:pwd]@][unix-socket][:port[/dbname]][?param1=value1&...]
+//	postgres://%2Ftmp%2Fpostgres/db
+//
+// will not work. You will need to use "host=/tmp/postgres dbname=db".
+//
+// # Environment
 //
 // Most [PostgreSQL environment variables] are supported by pq. Environment
 // variables have a lower precedence than explicitly provided connection

--- a/connector_test.go
+++ b/connector_test.go
@@ -296,9 +296,7 @@ func TestParseURL(t *testing.T) {
 		{"", "", "invalid connection protocol:"},
 		{"http://hostname.remote", "", "invalid connection protocol: http"},
 
-		//{"postgresql://%2Fvar%2Flib%2Fpostgresql/dbname", "", ``},
-		//{"postgres:// host/db", "dbname='db' host='host'", ""},
-		//{"postgres://host/db ", "dbname='db' host='host'", ""},
+		{"postgresql://%2Fvar%2Flib%2Fpostgresql/dbname", "", `invalid URL escape "%2F"`},
 	}
 
 	t.Parallel()


### PR DESCRIPTION
I spent some time trying to get this to work, but I can't get it to work with net/url.Parse reliably in all cases without caveats. I don't really want to maintain and internal fork of that, so it is what it is.

Fixes #796