### PR TITLE
fix: empty options not accepted by Supavisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+v1.11.2 (2025-02-10)
+--------------------
+This fixes two regressions:
+
+- Don't send startup parameters if there is no value, improving compatibility
+  with Supavisor ([#1260]).
+
+- Don't send `dbname` as a startup parameter if `database=[..]` is used in the
+  connection string. It's recommended to use dbname=, as database= is not a
+  libpq option, and only worked by accident previously. ([#1261])
+
+[#1260]: https://github.com/lib/pq/pull/1260
+[#1261]: https://github.com/lib/pq/pull/1261
+
 v1.11.1 (2025-01-29)
 --------------------
 This fixes two regressions present in the v1.11.0 release:

--- a/conn.go
+++ b/conn.go
@@ -1188,20 +1188,27 @@ func (cn *conn) startup(cfg Config) error {
 	w := cn.writeBuf(0)
 	w.int32(proto.ProtocolVersion30)
 
-	w.string("user")
-	w.string(cfg.User)
-	w.string("database")
-	w.string(cfg.Database)
+	if cfg.User != "" {
+		w.string("user")
+		w.string(cfg.User)
+	}
+	if cfg.Database != "" {
+		w.string("database")
+		w.string(cfg.Database)
+	}
 	// w.string("replication") // Sent by libpq, but we don't support that.
-	w.string("options")
-	w.string(cfg.Options)
+	if cfg.Options != "" {
+		w.string("options")
+		w.string(cfg.Options)
+	}
 	if cfg.ApplicationName != "" {
 		w.string("application_name")
 		w.string(cfg.ApplicationName)
 	}
-	w.string("client_encoding")
-	w.string(cfg.ClientEncoding)
-
+	if cfg.ClientEncoding != "" {
+		w.string("client_encoding")
+		w.string(cfg.ClientEncoding)
+	}
 	for k, v := range cfg.Runtime {
 		w.string(k)
 		w.string(v)


### PR DESCRIPTION
Supavisor will close the connection and log a :bad_startup_payload
if an empty `options` connection parameter is sent.

Fixes #1259
