### PR TITLE
Fix tests, add support for testing against Supavisor.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,88 @@ services:
       'PGPOOL_PARAMS_PORT':              '7432'
       'PGPOOL_PARAMS_BACKEND_HOSTNAME0': 'pg18'
 
+  supavisor-db:
+    profiles:   ["supavisor"]
+    image:      postgres:15
+    shm_size:   128mb
+    environment:
+      POSTGRES_DB:       pqgo
+      POSTGRES_USER:     pqgo
+      POSTGRES_PASSWORD: unused
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "pqgo"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 5s
+
+  supavisor:
+    profiles: ["supavisor"]
+    depends_on:
+      supavisor-db:
+        condition: service_healthy
+    image: supabase/supavisor:2.7.4
+    command: sh -c '/app/bin/migrate && /app/bin/server'
+    environment:
+      PORT: 4000
+      PROXY_PORT_SESSION: 5452
+      PROXY_PORT_TRANSACTION: 6543
+      CLUSTER_POSTGRES: "true"
+      DATABASE_URL: "ecto://pqgo:unused@supavisor-db:5432/pqgo"
+      SECRET_KEY_BASE: "12345678901234567890121234567890123456789012345678903212345678901234567890123456789032123456789012345678901234567890323456789032"
+      VAULT_ENC_KEY: "12345678901234567890123456789032"
+      API_JWT_SECRET: "dev"
+      METRICS_JWT_SECRET: "dev"
+      REGION: "local"
+      ERL_AFLAGS: -proto_dist inet_tcp
+      DB_POOL_SIZE: 50
+    ports:
+      - '127.0.0.1:4000:4000'
+      - '127.0.0.1:5452:5452'
+      - '127.0.0.1:6543:6543'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/api/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 5s
+
+  supavisor-create-tenant:
+    profiles: ["supavisor"]
+    depends_on:
+      supavisor:
+        condition: service_healthy
+    image: supabase/supavisor:2.7.4
+    command: |-
+      sh -c '
+        curl -sX PUT \
+          "http://supavisor:4000/api/tenants/dev_tenant" \
+          --header "Accept: */*" \
+          --header "User-Agent: Thunder Client (https://www.thunderclient.com)" \
+          --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJvbGUiOiJhbm9uIiwiaWF0IjoxNjQ1MTkyODI0LCJleHAiOjE5NjA3Njg4MjR9.M9jrxyvPLkUxWgOYSf5dNdJ8v_eRrq810ShFRT8N-6M" \
+          --header "Content-Type: application/json" \
+          --data-raw '\''{
+            "tenant": {
+              "db_host": "supavisor-db",
+              "db_port": 5432,
+              "db_database": "pqgo",
+              "ip_version": "auto",
+              "enforce_ssl": false,
+              "require_user": false,
+              "auth_query": "SELECT rolname, rolpassword FROM pg_authid WHERE rolname=$1;",
+              "users": [
+                {
+                  "db_user": "pqgo",
+                  "db_password": "unused",
+                  "pool_size": 20,
+                  "mode_type": "transaction",
+                  "is_manager": true
+                }
+              ]
+            }
+          }'\''
+      '
+
   pg18:
     image:      'postgres:18'
     ports:      ['127.0.0.1:5432:5432']

--- a/copy_test.go
+++ b/copy_test.go
@@ -66,6 +66,12 @@ func TestCopyInSchemaStmt(t *testing.T) {
 }
 
 func TestCopyInMultipleValues(t *testing.T) {
+	// "It is important to note that although the direct connections and
+	// Supavisor in session mode support prepared statements, Supavisor in
+	// transaction mode does not."
+	// https://supabase.com/docs/guides/troubleshooting/disabling-prepared-statements-qL8lEL
+	pqtest.SkipSupavisorTransactionMode(t)
+
 	tests := []struct {
 		cols []string
 	}{
@@ -122,7 +128,10 @@ func TestCopyInMultipleValues(t *testing.T) {
 }
 
 func TestCopyInRaiseStmtTrigger(t *testing.T) {
-	t.Parallel()
+	// Transaction mode connection pooling breaks parallel tests using COPY.
+	if !pqtest.SupavisorTransactionMode() {
+		t.Parallel()
+	}
 	db := pqtest.MustDB(t)
 
 	txn, err := db.Begin()
@@ -192,7 +201,10 @@ func TestCopyInRaiseStmtTrigger(t *testing.T) {
 }
 
 func TestCopyInTypes(t *testing.T) {
-	t.Parallel()
+	// Transaction mode connection pooling breaks parallel tests using COPY.
+	if !pqtest.SupavisorTransactionMode() {
+		t.Parallel()
+	}
 	db := pqtest.MustDB(t)
 
 	txn, err := db.Begin()
@@ -251,7 +263,10 @@ func TestCopyInTypes(t *testing.T) {
 }
 
 func TestCopyInWrongType(t *testing.T) {
-	t.Parallel()
+	// Transaction mode connection pooling breaks parallel tests using COPY.
+	if !pqtest.SupavisorTransactionMode() {
+		t.Parallel()
+	}
 	db := pqtest.MustDB(t)
 
 	txn, err := db.Begin()
@@ -324,7 +339,10 @@ func TestCopyInBinaryError(t *testing.T) {
 }
 
 func TestCopyFromError(t *testing.T) {
-	t.Parallel()
+	// Transaction mode connection pooling breaks parallel tests using COPY.
+	if !pqtest.SupavisorTransactionMode() {
+		t.Parallel()
+	}
 	db := pqtest.MustDB(t)
 
 	txn, err := db.Begin()
@@ -374,6 +392,10 @@ func TestCopySyntaxError(t *testing.T) {
 
 // Tests for connection errors in copyin.resploop()
 func TestCopyRespLoopConnectionError(t *testing.T) {
+	// This test won't work with transaction mode connection pooling
+	// without a transaction.
+	pqtest.SkipSupavisorTransactionMode(t)
+
 	t.Parallel()
 	db := pqtest.MustDB(t)
 

--- a/error_test.go
+++ b/error_test.go
@@ -275,6 +275,7 @@ func TestNetworkError(t *testing.T) {
 	}
 	c.Dialer(failDialer{})
 	db := sql.OpenDB(c)
+	defer db.Close()
 	db.SetMaxIdleConns(1)
 	db.SetMaxOpenConns(1)
 	if err := db.Ping(); err != nil {

--- a/internal/pqtest/pqtest.go
+++ b/internal/pqtest/pqtest.go
@@ -13,6 +13,10 @@ import (
 func Pgbouncer() bool { return os.Getenv("PGPORT") == "6432" }
 func Pgpool() bool    { return os.Getenv("PGPORT") == "7432" }
 
+func SupavisorSessionMode() bool     { return os.Getenv("PGPORT") == "5452" }
+func SupavisorTransactionMode() bool { return os.Getenv("PGPORT") == "6543" }
+func Supavisor() bool                { return SupavisorSessionMode() || SupavisorTransactionMode() }
+
 func SkipPgbouncer(t testing.TB) {
 	t.Helper()
 	if Pgbouncer() {
@@ -24,6 +28,27 @@ func SkipPgpool(t testing.TB) {
 	t.Helper()
 	if Pgpool() {
 		t.Skip("skipped for pgpool (PGPORT=7432)")
+	}
+}
+
+func SkipSupavisorSessionMode(t testing.TB) {
+	t.Helper()
+	if SupavisorSessionMode() {
+		t.Skip("skipped for supavisor session mode (PGPORT=5452)")
+	}
+}
+
+func SkipSupavisorTransactionMode(t testing.TB) {
+	t.Helper()
+	if SupavisorTransactionMode() {
+		t.Skip("skipped for supavisor transaction mode (PGPORT=6543)")
+	}
+}
+
+func SkipSupavisor(t testing.TB) {
+	t.Helper()
+	if Supavisor() {
+		t.Skip("skipped for supavisor (PGPORT=5452,6543)")
 	}
 }
 

--- a/notify_test.go
+++ b/notify_test.go
@@ -74,12 +74,20 @@ func newTestListenerConn(t *testing.T) (*ListenerConn, <-chan *Notification) {
 }
 
 func TestNewListenerConn(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListenerConn(t)
 
 	defer l.Close()
 }
 
 func TestListenerConnListen(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, channel := newTestListenerConn(t)
 
 	defer l.Close()
@@ -103,6 +111,10 @@ func TestListenerConnListen(t *testing.T) {
 }
 
 func TestListenerConnUnlisten(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, channel := newTestListenerConn(t)
 
 	defer l.Close()
@@ -141,6 +153,10 @@ func TestListenerConnUnlisten(t *testing.T) {
 }
 
 func TestListenerConnUnlistenAll(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, channel := newTestListenerConn(t)
 
 	defer l.Close()
@@ -179,6 +195,10 @@ func TestListenerConnUnlistenAll(t *testing.T) {
 }
 
 func TestListenerConnClose(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListenerConn(t)
 	defer l.Close()
 
@@ -193,6 +213,10 @@ func TestListenerConnClose(t *testing.T) {
 }
 
 func TestListernerConnPing(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListenerConn(t)
 	defer l.Close()
 	err := l.Ping()
@@ -211,6 +235,10 @@ func TestListernerConnPing(t *testing.T) {
 
 // Test for deadlock where a query fails while another one is queued
 func TestListenerConnExecDeadlock(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListenerConn(t)
 	defer l.Close()
 
@@ -239,6 +267,10 @@ func TestListenerConnExecDeadlock(t *testing.T) {
 
 // Test for ListenerConn being closed while a slow query is executing
 func TestListenerConnCloseWhileQueryIsExecuting(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListenerConn(t)
 	defer l.Close()
 
@@ -270,6 +302,10 @@ func TestListenerConnCloseWhileQueryIsExecuting(t *testing.T) {
 }
 
 func TestListenerNotifyExtra(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	db := pqtest.MustDB(t)
 
 	l, channel := newTestListenerConn(t)
@@ -311,6 +347,10 @@ func newTestListener(t *testing.T) (*Listener, <-chan ListenerEventType) {
 }
 
 func TestListenerListen(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListener(t)
 	defer l.Close()
 
@@ -333,6 +373,10 @@ func TestListenerListen(t *testing.T) {
 }
 
 func TestListenerUnlisten(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListener(t)
 	defer l.Close()
 
@@ -370,6 +414,10 @@ func TestListenerUnlisten(t *testing.T) {
 }
 
 func TestListenerUnlistenAll(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListener(t)
 	defer l.Close()
 
@@ -407,6 +455,10 @@ func TestListenerUnlistenAll(t *testing.T) {
 }
 
 func TestListenerFailedQuery(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, eventch := newTestListener(t)
 	defer l.Close()
 
@@ -454,6 +506,10 @@ func TestListenerFailedQuery(t *testing.T) {
 }
 
 func TestListenerReconnect(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, eventch := newTestListenerTimeout(t, 20*time.Millisecond, time.Hour)
 	defer l.Close()
 
@@ -485,6 +541,10 @@ func TestListenerReconnect(t *testing.T) {
 		}
 	} else if pqtest.Pgpool() {
 		if !pqtest.ErrorContains(err, "unable to forward message to frontend") {
+			t.Fatalf("unexpected error %T: %[1]s", err)
+		}
+	} else if pqtest.Supavisor() {
+		if !pqtest.ErrorContains(err, "{:shutdown, :db_termination}") {
 			t.Fatalf("unexpected error %T: %[1]s", err)
 		}
 	} else {
@@ -520,6 +580,10 @@ func TestListenerReconnect(t *testing.T) {
 }
 
 func TestListenerClose(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListenerTimeout(t, 20*time.Millisecond, time.Hour)
 	defer l.Close()
 
@@ -534,6 +598,10 @@ func TestListenerClose(t *testing.T) {
 }
 
 func TestListenerPing(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	l, _ := newTestListenerTimeout(t, 20*time.Millisecond, time.Hour)
 	defer l.Close()
 
@@ -554,6 +622,10 @@ func TestListenerPing(t *testing.T) {
 }
 
 func TestConnectorWithNotificationHandler_Simple(t *testing.T) {
+	// listen/notify currently broken in Supavisor
+	// https://github.com/supabase/supavisor/issues/85
+	pqtest.SkipSupavisor(t)
+
 	b, err := NewConnector("")
 	if err != nil {
 		t.Fatal(err)

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -30,6 +30,9 @@ func startSSLTest(t *testing.T, user string) {
 		wantErr = "protocol_violation"
 	} else if pqtest.Pgpool() {
 		wantErr = "internal_error"
+	} else if pqtest.Supavisor() {
+		// TODO: "Either external_id or sni_hostname must be provided" {:single, "pqgosslcert", nil}
+		wantErr = "internal_error"
 	}
 	_, err := openSSLConn(t, "sslmode=disable user="+user)
 	pqErr := pqError(t, err)
@@ -39,6 +42,9 @@ func startSSLTest(t *testing.T, user string) {
 }
 
 func TestSSLMode(t *testing.T) {
+	// TODO: need additional config to test SSL w/ Supavisor
+	pqtest.SkipSupavisor(t)
+
 	tests := []struct {
 		connect string
 		wantErr bool
@@ -92,6 +98,7 @@ func TestSSLMode(t *testing.T) {
 func TestSSLClientCertificates(t *testing.T) {
 	pqtest.SkipPgpool(t)    // TODO: can't get it to work.
 	pqtest.SkipPgbouncer(t) // TODO: can't get it to work.
+	pqtest.SkipSupavisor(t) // TODO: need to set SSL up in Supavisor.
 
 	startSSLTest(t, "pqgosslcert")
 
@@ -147,6 +154,9 @@ func TestSSLClientCertificates(t *testing.T) {
 
 // Check that clint sends SNI data when sslsni is not disabled
 func TestSSLSNI(t *testing.T) {
+	// TODO: need additional config to test SSL w/ Supavisor
+	pqtest.SkipSupavisor(t)
+
 	startSSLTest(t, "pqgosslcert")
 
 	tests := []struct {


### PR DESCRIPTION
Start Supavisor:

```shell
$ docker compose up -d supavisor-create-tenant
```

Run tests in session mode:

```shell
$ PGPORT=5452 PGHOST=localhost PGUSER=pqgo.dev_tenant PGPASSWORD=unused go test -shuffle=on -failfast -timeout 30m -count=5
```

Run tests in transaction mode:

```shell
$ PGPORT=6543 PGHOST=localhost PGUSER=pqgo.dev_tenant PGPASSWORD=unused go test -shuffle=on -failfast -timeout 30m -count=5
```

A number of tests were leaking connections due to missing cleanup/close
calls.
