### PR TITLE
Use "cleanstart/pgbouncer:latest" image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: 'test'
 on:
   pull_request:
-    paths: ['**.go', 'go.mod', '.github/workflows/*']
+    paths: ['**.go', 'go.mod', '.github/workflows/*', 'compose.yaml']
   push:
     branches: ['main', 'master']
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ name: 'pqgo'
 services:
   pgbouncer:
     profiles: ['pgbouncer']
-    image:    'cleanstart/pgbouncer:1.24'
+    image:    'cleanstart/pgbouncer:latest'
     ports:    ['127.0.0.1:6432:6432']
     command:  ['/init/pgbouncer.ini']
     volumes:  ['./testdata/init:/init']


### PR DESCRIPTION
So it looks like the cleanstart people updated the Docker image, and just blew away all previous tags, and they have just one tag (1.25.1): https://hub.docker.com/r/cleanstart/pgbouncer

What a weird thing to do...

Just use :latest for now, I guess. Should probably find or create something better at some point, but this at least allows running the tests for now.