### PR TITLE
Don't print to stderr when running tests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/lib/pq/internal/pgpass"
 	"github.com/lib/pq/internal/pqtest"
+	"github.com/lib/pq/internal/pqutil"
 	"github.com/lib/pq/internal/proto"
 )
 
@@ -102,6 +103,11 @@ func TestOpen(t *testing.T) {
 }
 
 func TestPgpass(t *testing.T) {
+	// Note: can't be run in parallel
+	warnbuf := new(bytes.Buffer)
+	pqutil.WarnFD = warnbuf
+	defer func() { pqutil.WarnFD = os.Stderr }()
+
 	assertPassword := func(want string, extra map[string]string) {
 		o := map[string]string{
 			"host":            "localhost",
@@ -136,6 +142,10 @@ func TestPgpass(t *testing.T) {
 
 	// wrong permissions for the pgpass file means it should be ignored
 	assertPassword("", map[string]string{"host": "example.com", "passfile": file, "user": "foo"})
+	if h := "has group or world access"; !strings.Contains(warnbuf.String(), h) {
+		t.Errorf("unexpected warning\nhave: %s\nwant: %s", warnbuf, h)
+	}
+	warnbuf.Reset()
 
 	if err := os.Chmod(file, 0600); err != nil { // Fix the permissions
 		t.Fatal(err)
@@ -153,6 +163,9 @@ func TestPgpass(t *testing.T) {
 	os.Setenv("PGPASSFILE", "/tmp")
 	defer os.Unsetenv("PGPASSFILE")
 	assertPassword("pass_A", map[string]string{"host": "server", "passfile": file, "dbname": "some_db", "user": "some_user"})
+	if warnbuf.String() != "" {
+		t.Errorf("warnbuf not empty: %s", warnbuf)
+	}
 }
 
 func TestExecNilSlice(t *testing.T) {

--- a/internal/pqutil/path.go
+++ b/internal/pqutil/path.go
@@ -2,6 +2,7 @@ package pqutil
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -36,6 +37,8 @@ func Home() string {
 	return home
 }
 
+var WarnFD io.Writer = os.Stderr
+
 // Pgpass gets the filepath to the pgpass file to use, returning "" if a pgpass
 // file shouldn't be used.
 func Pgpass(passfile string) string {
@@ -55,7 +58,7 @@ func Pgpass(passfile string) string {
 			return ""
 		}
 		if fi.Mode().Perm()&(0x77) != 0 {
-			fmt.Fprintf(os.Stderr,
+			fmt.Fprintf(WarnFD,
 				"WARNING: password file %q has group or world access; permissions should be u=rw (0600) or less\n",
 				passfile)
 			return ""


### PR DESCRIPTION
It's basically harmless, but it's been bugging me.