### PR TITLE
Fix SSL key permission check to allow modes stricter than 0600/0640

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 unreleased
 ----------
+
+### Features
+
 - Support protocol 3.2, and the `min_protocol_version` and
   `max_protocol_version` DSN parameters ([#1258]).
 
+### Fixes
+
+- Fix SSL key permission check to allow modes stricter than 0600/0640#1265 ([#1265]).
+
 [#1258]: https://github.com/lib/pq/pull/1258
+[#1265]: https://github.com/lib/pq/pull/1265
 
 v1.11.2 (2026-02-10)
 --------------------

--- a/internal/pqutil/perm.go
+++ b/internal/pqutil/perm.go
@@ -37,7 +37,7 @@ func checkPermissions(fi os.FileInfo) error {
 	// is allowed to have. This translates to u=rw. Regardless of if we're
 	// running as root or not, 0600 is acceptable, so we return if no bits
 	// beyond the regular user permission mask are set.
-	if fi.Mode().Perm()&^os.FileMode(0600) == 0 {
+	if fi.Mode().Perm()&^os.FileMode(0o600) == 0 {
 		return nil
 	}
 
@@ -54,7 +54,7 @@ func checkPermissions(fi os.FileInfo) error {
 	if sys.Uid == 0 {
 		// The maximum permissions that a private key file owned by root is
 		// allowed to have. This translates to u=rw,g=r.
-		if fi.Mode().Perm()&^os.FileMode(0640) != 0 {
+		if fi.Mode().Perm()&^os.FileMode(0o640) != 0 {
 			return ErrSSLKeyHasWorldPermissions
 		}
 		return nil

--- a/internal/pqutil/perm_test.go
+++ b/internal/pqutil/perm_test.go
@@ -28,23 +28,28 @@ func TestSSLKeyPermissions(t *testing.T) {
 		stat    syscall.Stat_t
 		wantErr string
 	}{
-		// user-owned: at most 0600
-		{syscall.Stat_t{Mode: 0600, Uid: currentUID, Gid: currentGID}, ""},
-		{syscall.Stat_t{Mode: 0400, Uid: currentUID, Gid: currentGID}, ""},
-		{syscall.Stat_t{Mode: 0000, Uid: currentUID, Gid: currentGID}, ""},
+		// user-owned: at most 0o600
+		{syscall.Stat_t{Mode: 0o600, Uid: currentUID, Gid: currentGID}, ""},
+		{syscall.Stat_t{Mode: 0o400, Uid: currentUID, Gid: currentGID}, ""},
+		{syscall.Stat_t{Mode: 0o000, Uid: currentUID, Gid: currentGID}, ""},
 
-		// root-owned: at most 0640
-		{syscall.Stat_t{Mode: 0640, Uid: 0, Gid: currentGID}, ""},
-		{syscall.Stat_t{Mode: 0600, Uid: 0, Gid: currentGID}, ""},
-		{syscall.Stat_t{Mode: 0400, Uid: 0, Gid: currentGID}, ""},
-		{syscall.Stat_t{Mode: 0000, Uid: 0, Gid: currentGID}, ""},
+		{syscall.Stat_t{Mode: 0o700, Uid: currentUID, Gid: currentGID}, "private key has world access"},
+		{syscall.Stat_t{Mode: 0o640, Uid: currentUID, Gid: currentGID}, "private key has world access"},
+		{syscall.Stat_t{Mode: 0o660, Uid: currentUID, Gid: currentGID}, "private key has world access"},
+		{syscall.Stat_t{Mode: 0o604, Uid: currentUID, Gid: currentGID}, "private key has world access"},
+		{syscall.Stat_t{Mode: 0o606, Uid: currentUID, Gid: currentGID}, "private key has world access"},
 
-		// excessive permissions
-		{syscall.Stat_t{Mode: 0644, Uid: currentUID, Gid: currentGID}, "private key has world access"},
-		{syscall.Stat_t{Mode: 0700, Uid: currentUID, Gid: currentGID}, "private key has world access"},
-		{syscall.Stat_t{Mode: 0666, Uid: currentUID, Gid: currentGID}, "private key has world access"},
-		{syscall.Stat_t{Mode: 0666, Uid: 0, Gid: currentGID}, "private key has world access"},
-		{syscall.Stat_t{Mode: 0660, Uid: 0, Gid: currentGID}, "private key has world access"},
+		// root-owned: at most 0o640
+		{syscall.Stat_t{Mode: 0o600, Uid: 0, Gid: currentGID}, ""},
+		{syscall.Stat_t{Mode: 0o400, Uid: 0, Gid: currentGID}, ""},
+		{syscall.Stat_t{Mode: 0o040, Uid: 0, Gid: currentGID}, ""},
+		{syscall.Stat_t{Mode: 0o640, Uid: 0, Gid: currentGID}, ""},
+		{syscall.Stat_t{Mode: 0o000, Uid: 0, Gid: currentGID}, ""},
+
+		{syscall.Stat_t{Mode: 0o060, Uid: 0, Gid: currentGID}, "private key has world access"},
+		{syscall.Stat_t{Mode: 0o006, Uid: 0, Gid: currentGID}, "private key has world access"},
+		{syscall.Stat_t{Mode: 0o004, Uid: 0, Gid: currentGID}, "private key has world access"},
+		{syscall.Stat_t{Mode: 0o666, Uid: 0, Gid: currentGID}, "private key has world access"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The permission check in `checkPermissions` used XOR (`^`) which only accepted
an exact mode match (0600 for user-owned, 0640 for root-owned). Modes more
restrictive than the maximum (e.g. 0400, read-only) were incorrectly rejected.

Use AND NOT (`&^`) to check that no permission bits exceed the allowed maximum
instead.

Fixes #1257