### PR TITLE
Add support for protocol 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+unreleased
+----------
+- Support protocol 3.2, and the `min_protocol_version` and
+  `max_protocol_version` DSN parameters ([#1258]).
+
+[#1258]: https://github.com/lib/pq/pull/1258
+
 v1.11.2 (2025-02-10)
 --------------------
 This fixes two regressions:

--- a/conn_go18.go
+++ b/conn_go18.go
@@ -151,8 +151,8 @@ func (cn *conn) cancel(ctx context.Context) error {
 
 	w := cn2.writeBuf(0)
 	w.int32(proto.CancelRequestCode)
-	w.int32(cn.processID)
-	w.int32(cn.secretKey)
+	w.int32(cn.pid)
+	w.bytes(cn.secretKey)
 	if err := cn2.sendStartupPacket(w); err != nil {
 		return err
 	}

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -10,7 +10,7 @@ import (
 // Constants from pqcomm.h
 const (
 	ProtocolVersion30 = (3 << 16) | 0 //lint:ignore SA4016 x
-	ProtocolVersion32 = (3 << 16) | 2 // PostgreSQL ≥18; not yet supported.
+	ProtocolVersion32 = (3 << 16) | 2 // PostgreSQL ≥18.
 	CancelRequestCode = (1234 << 16) | 5678
 	NegotiateSSLCode  = (1234 << 16) | 5679
 	NegotiateGSSCode  = (1234 << 16) | 5680


### PR DESCRIPTION
This adds support for the 3.2 protocol version, introduced with PostgreSQL 18.

It follows postgres in the sense that the default is still 3.0, but this allows for allocations to allow the 3.2 version of the protocol with longer secret key data.

This is to both improve security and to provide room for additional metadata for middleware.

See also https://github.com/jackc/pgx/pull/2498 for a similar change I submitted there. 