### PR TITLE
Add healthcheck to compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,56 +21,60 @@ services:
       'PGPOOL_PARAMS_BACKEND_HOSTNAME0': 'pg18'
 
   pg18:
-    image:      'postgres:18'
-    ports:      ['127.0.0.1:5432:5432']
-    entrypoint: '/init/entry.sh'
-    volumes:    ['./testdata/init:/init']
-    shm_size:   '128mb'
+    image:       'postgres:18'
+    ports:       ['127.0.0.1:5432:5432']
+    entrypoint:  '/init/entry.sh'
+    volumes:     ['./testdata/init:/init']
+    shm_size:    '128mb'
+    healthcheck: {test: ['CMD-SHELL', 'pg_isready', '-U', 'pqgo', '-d', 'pqgo'], start_period: '30s', start_interval: '1s'}
     environment:
       'POSTGRES_DATABASE': 'pqgo'
       'POSTGRES_USER':     'pqgo'
       'POSTGRES_PASSWORD': 'unused'
   pg17:
-    profiles:   ['pg17']
-    image:      'postgres:17'
-    ports:      ['127.0.0.1:5432:5432']
-    entrypoint: '/init/entry.sh'
-    volumes:    ['./testdata/init:/init']
-    shm_size:   '128mb'
-    user: 'root'
+    profiles:    ['pg17']
+    image:       'postgres:17'
+    ports:       ['127.0.0.1:5432:5432']
+    entrypoint:  '/init/entry.sh'
+    volumes:     ['./testdata/init:/init']
+    shm_size:    '128mb'
+    healthcheck: {test: ['CMD-SHELL', 'pg_isready', '-U', 'pqgo', '-d', 'pqgo'], start_period: '30s', start_interval: '1s'}
     environment:
       'POSTGRES_DATABASE': 'pqgo'
       'POSTGRES_USER':     'pqgo'
       'POSTGRES_PASSWORD': 'unused'
   pg16:
-    profiles:   ['pg16']
-    image:      'postgres:16'
-    ports:      ['127.0.0.1:5432:5432']
-    entrypoint: '/init/entry.sh'
-    volumes:    ['./testdata/init:/init']
-    shm_size:   '128mb'
+    profiles:    ['pg16']
+    image:       'postgres:16'
+    ports:       ['127.0.0.1:5432:5432']
+    entrypoint:  '/init/entry.sh'
+    volumes:     ['./testdata/init:/init']
+    shm_size:    '128mb'
+    healthcheck: {test: ['CMD-SHELL', 'pg_isready', '-U', 'pqgo', '-d', 'pqgo'], start_period: '30s', start_interval: '1s'}
     environment:
       'POSTGRES_DATABASE': 'pqgo'
       'POSTGRES_USER':     'pqgo'
       'POSTGRES_PASSWORD': 'unused'
   pg15:
-    profiles:   ['pg15']
-    image:      'postgres:15'
-    ports:      ['127.0.0.1:5432:5432']
-    entrypoint: '/init/entry.sh'
-    volumes:    ['./testdata/init:/init']
-    shm_size:   '128mb'
+    profiles:    ['pg15']
+    image:       'postgres:15'
+    ports:       ['127.0.0.1:5432:5432']
+    entrypoint:  '/init/entry.sh'
+    volumes:     ['./testdata/init:/init']
+    shm_size:    '128mb'
+    healthcheck: {test: ['CMD-SHELL', 'pg_isready', '-U', 'pqgo', '-d', 'pqgo'], start_period: '30s', start_interval: '1s'}
     environment:
       'POSTGRES_DATABASE': 'pqgo'
       'POSTGRES_USER':     'pqgo'
       'POSTGRES_PASSWORD': 'unused'
   pg14:
-    profiles:   ['pg14']
-    image:      'postgres:14'
-    ports:      ['127.0.0.1:5432:5432']
-    entrypoint: '/init/entry.sh'
-    volumes:    ['./testdata/init:/init']
-    shm_size:   '128mb'
+    profiles:    ['pg14']
+    image:       'postgres:14'
+    ports:       ['127.0.0.1:5432:5432']
+    entrypoint:  '/init/entry.sh'
+    volumes:     ['./testdata/init:/init']
+    shm_size:    '128mb'
+    healthcheck: {test: ['CMD-SHELL', 'pg_isready', '-U', 'pqgo', '-d', 'pqgo'], start_period: '30s', start_interval: '1s'}
     environment:
       'POSTGRES_DATABASE': 'pqgo'
       'POSTGRES_USER':     'pqgo'


### PR DESCRIPTION
Should make "compose up --wait" more reliable, reducing some of the "server is not yet ready" failures in the CI.