### PR TITLE
Handle pre-protocol errors to prevent memory exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,10 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
   ignore ENOTDIR errors, and use APPDATA on Windows ([#1214]).
 
 - Fix `sslmode=verify-ca` verifying the hostname anyway when connecting to a DNS
-  name (rather than IP) ([#1226])
+  name (rather than IP) ([#1226]).
+
+- Correctly detect pre-protocol errors such as the server not being able to fork
+  or running out of memory ([#1248]).
 
 - Fix build with wasm ([#1184]), appengine ([#745]), and Plan 9 ([#1133]).
 
@@ -117,6 +120,7 @@ newer. Previously PostgreSQL 8.4 and newer were supported.
 [#1240]: https://github.com/lib/pq/pull/1240
 [#1243]: https://github.com/lib/pq/pull/1243
 [#1246]: https://github.com/lib/pq/pull/1246
+[#1248]: https://github.com/lib/pq/pull/1248
 
 
 v1.10.9 (2023-04-26)

--- a/conn_test.go
+++ b/conn_test.go
@@ -2165,3 +2165,51 @@ func TestUint64(t *testing.T) {
 		}
 	}
 }
+
+func TestPreProtocolError(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     string
+		wantErr string
+	}{
+		{
+			name:    "could not fork",
+			msg:     "could not fork new process for connection: Resource temporarily unavailable\n",
+			wantErr: "server error: could not fork new process for connection: Resource temporarily unavailable",
+		},
+		{
+			name:    "too many connections",
+			msg:     "sorry, too many clients already\n",
+			wantErr: "server error: sorry, too many clients already",
+		},
+		{
+			name:    "out of memory",
+			msg:     "out of memory\n",
+			wantErr: "server error: out of memory",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := pqtest.NewFake(t, func(f pqtest.Fake, cn net.Conn) {
+				f.ReadStartup(cn)
+				// Send pre-protocol error: 'E' followed by plain text
+				// This simulates what PostgreSQL sends when it can't fork
+				cn.Write(append([]byte{'E'}, tt.msg...))
+				cn.Close()
+			})
+			defer f.Close()
+
+			db := pqtest.MustDB(t, f.DSN())
+			err := db.Ping()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("wrong error:\nhave: %s\nwant: %s", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -16,6 +16,11 @@ const (
 	NegotiateGSSCode  = (1234 << 16) | 5680
 )
 
+// Constants from fe-connect.c
+const (
+	MaxErrlen = 30_000 // https://github.com/postgres/postgres/blob/c6a10a89f/src/interfaces/libpq/fe-connect.c#L4067
+)
+
 // RequestCode is a request codes sent by the frontend.
 type RequestCode byte
 


### PR DESCRIPTION
When PostgreSQL cannot fork a backend process (e.g., an external process limit), it sends a plain text error like "Ecould not fork new process for connection: Resource temporarily unavailable" before any protocol handshake. The 'E' byte gets parsed as an ErrorResponse message type, but the following bytes are plain text, not a binary length field.

This causes lib/pq to interpret ASCII text as a message length (e.g., "coul" = 0x636f756c = 1.6GB), leading to massive memory allocations and a likely OOM under connection pressure.

This fix matches libpq's behavior in fe-connect.c: if an ErrorResponse has msgLength < 8 or > 30000, treat it as a pre-protocol plain text error and read it as a null-terminated string instead.

There's a decent chance this is related to #638.

Closes #1248