### PR TITLE
Fix []byte types incorrectly converted to PostgreSQL array

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -829,18 +829,14 @@ func (cn *conn) CheckNamedValue(nv *driver.NamedValue) error {
 	if !v.IsValid() {
 		return driver.ErrSkip
 	}
+	t := v.Type()
+	for t.Kind() == reflect.Ptr {
+		t, v = t.Elem(), v.Elem()
+	}
 
 	// Ignore []byte and related types: *[]byte, json.RawMessage, etc.
-	t := v.Type()
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
 	if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8 {
 		return driver.ErrSkip
-	}
-
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
 	}
 
 	switch v.Kind() {

--- a/internal/pqtest/pqtest.go
+++ b/internal/pqtest/pqtest.go
@@ -51,6 +51,13 @@ func InvalidCertificate(err error) bool {
 	return false
 }
 
+// Ptr gets a pointer to any value.
+//
+// TODO: replace with new(..) once pq requires Go 1.26.
+func Ptr[T any](t T) *T {
+	return &t
+}
+
 var envOnce sync.Once
 
 func DSN(conninfo string) string {


### PR DESCRIPTION
In running Mattermost's sqlstore test suite with the new release -- and also to validate https://github.com/lib/pq/pull/1249 -- I ran into a series of errors handling byte slice types. Here's a proposed fix that now passes our test suite.

CheckNamedValue was incorrectly converting byte slice types to PostgreSQL arrays. This affected:
- `*[]byte` pointers (dereference would result in `[]byte` hitting Slice case)
- Named `byte` slice types like `json.RawMessage`

The fix checks if the value's element type is `uint8` after pointer dereferencing, which correctly handles both `[]byte` and named types whose underlying type is `[]byte`.