### PR TITLE
Refactor array tests

### DIFF
--- a/array.go
+++ b/array.go
@@ -486,7 +486,7 @@ func (a GenericArray) Value() (driver.Value, error) {
 		}
 	case reflect.Array:
 	default:
-		return nil, fmt.Errorf("pq: Unable to convert %T to array", a.A)
+		return nil, fmt.Errorf("pq: unable to convert %T to array", a.A)
 	}
 
 	if n := rv.Len(); n > 0 {

--- a/array_test.go
+++ b/array_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/lib/pq/internal/pqtest"
 )
 
-func TestParseArray(t *testing.T) {
-	for _, tt := range []struct {
-		input string
+func TestArrayParse(t *testing.T) {
+	tests := []struct {
+		in    string
 		delim string
 		dims  []int
 		elems [][]byte
@@ -45,24 +45,28 @@ func TestParseArray(t *testing.T) {
 			{'"'}, {'"'}, {'"'}, {'"'}, {'"'}, {'"'},
 		}},
 		{`{axyzb}`, `xyz`, []int{2}, [][]byte{{'a'}, {'b'}}},
-	} {
-		dims, elems, err := parseArray([]byte(tt.input), []byte(tt.delim))
+	}
 
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %q", tt.input, err)
-		}
-		if !reflect.DeepEqual(dims, tt.dims) {
-			t.Errorf("Expected %v dimensions for %q, got %v", tt.dims, tt.input, dims)
-		}
-		if !reflect.DeepEqual(elems, tt.elems) {
-			t.Errorf("Expected %v elements for %q, got %v", tt.elems, tt.input, elems)
-		}
+	t.Parallel()
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			dims, elems, err := parseArray([]byte(tt.in), []byte(tt.delim))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(dims, tt.dims) {
+				t.Errorf("dims wrong\nhave: %#v\nwant: %#v", dims, tt.dims)
+			}
+			if !reflect.DeepEqual(elems, tt.elems) {
+				t.Errorf("elems wrong\nhave: %#v\nwant: %#v", elems, tt.elems)
+			}
+		})
 	}
 }
 
-func TestParseArrayError(t *testing.T) {
-	for _, tt := range []struct {
-		input, err string
+func TestArrayParseError(t *testing.T) {
+	tests := []struct {
+		in, wantErr string
 	}{
 		{``, "expected '{' at offset 0"},
 		{`x`, "expected '{' at offset 0"},
@@ -79,1584 +83,74 @@ func TestParseArrayError(t *testing.T) {
 		{`{{x}`, "expected '}' at offset 4"},
 		{`{""x}`, "unexpected 'x' at offset 3"},
 		{`{{a},{b,c}}`, "multidimensional arrays must have elements with matching dimensions"},
-	} {
-		_, _, err := parseArray([]byte(tt.input), []byte{','})
-
-		if err == nil {
-			t.Fatalf("Expected error for %q, got none", tt.input)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
-		}
-	}
-}
-
-func TestArrayScanner(t *testing.T) {
-	var s sql.Scanner = Array(&[]bool{})
-	if _, ok := s.(*BoolArray); !ok {
-		t.Errorf("Expected *BoolArray, got %T", s)
-	}
-
-	s = Array(&[]float64{})
-	if _, ok := s.(*Float64Array); !ok {
-		t.Errorf("Expected *Float64Array, got %T", s)
-	}
-
-	s = Array(&[]int64{})
-	if _, ok := s.(*Int64Array); !ok {
-		t.Errorf("Expected *Int64Array, got %T", s)
-	}
-
-	s = Array(&[]float32{})
-	if _, ok := s.(*Float32Array); !ok {
-		t.Errorf("Expected *Float32Array, got %T", s)
-	}
-
-	s = Array(&[]int32{})
-	if _, ok := s.(*Int32Array); !ok {
-		t.Errorf("Expected *Int32Array, got %T", s)
-	}
-
-	s = Array(&[]string{})
-	if _, ok := s.(*StringArray); !ok {
-		t.Errorf("Expected *StringArray, got %T", s)
-	}
-
-	s = Array(&[][]byte{})
-	if _, ok := s.(*ByteaArray); !ok {
-		t.Errorf("Expected *ByteaArray, got %T", s)
-	}
-
-	for _, tt := range []any{
-		&[]sql.Scanner{},
-		&[][]bool{},
-		&[][]float64{},
-		&[][]int64{},
-		&[][]float32{},
-		&[][]int32{},
-		&[][]string{},
-	} {
-		s = Array(tt)
-		if _, ok := s.(GenericArray); !ok {
-			t.Errorf("Expected GenericArray for %T, got %T", tt, s)
-		}
-	}
-}
-
-func TestArrayValuer(t *testing.T) {
-	var v driver.Valuer = Array([]bool{})
-	if _, ok := v.(*BoolArray); !ok {
-		t.Errorf("Expected *BoolArray, got %T", v)
-	}
-
-	v = Array([]float64{})
-	if _, ok := v.(*Float64Array); !ok {
-		t.Errorf("Expected *Float64Array, got %T", v)
-	}
-
-	v = Array([]int64{})
-	if _, ok := v.(*Int64Array); !ok {
-		t.Errorf("Expected *Int64Array, got %T", v)
-	}
-
-	v = Array([]float32{})
-	if _, ok := v.(*Float32Array); !ok {
-		t.Errorf("Expected *Float32Array, got %T", v)
-	}
-
-	v = Array([]int32{})
-	if _, ok := v.(*Int32Array); !ok {
-		t.Errorf("Expected *Int32Array, got %T", v)
-	}
-
-	v = Array([]string{})
-	if _, ok := v.(*StringArray); !ok {
-		t.Errorf("Expected *StringArray, got %T", v)
-	}
-
-	v = Array([][]byte{})
-	if _, ok := v.(*ByteaArray); !ok {
-		t.Errorf("Expected *ByteaArray, got %T", v)
-	}
-
-	for _, tt := range []any{
-		nil,
-		[]driver.Value{},
-		[][]bool{},
-		[][]float64{},
-		[][]int64{},
-		[][]float32{},
-		[][]int32{},
-		[][]string{},
-	} {
-		v = Array(tt)
-		if _, ok := v.(GenericArray); !ok {
-			t.Errorf("Expected GenericArray for %T, got %T", tt, v)
-		}
-	}
-}
-
-func TestBoolArrayScanUnsupported(t *testing.T) {
-	var arr BoolArray
-	err := arr.Scan(1)
-
-	if err == nil {
-		t.Fatal("Expected error when scanning from int")
-	}
-	if !strings.Contains(err.Error(), "int to BoolArray") {
-		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
-	}
-}
-
-func TestBoolArrayScanEmpty(t *testing.T) {
-	var arr BoolArray
-	err := arr.Scan(`{}`)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr == nil || len(arr) != 0 {
-		t.Errorf("Expected empty, got %#v", arr)
-	}
-}
-
-func TestBoolArrayScanNil(t *testing.T) {
-	arr := BoolArray{true, true, true}
-	err := arr.Scan(nil)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr != nil {
-		t.Errorf("Expected nil, got %+v", arr)
-	}
-}
-
-var BoolArrayStringTests = []struct {
-	str string
-	arr BoolArray
-}{
-	{`{}`, BoolArray{}},
-	{`{t}`, BoolArray{true}},
-	{`{f,t}`, BoolArray{false, true}},
-}
-
-func TestBoolArrayScanBytes(t *testing.T) {
-	for _, tt := range BoolArrayStringTests {
-		bytes := []byte(tt.str)
-		arr := BoolArray{true, true, true}
-		err := arr.Scan(bytes)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", bytes, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
-		}
-	}
-}
-
-func BenchmarkBoolArrayScanBytes(b *testing.B) {
-	var a BoolArray
-	var x any = []byte(`{t,f,t,f,t,f,t,f,t,f}`)
-
-	for i := 0; i < b.N; i++ {
-		a = BoolArray{}
-		a.Scan(x)
-	}
-}
-
-func TestBoolArrayScanString(t *testing.T) {
-	for _, tt := range BoolArrayStringTests {
-		arr := BoolArray{true, true, true}
-		err := arr.Scan(tt.str)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
-		}
-	}
-}
-
-func TestBoolArrayScanError(t *testing.T) {
-	for _, tt := range []struct {
-		input, err string
-	}{
-		{``, "unable to parse array"},
-		{`{`, "unable to parse array"},
-		{`{{t},{f}}`, "cannot convert ARRAY[2][1] to BoolArray"},
-		{`{NULL}`, `could not parse boolean array index 0: invalid boolean ""`},
-		{`{a}`, `could not parse boolean array index 0: invalid boolean "a"`},
-		{`{t,b}`, `could not parse boolean array index 1: invalid boolean "b"`},
-		{`{t,f,cd}`, `could not parse boolean array index 2: invalid boolean "cd"`},
-	} {
-		arr := BoolArray{true, true, true}
-		err := arr.Scan(tt.input)
-
-		if err == nil {
-			t.Fatalf("Expected error for %q, got none", tt.input)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
-		}
-		if !reflect.DeepEqual(arr, BoolArray{true, true, true}) {
-			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
-		}
-	}
-}
-
-func TestBoolArrayValue(t *testing.T) {
-	result, err := BoolArray(nil).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for nil, got %v", err)
-	}
-	if result != nil {
-		t.Errorf("Expected nil, got %q", result)
-	}
-
-	result, err = BoolArray([]bool{}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for empty, got %v", err)
-	}
-	if expected := `{}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected empty, got %q", result)
-	}
-
-	result, err = BoolArray([]bool{false, true, false}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if expected := `{f,t,f}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %q, got %q", expected, result)
-	}
-}
-
-func BenchmarkBoolArrayValue(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([]bool, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = rnd.Intn(2) == 0
-	}
-	a := BoolArray(x)
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func TestByteaArrayScanUnsupported(t *testing.T) {
-	var arr ByteaArray
-	err := arr.Scan(1)
-
-	if err == nil {
-		t.Fatal("Expected error when scanning from int")
-	}
-	if !strings.Contains(err.Error(), "int to ByteaArray") {
-		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
-	}
-}
-
-func TestByteaArrayScanEmpty(t *testing.T) {
-	var arr ByteaArray
-	err := arr.Scan(`{}`)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr == nil || len(arr) != 0 {
-		t.Errorf("Expected empty, got %#v", arr)
-	}
-}
-
-func TestByteaArrayScanNil(t *testing.T) {
-	arr := ByteaArray{{2}, {6}, {0, 0}}
-	err := arr.Scan(nil)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr != nil {
-		t.Errorf("Expected nil, got %+v", arr)
-	}
-}
-
-var ByteaArrayStringTests = []struct {
-	str string
-	arr ByteaArray
-}{
-	{`{}`, ByteaArray{}},
-	{`{NULL}`, ByteaArray{nil}},
-	{`{"\\xfeff"}`, ByteaArray{{'\xFE', '\xFF'}}},
-	{`{"\\xdead","\\xbeef"}`, ByteaArray{{'\xDE', '\xAD'}, {'\xBE', '\xEF'}}},
-}
-
-func TestByteaArrayScanBytes(t *testing.T) {
-	for _, tt := range ByteaArrayStringTests {
-		bytes := []byte(tt.str)
-		arr := ByteaArray{{2}, {6}, {0, 0}}
-		err := arr.Scan(bytes)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", bytes, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
-		}
-	}
-}
-
-func BenchmarkByteaArrayScanBytes(b *testing.B) {
-	var a ByteaArray
-	var x any = []byte(`{"\\xfe","\\xff","\\xdead","\\xbeef","\\xfe","\\xff","\\xdead","\\xbeef","\\xfe","\\xff"}`)
-
-	for i := 0; i < b.N; i++ {
-		a = ByteaArray{}
-		a.Scan(x)
-	}
-}
-
-func TestByteaArrayScanString(t *testing.T) {
-	for _, tt := range ByteaArrayStringTests {
-		arr := ByteaArray{{2}, {6}, {0, 0}}
-		err := arr.Scan(tt.str)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
-		}
-	}
-}
-
-func TestByteaArrayScanError(t *testing.T) {
-	for _, tt := range []struct {
-		input, err string
-	}{
-		{``, "unable to parse array"},
-		{`{`, "unable to parse array"},
-		{`{{"\\xfeff"},{"\\xbeef"}}`, "cannot convert ARRAY[2][1] to ByteaArray"},
-		{`{"\\abc"}`, "could not parse bytea array index 0: could not parse bytea value"},
-	} {
-		arr := ByteaArray{{2}, {6}, {0, 0}}
-		err := arr.Scan(tt.input)
-
-		if err == nil {
-			t.Fatalf("Expected error for %q, got none", tt.input)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
-		}
-		if !reflect.DeepEqual(arr, ByteaArray{{2}, {6}, {0, 0}}) {
-			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
-		}
-	}
-}
-
-func TestByteaArrayValue(t *testing.T) {
-	result, err := ByteaArray(nil).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for nil, got %v", err)
-	}
-	if result != nil {
-		t.Errorf("Expected nil, got %q", result)
-	}
-
-	result, err = ByteaArray([][]byte{}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for empty, got %v", err)
-	}
-	if expected := `{}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected empty, got %q", result)
-	}
-
-	result, err = ByteaArray([][]byte{{'\xDE', '\xAD', '\xBE', '\xEF'}, {'\xFE', '\xFF'}, {}}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if expected := `{"\\xdeadbeef","\\xfeff","\\x"}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %q, got %q", expected, result)
-	}
-}
-
-func BenchmarkByteaArrayValue(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([][]byte, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = make([]byte, len(x))
-		for j := 0; j < len(x); j++ {
-			x[i][j] = byte(rnd.Int())
-		}
-	}
-	a := ByteaArray(x)
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func TestFloat64ArrayScanUnsupported(t *testing.T) {
-	var arr Float64Array
-	err := arr.Scan(true)
-
-	if err == nil {
-		t.Fatal("Expected error when scanning from bool")
-	}
-	if !strings.Contains(err.Error(), "bool to Float64Array") {
-		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
-	}
-}
-
-func TestFloat64ArrayScanEmpty(t *testing.T) {
-	var arr Float64Array
-	err := arr.Scan(`{}`)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr == nil || len(arr) != 0 {
-		t.Errorf("Expected empty, got %#v", arr)
-	}
-}
-
-func TestFloat64ArrayScanNil(t *testing.T) {
-	arr := Float64Array{5, 5, 5}
-	err := arr.Scan(nil)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr != nil {
-		t.Errorf("Expected nil, got %+v", arr)
-	}
-}
-
-var Float64ArrayStringTests = []struct {
-	str string
-	arr Float64Array
-}{
-	{`{}`, Float64Array{}},
-	{`{1.2}`, Float64Array{1.2}},
-	{`{3.456,7.89}`, Float64Array{3.456, 7.89}},
-	{`{3,1,2}`, Float64Array{3, 1, 2}},
-}
-
-func TestFloat64ArrayScanBytes(t *testing.T) {
-	for _, tt := range Float64ArrayStringTests {
-		bytes := []byte(tt.str)
-		arr := Float64Array{5, 5, 5}
-		err := arr.Scan(bytes)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", bytes, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
-		}
-	}
-}
-
-func BenchmarkFloat64ArrayScanBytes(b *testing.B) {
-	var a Float64Array
-	var x any = []byte(`{1.2,3.4,5.6,7.8,9.01,2.34,5.67,8.90,1.234,5.678}`)
-
-	for i := 0; i < b.N; i++ {
-		a = Float64Array{}
-		a.Scan(x)
-	}
-}
-
-func TestFloat64ArrayScanString(t *testing.T) {
-	for _, tt := range Float64ArrayStringTests {
-		arr := Float64Array{5, 5, 5}
-		err := arr.Scan(tt.str)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
-		}
-	}
-}
-
-func TestFloat64ArrayScanError(t *testing.T) {
-	for _, tt := range []struct {
-		input, err string
-	}{
-		{``, "unable to parse array"},
-		{`{`, "unable to parse array"},
-		{`{{5.6},{7.8}}`, "cannot convert ARRAY[2][1] to Float64Array"},
-		{`{NULL}`, "parsing array element index 0:"},
-		{`{a}`, "parsing array element index 0:"},
-		{`{5.6,a}`, "parsing array element index 1:"},
-		{`{5.6,7.8,a}`, "parsing array element index 2:"},
-	} {
-		arr := Float64Array{5, 5, 5}
-		err := arr.Scan(tt.input)
-
-		if err == nil {
-			t.Fatalf("Expected error for %q, got none", tt.input)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
-		}
-		if !reflect.DeepEqual(arr, Float64Array{5, 5, 5}) {
-			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
-		}
-	}
-}
-
-func TestFloat64ArrayValue(t *testing.T) {
-	result, err := Float64Array(nil).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for nil, got %v", err)
-	}
-	if result != nil {
-		t.Errorf("Expected nil, got %q", result)
-	}
-
-	result, err = Float64Array([]float64{}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for empty, got %v", err)
-	}
-	if expected := `{}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected empty, got %q", result)
-	}
-
-	result, err = Float64Array([]float64{1.2, 3.4, 5.6}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if expected := `{1.2,3.4,5.6}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %q, got %q", expected, result)
-	}
-}
-
-func BenchmarkFloat64ArrayValue(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([]float64, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = rnd.NormFloat64()
-	}
-	a := Float64Array(x)
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func TestInt64ArrayScanUnsupported(t *testing.T) {
-	var arr Int64Array
-	err := arr.Scan(true)
-
-	if err == nil {
-		t.Fatal("Expected error when scanning from bool")
-	}
-	if !strings.Contains(err.Error(), "bool to Int64Array") {
-		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
-	}
-}
-
-func TestInt64ArrayScanEmpty(t *testing.T) {
-	var arr Int64Array
-	err := arr.Scan(`{}`)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr == nil || len(arr) != 0 {
-		t.Errorf("Expected empty, got %#v", arr)
-	}
-}
-
-func TestInt64ArrayScanNil(t *testing.T) {
-	arr := Int64Array{5, 5, 5}
-	err := arr.Scan(nil)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr != nil {
-		t.Errorf("Expected nil, got %+v", arr)
-	}
-}
-
-var Int64ArrayStringTests = []struct {
-	str string
-	arr Int64Array
-}{
-	{`{}`, Int64Array{}},
-	{`{12}`, Int64Array{12}},
-	{`{345,678}`, Int64Array{345, 678}},
-}
-
-func TestInt64ArrayScanBytes(t *testing.T) {
-	for _, tt := range Int64ArrayStringTests {
-		bytes := []byte(tt.str)
-		arr := Int64Array{5, 5, 5}
-		err := arr.Scan(bytes)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", bytes, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
-		}
-	}
-}
-
-func BenchmarkInt64ArrayScanBytes(b *testing.B) {
-	var a Int64Array
-	var x any = []byte(`{1,2,3,4,5,6,7,8,9,0}`)
-
-	for i := 0; i < b.N; i++ {
-		a = Int64Array{}
-		a.Scan(x)
-	}
-}
-
-func TestInt64ArrayScanString(t *testing.T) {
-	for _, tt := range Int64ArrayStringTests {
-		arr := Int64Array{5, 5, 5}
-		err := arr.Scan(tt.str)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
-		}
-	}
-}
-
-func TestInt64ArrayScanError(t *testing.T) {
-	for _, tt := range []struct {
-		input, err string
-	}{
-		{``, "unable to parse array"},
-		{`{`, "unable to parse array"},
-		{`{{5},{6}}`, "cannot convert ARRAY[2][1] to Int64Array"},
-		{`{NULL}`, "parsing array element index 0:"},
-		{`{a}`, "parsing array element index 0:"},
-		{`{5,a}`, "parsing array element index 1:"},
-		{`{5,6,a}`, "parsing array element index 2:"},
-	} {
-		arr := Int64Array{5, 5, 5}
-		err := arr.Scan(tt.input)
-
-		if err == nil {
-			t.Fatalf("Expected error for %q, got none", tt.input)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
-		}
-		if !reflect.DeepEqual(arr, Int64Array{5, 5, 5}) {
-			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
-		}
-	}
-}
-
-func TestInt64ArrayValue(t *testing.T) {
-	result, err := Int64Array(nil).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for nil, got %v", err)
-	}
-	if result != nil {
-		t.Errorf("Expected nil, got %q", result)
-	}
-
-	result, err = Int64Array([]int64{}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for empty, got %v", err)
-	}
-	if expected := `{}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected empty, got %q", result)
-	}
-
-	result, err = Int64Array([]int64{1, 2, 3}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if expected := `{1,2,3}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %q, got %q", expected, result)
-	}
-}
-
-func BenchmarkInt64ArrayValue(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([]int64, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = rnd.Int63()
-	}
-	a := Int64Array(x)
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func TestFloat32ArrayScanUnsupported(t *testing.T) {
-	var arr Float32Array
-	err := arr.Scan(true)
-
-	if err == nil {
-		t.Fatal("Expected error when scanning from bool")
-	}
-	if !strings.Contains(err.Error(), "bool to Float32Array") {
-		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
-	}
-}
-
-func TestFloat32ArrayScanEmpty(t *testing.T) {
-	var arr Float32Array
-	err := arr.Scan(`{}`)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr == nil || len(arr) != 0 {
-		t.Errorf("Expected empty, got %#v", arr)
 	}
-}
-
-func TestFloat32ArrayScanNil(t *testing.T) {
-	arr := Float32Array{5, 5, 5}
-	err := arr.Scan(nil)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr != nil {
-		t.Errorf("Expected nil, got %+v", arr)
-	}
-}
-
-var Float32ArrayStringTests = []struct {
-	str string
-	arr Float32Array
-}{
-	{`{}`, Float32Array{}},
-	{`{1.2}`, Float32Array{1.2}},
-	{`{3.456,7.89}`, Float32Array{3.456, 7.89}},
-	{`{3,1,2}`, Float32Array{3, 1, 2}},
-}
-
-func TestFloat32ArrayScanBytes(t *testing.T) {
-	for _, tt := range Float32ArrayStringTests {
-		bytes := []byte(tt.str)
-		arr := Float32Array{5, 5, 5}
-		err := arr.Scan(bytes)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", bytes, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
-		}
-	}
-}
-
-func BenchmarkFloat32ArrayScanBytes(b *testing.B) {
-	var a Float32Array
-	var x any = []byte(`{1.2,3.4,5.6,7.8,9.01,2.34,5.67,8.90,1.234,5.678}`)
-
-	for i := 0; i < b.N; i++ {
-		a = Float32Array{}
-		a.Scan(x)
-	}
-}
-
-func TestFloat32ArrayScanString(t *testing.T) {
-	for _, tt := range Float32ArrayStringTests {
-		arr := Float32Array{5, 5, 5}
-		err := arr.Scan(tt.str)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
-		}
-	}
-}
-
-func TestFloat32ArrayScanError(t *testing.T) {
-	for _, tt := range []struct {
-		input, err string
-	}{
-		{``, "unable to parse array"},
-		{`{`, "unable to parse array"},
-		{`{{5.6},{7.8}}`, "cannot convert ARRAY[2][1] to Float32Array"},
-		{`{NULL}`, "parsing array element index 0:"},
-		{`{a}`, "parsing array element index 0:"},
-		{`{5.6,a}`, "parsing array element index 1:"},
-		{`{5.6,7.8,a}`, "parsing array element index 2:"},
-	} {
-		arr := Float32Array{5, 5, 5}
-		err := arr.Scan(tt.input)
-
-		if err == nil {
-			t.Fatalf("Expected error for %q, got none", tt.input)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
-		}
-		if !reflect.DeepEqual(arr, Float32Array{5, 5, 5}) {
-			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
-		}
-	}
-}
-
-func TestFloat32ArrayValue(t *testing.T) {
-	result, err := Float32Array(nil).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for nil, got %v", err)
-	}
-	if result != nil {
-		t.Errorf("Expected nil, got %q", result)
-	}
-
-	result, err = Float32Array([]float32{}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for empty, got %v", err)
-	}
-	if expected := `{}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected empty, got %q", result)
-	}
-
-	result, err = Float32Array([]float32{1.2, 3.4, 5.6}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if expected := `{1.2,3.4,5.6}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %q, got %q", expected, result)
-	}
-}
-
-func BenchmarkFloat32ArrayValue(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([]float32, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = rnd.Float32()
-	}
-	a := Float32Array(x)
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func TestInt32ArrayScanUnsupported(t *testing.T) {
-	var arr Int32Array
-	err := arr.Scan(true)
-
-	if err == nil {
-		t.Fatal("Expected error when scanning from bool")
-	}
-	if !strings.Contains(err.Error(), "bool to Int32Array") {
-		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
-	}
-}
-
-func TestInt32ArrayScanEmpty(t *testing.T) {
-	var arr Int32Array
-	err := arr.Scan(`{}`)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr == nil || len(arr) != 0 {
-		t.Errorf("Expected empty, got %#v", arr)
-	}
-}
-
-func TestInt32ArrayScanNil(t *testing.T) {
-	arr := Int32Array{5, 5, 5}
-	err := arr.Scan(nil)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr != nil {
-		t.Errorf("Expected nil, got %+v", arr)
-	}
-}
-
-var Int32ArrayStringTests = []struct {
-	str string
-	arr Int32Array
-}{
-	{`{}`, Int32Array{}},
-	{`{12}`, Int32Array{12}},
-	{`{345,678}`, Int32Array{345, 678}},
-}
-
-func TestInt32ArrayScanBytes(t *testing.T) {
-	for _, tt := range Int32ArrayStringTests {
-		bytes := []byte(tt.str)
-		arr := Int32Array{5, 5, 5}
-		err := arr.Scan(bytes)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", bytes, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
-		}
-	}
-}
-
-func BenchmarkInt32ArrayScanBytes(b *testing.B) {
-	var a Int32Array
-	var x any = []byte(`{1,2,3,4,5,6,7,8,9,0}`)
-
-	for i := 0; i < b.N; i++ {
-		a = Int32Array{}
-		a.Scan(x)
-	}
-}
-
-func TestInt32ArrayScanString(t *testing.T) {
-	for _, tt := range Int32ArrayStringTests {
-		arr := Int32Array{5, 5, 5}
-		err := arr.Scan(tt.str)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
-		}
-	}
-}
-
-func TestInt32ArrayScanError(t *testing.T) {
-	for _, tt := range []struct {
-		input, err string
-	}{
-		{``, "unable to parse array"},
-		{`{`, "unable to parse array"},
-		{`{{5},{6}}`, "cannot convert ARRAY[2][1] to Int32Array"},
-		{`{NULL}`, "parsing array element index 0:"},
-		{`{a}`, "parsing array element index 0:"},
-		{`{5,a}`, "parsing array element index 1:"},
-		{`{5,6,a}`, "parsing array element index 2:"},
-	} {
-		arr := Int32Array{5, 5, 5}
-		err := arr.Scan(tt.input)
-
-		if err == nil {
-			t.Fatalf("Expected error for %q, got none", tt.input)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
-		}
-		if !reflect.DeepEqual(arr, Int32Array{5, 5, 5}) {
-			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
-		}
-	}
-}
-
-func TestInt32ArrayValue(t *testing.T) {
-	result, err := Int32Array(nil).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for nil, got %v", err)
-	}
-	if result != nil {
-		t.Errorf("Expected nil, got %q", result)
-	}
-
-	result, err = Int32Array([]int32{}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for empty, got %v", err)
-	}
-	if expected := `{}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected empty, got %q", result)
-	}
-
-	result, err = Int32Array([]int32{1, 2, 3}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if expected := `{1,2,3}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %q, got %q", expected, result)
-	}
-}
-
-func BenchmarkInt32ArrayValue(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([]int32, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = rnd.Int31()
-	}
-	a := Int32Array(x)
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func TestStringArrayScanUnsupported(t *testing.T) {
-	var arr StringArray
-	err := arr.Scan(true)
-
-	if err == nil {
-		t.Fatal("Expected error when scanning from bool")
-	}
-	if !strings.Contains(err.Error(), "bool to StringArray") {
-		t.Errorf("Expected type to be mentioned when scanning, got %q", err)
-	}
-}
-
-func TestStringArrayScanEmpty(t *testing.T) {
-	var arr StringArray
-	err := arr.Scan(`{}`)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr == nil || len(arr) != 0 {
-		t.Errorf("Expected empty, got %#v", arr)
-	}
-}
-
-func TestStringArrayScanNil(t *testing.T) {
-	arr := StringArray{"x", "x", "x"}
-	err := arr.Scan(nil)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if arr != nil {
-		t.Errorf("Expected nil, got %+v", arr)
-	}
-}
-
-var StringArrayStringTests = []struct {
-	str string
-	arr StringArray
-}{
-	{`{}`, StringArray{}},
-	{`{t}`, StringArray{"t"}},
-	{`{f,1}`, StringArray{"f", "1"}},
-	{`{"a\\b","c d",","}`, StringArray{"a\\b", "c d", ","}},
-}
-
-func TestStringArrayScanBytes(t *testing.T) {
-	for _, tt := range StringArrayStringTests {
-		bytes := []byte(tt.str)
-		arr := StringArray{"x", "x", "x"}
-		err := arr.Scan(bytes)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", bytes, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, bytes, arr)
-		}
-	}
-}
-
-func BenchmarkStringArrayScanBytes(b *testing.B) {
-	var a StringArray
-	var x any = []byte(`{a,b,c,d,e,f,g,h,i,j}`)
-	var y any = []byte(`{"\a","\b","\c","\d","\e","\f","\g","\h","\i","\j"}`)
-
-	for i := 0; i < b.N; i++ {
-		a = StringArray{}
-		a.Scan(x)
-		a = StringArray{}
-		a.Scan(y)
-	}
-}
-
-func TestStringArrayScanString(t *testing.T) {
-	for _, tt := range StringArrayStringTests {
-		arr := StringArray{"x", "x", "x"}
-		err := arr.Scan(tt.str)
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", tt.str, err)
-		}
-		if !reflect.DeepEqual(arr, tt.arr) {
-			t.Errorf("Expected %+v for %q, got %+v", tt.arr, tt.str, arr)
-		}
-	}
-}
-
-func TestStringArrayScanError(t *testing.T) {
-	for _, tt := range []struct {
-		input, err string
-	}{
-		{``, "unable to parse array"},
-		{`{`, "unable to parse array"},
-		{`{{a},{b}}`, "cannot convert ARRAY[2][1] to StringArray"},
-		{`{NULL}`, "parsing array element index 0: cannot convert nil to string"},
-		{`{a,NULL}`, "parsing array element index 1: cannot convert nil to string"},
-		{`{a,b,NULL}`, "parsing array element index 2: cannot convert nil to string"},
-	} {
-		arr := StringArray{"x", "x", "x"}
-		err := arr.Scan(tt.input)
-
-		if err == nil {
-			t.Fatalf("Expected error for %q, got none", tt.input)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for %q, got %q", tt.err, tt.input, err)
-		}
-		if !reflect.DeepEqual(arr, StringArray{"x", "x", "x"}) {
-			t.Errorf("Expected destination not to change for %q, got %+v", tt.input, arr)
-		}
-	}
-}
-
-func TestStringArrayValue(t *testing.T) {
-	result, err := StringArray(nil).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for nil, got %v", err)
-	}
-	if result != nil {
-		t.Errorf("Expected nil, got %q", result)
-	}
-
-	result, err = StringArray([]string{}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for empty, got %v", err)
-	}
-	if expected := `{}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected empty, got %q", result)
-	}
-
-	result, err = StringArray([]string{`a`, `\b`, `c"`, `d,e`}).Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if expected := `{"a","\\b","c\"","d,e"}`; !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %q, got %q", expected, result)
-	}
-}
-
-func BenchmarkStringArrayValue(b *testing.B) {
-	x := make([]string, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = strings.Repeat(`abc"def\ghi`, 5)
-	}
-	a := StringArray(x)
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func TestGenericArrayScanUnsupported(t *testing.T) {
-	var s string
-	var ss []string
-	var nsa [1]sql.NullString
-
-	for _, tt := range []struct {
-		src, dest any
-		err       string
-	}{
-		{nil, nil, "destination <nil> is not a pointer to array or slice"},
-		{nil, true, "destination bool is not a pointer to array or slice"},
-		{nil, &s, "destination *string is not a pointer to array or slice"},
-		{nil, ss, "destination []string is not a pointer to array or slice"},
-		{nil, &nsa, "<nil> to [1]sql.NullString"},
-		{true, &ss, "bool to []string"},
-		{`{{x}}`, &ss, "multidimensional ARRAY[1][1] is not implemented"},
-		{`{{x},{x}}`, &ss, "multidimensional ARRAY[2][1] is not implemented"},
-		{`{x}`, &ss, "scanning to string is not implemented"},
-	} {
-		err := GenericArray{tt.dest}.Scan(tt.src)
-
-		if err == nil {
-			t.Fatalf("Expected error for [%#v %#v]", tt.src, tt.dest)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for [%#v %#v], got %q", tt.err, tt.src, tt.dest, err)
-		}
-	}
-}
-
-func TestGenericArrayScanScannerArrayBytes(t *testing.T) {
-	src, expected, nsa := []byte(`{NULL,abc,"\""}`),
-		[3]sql.NullString{{}, {String: `abc`, Valid: true}, {String: `"`, Valid: true}},
-		[3]sql.NullString{{String: ``, Valid: true}, {}, {}}
-
-	if err := (GenericArray{&nsa}).Scan(src); err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if !reflect.DeepEqual(nsa, expected) {
-		t.Errorf("Expected %v, got %v", expected, nsa)
-	}
-}
-
-func TestGenericArrayScanScannerArrayString(t *testing.T) {
-	src, expected, nsa := `{NULL,"\"",xyz}`,
-		[3]sql.NullString{{}, {String: `"`, Valid: true}, {String: `xyz`, Valid: true}},
-		[3]sql.NullString{{String: ``, Valid: true}, {}, {}}
-
-	if err := (GenericArray{&nsa}).Scan(src); err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if !reflect.DeepEqual(nsa, expected) {
-		t.Errorf("Expected %v, got %v", expected, nsa)
-	}
-}
-
-func TestGenericArrayScanScannerSliceEmpty(t *testing.T) {
-	var nss []sql.NullString
-
-	if err := (GenericArray{&nss}).Scan(`{}`); err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if nss == nil || len(nss) != 0 {
-		t.Errorf("Expected empty, got %#v", nss)
-	}
-}
-
-func TestGenericArrayScanScannerSliceNil(t *testing.T) {
-	nss := []sql.NullString{{String: ``, Valid: true}, {}}
-
-	if err := (GenericArray{&nss}).Scan(nil); err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if nss != nil {
-		t.Errorf("Expected nil, got %+v", nss)
-	}
-}
-
-func TestGenericArrayScanScannerSliceBytes(t *testing.T) {
-	src, expected, nss := []byte(`{NULL,abc,"\""}`),
-		[]sql.NullString{{}, {String: `abc`, Valid: true}, {String: `"`, Valid: true}},
-		[]sql.NullString{{String: ``, Valid: true}, {}, {}, {}, {}}
-
-	if err := (GenericArray{&nss}).Scan(src); err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if !reflect.DeepEqual(nss, expected) {
-		t.Errorf("Expected %v, got %v", expected, nss)
-	}
-}
-
-func BenchmarkGenericArrayScanScannerSliceBytes(b *testing.B) {
-	var a GenericArray
-	var x any = []byte(`{a,b,c,d,e,f,g,h,i,j}`)
-	var y any = []byte(`{"\a","\b","\c","\d","\e","\f","\g","\h","\i","\j"}`)
-
-	for i := 0; i < b.N; i++ {
-		a = GenericArray{new([]sql.NullString)}
-		a.Scan(x)
-		a = GenericArray{new([]sql.NullString)}
-		a.Scan(y)
-	}
-}
-
-func TestGenericArrayScanScannerSliceString(t *testing.T) {
-	src, expected, nss := `{NULL,"\"",xyz}`,
-		[]sql.NullString{{}, {String: `"`, Valid: true}, {String: `xyz`, Valid: true}},
-		[]sql.NullString{{String: ``, Valid: true}, {}, {}}
-
-	if err := (GenericArray{&nss}).Scan(src); err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if !reflect.DeepEqual(nss, expected) {
-		t.Errorf("Expected %v, got %v", expected, nss)
-	}
-}
-
-type TildeNullInt64 struct{ sql.NullInt64 }
-
-func (TildeNullInt64) ArrayDelimiter() string { return "~" }
-
-func TestGenericArrayScanDelimiter(t *testing.T) {
-	src, expected, tnis := `{12~NULL~76}`,
-		[]TildeNullInt64{{sql.NullInt64{Int64: 12, Valid: true}}, {}, {sql.NullInt64{Int64: 76, Valid: true}}},
-		[]TildeNullInt64{{sql.NullInt64{Int64: 0, Valid: true}}, {}}
-
-	if err := (GenericArray{&tnis}).Scan(src); err != nil {
-		t.Fatalf("Expected no error for %#v, got %v", src, err)
-	}
-	if !reflect.DeepEqual(tnis, expected) {
-		t.Errorf("Expected %v for %#v, got %v", expected, src, tnis)
-	}
-}
-
-func TestGenericArrayScanErrors(t *testing.T) {
-	var sa [1]string
-	var nis []sql.NullInt64
-	var pss *[]string
-
-	for _, tt := range []struct {
-		src, dest any
-		err       string
-	}{
-		{nil, pss, "destination *[]string is nil"},
-		{`{`, &sa, "unable to parse"},
-		{`{}`, &sa, "cannot convert ARRAY[0] to [1]string"},
-		{`{x,x}`, &sa, "cannot convert ARRAY[2] to [1]string"},
-		{`{x}`, &nis, `parsing array element index 0: converting`},
-	} {
-		err := GenericArray{tt.dest}.Scan(tt.src)
-
-		if err == nil {
-			t.Fatalf("Expected error for [%#v %#v]", tt.src, tt.dest)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Expected error to contain %q for [%#v %#v], got %q", tt.err, tt.src, tt.dest, err)
-		}
-	}
-}
-
-func TestGenericArrayValueUnsupported(t *testing.T) {
-	_, err := GenericArray{true}.Value()
-
-	if err == nil {
-		t.Fatal("Expected error for bool")
-	}
-	if !strings.Contains(err.Error(), "bool to array") {
-		t.Errorf("Expected type to be mentioned, got %q", err)
-	}
-}
-
-type ByteArrayValuer [1]byte
-type ByteSliceValuer []byte
-type FuncArrayValuer struct {
-	delimiter func() string
-	value     func() (driver.Value, error)
-}
-
-func (a ByteArrayValuer) Value() (driver.Value, error) { return a[:], nil }
-func (b ByteSliceValuer) Value() (driver.Value, error) { return []byte(b), nil }
-func (f FuncArrayValuer) ArrayDelimiter() string       { return f.delimiter() }
-func (f FuncArrayValuer) Value() (driver.Value, error) { return f.value() }
-
-func TestGenericArrayValue(t *testing.T) {
-	result, err := GenericArray{nil}.Value()
-
-	if err != nil {
-		t.Fatalf("Expected no error for nil, got %v", err)
-	}
-	if result != nil {
-		t.Errorf("Expected nil, got %q", result)
-	}
-
-	for _, tt := range []any{
-		[]bool(nil),
-		[][]int(nil),
-		[]*int(nil),
-		[]sql.NullString(nil),
-	} {
-		result, err := GenericArray{tt}.Value()
-
-		if err != nil {
-			t.Fatalf("Expected no error for %#v, got %v", tt, err)
-		}
-		if result != nil {
-			t.Errorf("Expected nil for %#v, got %q", tt, result)
-		}
-	}
-
-	Tilde := func(v driver.Value) FuncArrayValuer {
-		return FuncArrayValuer{
-			func() string { return "~" },
-			func() (driver.Value, error) { return v, nil }}
-	}
-
-	for _, tt := range []struct {
-		result string
-		input  any
-	}{
-		{`{}`, []bool{}},
-		{`{true}`, []bool{true}},
-		{`{true,false}`, []bool{true, false}},
-		{`{true,false}`, [2]bool{true, false}},
-
-		{`{}`, [][]int{{}}},
-		{`{}`, [][]int{{}, {}}},
-		{`{{1}}`, [][]int{{1}}},
-		{`{{1},{2}}`, [][]int{{1}, {2}}},
-		{`{{1,2},{3,4}}`, [][]int{{1, 2}, {3, 4}}},
-		{`{{1,2},{3,4}}`, [2][2]int{{1, 2}, {3, 4}}},
-
-		{`{"a","\\b","c\"","d,e"}`, []string{`a`, `\b`, `c"`, `d,e`}},
-		{`{"a","\\b","c\"","d,e"}`, [][]byte{{'a'}, {'\\', 'b'}, {'c', '"'}, {'d', ',', 'e'}}},
-
-		{`{NULL}`, []*int{nil}},
-		{`{0,NULL}`, []*int{new(int), nil}},
-
-		{`{NULL}`, []sql.NullString{{}}},
-		{`{"\"",NULL}`, []sql.NullString{{String: `"`, Valid: true}, {}}},
-
-		{`{"a","b"}`, []ByteArrayValuer{{'a'}, {'b'}}},
-		{`{{"a","b"},{"c","d"}}`, [][]ByteArrayValuer{{{'a'}, {'b'}}, {{'c'}, {'d'}}}},
-
-		{`{"e","f"}`, []ByteSliceValuer{{'e'}, {'f'}}},
-		{`{{"e","f"},{"g","h"}}`, [][]ByteSliceValuer{{{'e'}, {'f'}}, {{'g'}, {'h'}}}},
-
-		{`{1~2}`, []FuncArrayValuer{Tilde(int64(1)), Tilde(int64(2))}},
-		{`{{1~2}~{3~4}}`, [][]FuncArrayValuer{{Tilde(int64(1)), Tilde(int64(2))}, {Tilde(int64(3)), Tilde(int64(4))}}},
-	} {
-		result, err := GenericArray{tt.input}.Value()
-
-		if err != nil {
-			t.Fatalf("Expected no error for %q, got %v", tt.input, err)
-		}
-		if !reflect.DeepEqual(result, tt.result) {
-			t.Errorf("Expected %q for %q, got %q", tt.result, tt.input, result)
-		}
-	}
-}
-
-func TestGenericArrayValueErrors(t *testing.T) {
-	v := []any{func() {}}
-	if _, err := (GenericArray{v}).Value(); err == nil {
-		t.Errorf("Expected error for %q, got nil", v)
-	}
-
-	v = []any{nil, func() {}}
-	if _, err := (GenericArray{v}).Value(); err == nil {
-		t.Errorf("Expected error for %q, got nil", v)
-	}
-}
-
-func BenchmarkGenericArrayValueBools(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([]bool, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = rnd.Intn(2) == 0
-	}
-	a := GenericArray{x}
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func BenchmarkGenericArrayValueFloat64s(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([]float64, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = rnd.NormFloat64()
-	}
-	a := GenericArray{x}
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func BenchmarkGenericArrayValueInt64s(b *testing.B) {
-	rnd := rand.New(rand.NewSource(1))
-	x := make([]int64, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = rnd.Int63()
-	}
-	a := GenericArray{x}
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func BenchmarkGenericArrayValueByteSlices(b *testing.B) {
-	x := make([][]byte, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = bytes.Repeat([]byte(`abc"def\ghi`), 5)
-	}
-	a := GenericArray{x}
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func BenchmarkGenericArrayValueStrings(b *testing.B) {
-	x := make([]string, 10)
-	for i := 0; i < len(x); i++ {
-		x[i] = strings.Repeat(`abc"def\ghi`, 5)
-	}
-	a := GenericArray{x}
-
-	for i := 0; i < b.N; i++ {
-		a.Value()
-	}
-}
-
-func TestArrayScanBackend(t *testing.T) {
-	db := pqtest.MustDB(t)
 
-	for _, tt := range []struct {
-		s string
-		d sql.Scanner
-		e any
-	}{
-		{`ARRAY[true, false]`, new(BoolArray), &BoolArray{true, false}},
-		{`ARRAY[E'\\xdead', E'\\xbeef']`, new(ByteaArray), &ByteaArray{{'\xDE', '\xAD'}, {'\xBE', '\xEF'}}},
-		{`ARRAY[1.2, 3.4]`, new(Float64Array), &Float64Array{1.2, 3.4}},
-		{`ARRAY[1, 2, 3]`, new(Int64Array), &Int64Array{1, 2, 3}},
-		{`ARRAY['a', E'\\b', 'c"', 'd,e']`, new(StringArray), &StringArray{`a`, `\b`, `c"`, `d,e`}},
-	} {
+	t.Parallel()
+	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			err := db.QueryRow(`SELECT ` + tt.s).Scan(tt.d)
-			if err != nil {
-				t.Errorf("Expected no error when scanning %s into %T, got %v", tt.s, tt.d, err)
-			}
-			if !reflect.DeepEqual(tt.d, tt.e) {
-				t.Errorf("Expected %v when scanning %s into %T, got %v", tt.e, tt.s, tt.d, tt.d)
+			_, _, err := parseArray([]byte(tt.in), []byte{','})
+			if !pqtest.ErrorContains(err, tt.wantErr) {
+				t.Errorf("wrong error:\nhave: %s\nwant: %s", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestArrayValueBackend(t *testing.T) {
-	db := pqtest.MustDB(t)
-
-	for _, tt := range []struct {
-		s string
-		v driver.Valuer
+func TestArrayFunc(t *testing.T) {
+	tests := []struct {
+		in   any
+		want any
 	}{
-		{`ARRAY[true, false]`, BoolArray{true, false}},
-		{`ARRAY[E'\\xdead', E'\\xbeef']`, ByteaArray{{'\xDE', '\xAD'}, {'\xBE', '\xEF'}}},
-		{`ARRAY[1.2, 3.4]`, Float64Array{1.2, 3.4}},
-		{`ARRAY[1, 2, 3]`, Int64Array{1, 2, 3}},
-		{`ARRAY['a', E'\\b', 'c"', 'd,e']`, StringArray{`a`, `\b`, `c"`, `d,e`}},
-	} {
-		var x int
-		err := db.QueryRow(`SELECT 1 WHERE `+tt.s+` <> $1`, tt.v).Scan(&x)
-		if err != sql.ErrNoRows {
-			t.Errorf("Expected %v to equal %s, got %v", tt.v, tt.s, err)
-		}
+		{[]bool{}, &BoolArray{}},
+		{[]float64{}, &Float64Array{}},
+		{[]int64{}, &Int64Array{}},
+		{[]float32{}, &Float32Array{}},
+		{[]int32{}, &Int32Array{}},
+		{[]string{}, &StringArray{}},
+		{[][]byte{}, &ByteaArray{}},
+		{nil, GenericArray{nil}},
+		{[]driver.Value{}, GenericArray{[]driver.Value{}}},
+		{[][]bool{}, GenericArray{[][]bool{}}},
+		{[][]float64{}, GenericArray{[][]float64{}}},
+		{[][]int64{}, GenericArray{[][]int64{}}},
+		{[][]float32{}, GenericArray{[][]float32{}}},
+		{[][]int32{}, GenericArray{[][]int32{}}},
+		{[][]string{}, GenericArray{[][]string{}}},
+
+		{&[]bool{}, &BoolArray{}},
+		{&[]float64{}, &Float64Array{}},
+		{&[]int64{}, &Int64Array{}},
+		{&[]float32{}, &Float32Array{}},
+		{&[]int32{}, &Int32Array{}},
+		{&[]string{}, &StringArray{}},
+		{&[][]byte{}, &ByteaArray{}},
+		{&[]sql.Scanner{}, GenericArray{&[]sql.Scanner{}}},
+		{&[][]bool{}, GenericArray{&[][]bool{}}},
+		{&[][]float64{}, GenericArray{&[][]float64{}}},
+		{&[][]int64{}, GenericArray{&[][]int64{}}},
+		{&[][]float32{}, GenericArray{&[][]float32{}}},
+		{&[][]int32{}, GenericArray{&[][]int32{}}},
+		{&[][]string{}, GenericArray{&[][]string{}}},
+	}
+
+	t.Parallel()
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have := Array(tt.in)
+			if !reflect.DeepEqual(have, tt.want) {
+				t.Errorf("\nhave: %#v\nwant: %#v", have, tt.want)
+			}
+			if _, ok := have.(sql.Scanner); !ok {
+				t.Error("not a sql.Scanner")
+			}
+			if _, ok := have.(driver.Valuer); !ok {
+				t.Error("not a driver.Valuer")
+			}
+		})
 	}
 }
 
-func TestArrayArg(t *testing.T) {
-	db := pqtest.MustDB(t)
-
+func TestArrayParameter(t *testing.T) {
 	tests := []struct {
 		pgType  string
 		in, out any
@@ -1669,6 +163,8 @@ func TestArrayArg(t *testing.T) {
 		{"varchar[]", &[]string{"hello", "world"}, []string{"hello", "world"}},
 	}
 
+	db := pqtest.MustDB(t)
+	t.Parallel()
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			if tt.out == nil {
@@ -1704,5 +200,435 @@ func TestArrayArg(t *testing.T) {
 			}
 		})
 	}
+}
 
+type TildeNullInt64 struct{ sql.NullInt64 }
+
+func (TildeNullInt64) ArrayDelimiter() string { return "~" }
+func ptr[T any](t T) *T                       { return &t }
+
+func TestArrayScan(t *testing.T) {
+	var (
+		newBool    = func() *BoolArray { return &BoolArray{true, true, true} }
+		newBytea   = func() *ByteaArray { return &ByteaArray{{2}, {6}, {0, 0}} }
+		newString  = func() *StringArray { return &StringArray{"x", "y", "z"} }
+		newInt64   = func() *Int64Array { return &Int64Array{1, 2, 3} }
+		newInt32   = func() *Int32Array { return &Int32Array{4, 5, 6} }
+		newFloat64 = func() *Float64Array { return &Float64Array{7.1, 7.2, 7.3} }
+		newFloat32 = func() *Float32Array { return &Float32Array{8.1, 8.2, 8.3} }
+	)
+	tests := []struct {
+		array   sql.Scanner
+		in      any
+		want    driver.Valuer
+		wantErr string
+	}{
+		{&BoolArray{}, nil, new(BoolArray), ``},
+		{&BoolArray{}, `{}`, &BoolArray{}, ``},
+		{&BoolArray{}, `{t}`, &BoolArray{true}, ``},
+		{&BoolArray{true, true, true}, `{}`, &BoolArray{}, ``},
+		{&BoolArray{true, true, true}, `{t}`, &BoolArray{true}, ``},
+		{&BoolArray{true, true, true}, `{f,t}`, &BoolArray{false, true}, ``},
+
+		{&BoolArray{}, 1, &BoolArray{}, `int to BoolArray`},
+		{newBool(), ``, newBool(), `unable to parse array`},
+		{newBool(), `{`, newBool(), `unable to parse array`},
+		{newBool(), `{{t},{f}}`, newBool(), `cannot convert ARRAY[2][1] to BoolArray`},
+		{newBool(), `{NULL}`, newBool(), `could not parse boolean array index 0: invalid boolean ""`},
+		{newBool(), `{a}`, newBool(), `could not parse boolean array index 0: invalid boolean "a"`},
+		{newBool(), `{t,b}`, newBool(), `could not parse boolean array index 1: invalid boolean "b"`},
+		{newBool(), `{t,f,cd}`, newBool(), `could not parse boolean array index 2: invalid boolean "cd"`},
+
+		{&ByteaArray{}, nil, new(ByteaArray), ``},
+		{&ByteaArray{}, `{}`, &ByteaArray{}, ``},
+		{newBytea(), `{}`, &ByteaArray{}, ``},
+		{newBytea(), `{NULL}`, &ByteaArray{nil}, ``},
+		{newBytea(), `{"\\xfeff"}`, &ByteaArray{{'\xFE', '\xFF'}}, ``},
+		{newBytea(), `{"\\xdead","\\xbeef"}`, &ByteaArray{{'\xDE', '\xAD'}, {'\xBE', '\xEF'}}, ``},
+		{&ByteaArray{{2}, {6}, {0, 0}}, ``, newBytea(), `unable to parse array`},
+		{&ByteaArray{{2}, {6}, {0, 0}}, `{`, newBytea(), `unable to parse array`},
+		{&ByteaArray{{2}, {6}, {0, 0}}, `{{"\\xfeff"},{"\\xbeef"}}`, newBytea(), `cannot convert ARRAY[2][1] to ByteaArray`},
+		{&ByteaArray{{2}, {6}, {0, 0}}, `{"\\abc"}`, newBytea(), `could not parse bytea array index 0: could not parse bytea value`},
+
+		{&StringArray{}, nil, new(StringArray), ``},
+		{&StringArray{}, `{}`, &StringArray{}, ``},
+		{newString(), `{}`, &StringArray{}, ``},
+		{newString(), `{}`, &StringArray{}, ``},
+		{newString(), `{t}`, &StringArray{"t"}, ``},
+		{newString(), `{f,1}`, &StringArray{"f", "1"}, ``},
+		{newString(), `{"a\\b","c d",","}`, &StringArray{"a\\b", "c d", ","}, ``},
+		{newString(), true, newString(), `cannot convert bool to StringArray`},
+		{newString(), ``, newString(), `unable to parse array`},
+		{newString(), `{`, newString(), `unable to parse array`},
+		{newString(), `{{a},{b}}`, newString(), `cannot convert ARRAY[2][1] to StringArray`},
+		{newString(), `{NULL}`, newString(), `parsing array element index 0: cannot convert nil to string`},
+		{newString(), `{a,NULL}`, newString(), `parsing array element index 1: cannot convert nil to string`},
+		{newString(), `{a,b,NULL}`, newString(), `parsing array element index 2: cannot convert nil to string`},
+
+		{&Int64Array{}, nil, new(Int64Array), ``},
+		{&Int64Array{}, `{}`, &Int64Array{}, ``},
+		{newInt64(), `{}`, &Int64Array{}, ``},
+		{newInt64(), `{}`, &Int64Array{}, ``},
+		{newInt64(), `{12}`, &Int64Array{12}, ``},
+		{newInt64(), `{345,678}`, &Int64Array{345, 678}, ``},
+		{newInt64(), true, newInt64(), `cannot convert bool to Int64Array`},
+		{newInt64(), ``, newInt64(), `unable to parse array`},
+		{newInt64(), `{`, newInt64(), `unable to parse array`},
+		{newInt64(), `{{5},{6}}`, newInt64(), `cannot convert ARRAY[2][1] to Int64Array`},
+		{newInt64(), `{NULL}`, newInt64(), `parsing array element index 0:`},
+		{newInt64(), `{a}`, newInt64(), `parsing array element index 0:`},
+		{newInt64(), `{5,a}`, newInt64(), `parsing array element index 1:`},
+		{newInt64(), `{5,6,a}`, newInt64(), `parsing array element index 2:`},
+
+		{&Int32Array{}, nil, new(Int32Array), ``},
+		{&Int32Array{}, `{}`, &Int32Array{}, ``},
+		{newInt32(), `{}`, &Int32Array{}, ``},
+		{newInt32(), `{}`, &Int32Array{}, ``},
+		{newInt32(), `{12}`, &Int32Array{12}, ``},
+		{newInt32(), `{345,678}`, &Int32Array{345, 678}, ``},
+		{newInt32(), true, newInt32(), `cannot convert bool to Int32Array`},
+		{newInt32(), ``, newInt32(), `unable to parse array`},
+		{newInt32(), `{`, newInt32(), `unable to parse array`},
+		{newInt32(), `{{5},{6}}`, newInt32(), `cannot convert ARRAY[2][1] to Int32Array`},
+		{newInt32(), `{NULL}`, newInt32(), `parsing array element index 0:`},
+		{newInt32(), `{a}`, newInt32(), `parsing array element index 0:`},
+		{newInt32(), `{5,a}`, newInt32(), `parsing array element index 1:`},
+		{newInt32(), `{5,6,a}`, newInt32(), `parsing array element index 2:`},
+
+		{&Float64Array{}, nil, new(Float64Array), ``},
+		{&Float64Array{}, `{}`, &Float64Array{}, ``},
+		{newFloat64(), `{}`, &Float64Array{}, ``},
+		{newFloat64(), `{}`, &Float64Array{}, ``},
+		{newFloat64(), `{1.2}`, &Float64Array{1.2}, ``},
+		{newFloat64(), `{3.456,7.89}`, &Float64Array{3.456, 7.89}, ``},
+		{newFloat64(), `{3,1,2}`, &Float64Array{3, 1, 2}, ``},
+		{newFloat64(), true, newFloat64(), `cannot convert bool to Float64Array`},
+		{newFloat64(), ``, newFloat64(), `unable to parse array`},
+		{newFloat64(), `{`, newFloat64(), `unable to parse array`},
+		{newFloat64(), `{{5.6},{7.8}}`, newFloat64(), `cannot convert ARRAY[2][1] to Float64Array`},
+		{newFloat64(), `{NULL}`, newFloat64(), `parsing array element index 0:`},
+		{newFloat64(), `{a}`, newFloat64(), `parsing array element index 0:`},
+		{newFloat64(), `{5.6,a}`, newFloat64(), `parsing array element index 1:`},
+		{newFloat64(), `{5.6,7.8,a}`, newFloat64(), `parsing array element index 2:`},
+
+		{&Float32Array{}, nil, new(Float32Array), ``},
+		{&Float32Array{}, `{}`, &Float32Array{}, ``},
+		{newFloat32(), `{}`, &Float32Array{}, ``},
+		{newFloat32(), `{}`, &Float32Array{}, ``},
+		{newFloat32(), `{1.2}`, &Float32Array{1.2}, ``},
+		{newFloat32(), `{3.456,7.89}`, &Float32Array{3.456, 7.89}, ``},
+		{newFloat32(), `{3,1,2}`, &Float32Array{3, 1, 2}, ``},
+		{newFloat32(), true, newFloat32(), `cannot convert bool to Float32Array`},
+		{newFloat32(), ``, newFloat32(), `unable to parse array`},
+		{newFloat32(), `{`, newFloat32(), `unable to parse array`},
+		{newFloat32(), `{{5.6},{7.8}}`, newFloat32(), `cannot convert ARRAY[2][1] to Float32Array`},
+		{newFloat32(), `{NULL}`, newFloat32(), `parsing array element index 0:`},
+		{newFloat32(), `{a}`, newFloat32(), `parsing array element index 0:`},
+		{newFloat32(), `{5.6,a}`, newFloat32(), `parsing array element index 1:`},
+		{newFloat32(), `{5.6,7.8,a}`, newFloat32(), `parsing array element index 2:`},
+
+		{
+			&GenericArray{ptr([]sql.NullString{})},
+			`{}`,
+			&GenericArray{ptr([]sql.NullString{})},
+			``,
+		},
+		{
+			&GenericArray{ptr([]sql.NullString{{String: ``, Valid: true}, {}})},
+			nil,
+			&GenericArray{new([]sql.NullString)},
+			``,
+		},
+		{
+			&GenericArray{ptr([]sql.NullString{{String: ``, Valid: true}, {}, {}, {}, {}})},
+			`{NULL,abc,"\""}`,
+			&GenericArray{ptr([]sql.NullString{{}, {String: `abc`, Valid: true}, {String: `"`, Valid: true}})},
+			``,
+		},
+		{
+			&GenericArray{ptr([3]sql.NullString{{String: ``, Valid: true}, {}, {}})},
+			`{NULL,"\"",xyz}`,
+			&GenericArray{ptr([3]sql.NullString{{}, {String: `"`, Valid: true}, {String: `xyz`, Valid: true}})},
+			``,
+		},
+
+		{
+			&GenericArray{ptr([]TildeNullInt64{{sql.NullInt64{Int64: 0, Valid: true}}, {}})},
+			`{12~NULL~76}`,
+			&GenericArray{ptr([]TildeNullInt64{{sql.NullInt64{Int64: 12, Valid: true}}, {}, {sql.NullInt64{Int64: 76, Valid: true}}})},
+			``,
+		},
+		{&GenericArray{nil}, nil, &GenericArray{}, `destination <nil> is not a pointer to array or slice`},
+		{&GenericArray{true}, nil, &GenericArray{true}, `destination bool is not a pointer to array or slice`},
+		{&GenericArray{ptr(``)}, nil, &GenericArray{ptr(``)}, `destination *string is not a pointer to array or slice`},
+		{&GenericArray{[]string{}}, nil, &GenericArray{[]string{}}, `destination []string is not a pointer to array or slice`},
+		{&GenericArray{ptr([1]sql.NullString{})}, nil, &GenericArray{ptr([1]sql.NullString{})}, `<nil> to [1]sql.NullString`},
+		{&GenericArray{ptr([]string{})}, true, &GenericArray{ptr([]string{})}, `bool to []string`},
+		{&GenericArray{ptr([]string{})}, `{{x}}`, &GenericArray{ptr([]string{})}, `multidimensional ARRAY[1][1] is not implemented`},
+		{&GenericArray{ptr([]string{})}, `{{x},{x}}`, &GenericArray{ptr([]string{})}, `multidimensional ARRAY[2][1] is not implemented`},
+		{&GenericArray{ptr([]string{})}, `{x}`, &GenericArray{ptr([]string{})}, `scanning to string is not implemented`},
+		{&GenericArray{(*[]string)(nil)}, nil, &GenericArray{(*[]string)(nil)}, `destination *[]string is nil`},
+		{&GenericArray{new([1]string)}, `{`, &GenericArray{new([1]string)}, `unable to parse`},
+		{&GenericArray{new([1]string)}, `{}`, &GenericArray{new([1]string)}, `cannot convert ARRAY[0] to [1]string`},
+		{&GenericArray{new([1]string)}, `{x,x}`, &GenericArray{new([1]string)}, `cannot convert ARRAY[2] to [1]string`},
+		{&GenericArray{new([]sql.NullInt64)}, `{x}`, &GenericArray{new([]sql.NullInt64)}, `parsing array element index 0: converting`},
+	}
+
+	t.Parallel()
+	for _, tt := range tests {
+		t.Run(strings.TrimPrefix(fmt.Sprintf("%T", tt.array), "*pq."), func(t *testing.T) {
+			err := tt.array.Scan(tt.in)
+			if !pqtest.ErrorContains(err, tt.wantErr) {
+				t.Errorf("wrong error:\nhave: %s\nwant: %s", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(tt.array, tt.want) {
+				t.Errorf("\nhave: %#v\nwant: %#v", tt.array, tt.want)
+			}
+
+			// Run again but with []byte input instead of string.
+			if str, ok := tt.in.(string); ok {
+				err := tt.array.Scan([]byte(str))
+				if !pqtest.ErrorContains(err, tt.wantErr) {
+					t.Errorf("wrong error:\nhave: %s\nwant: %s", err, tt.wantErr)
+				}
+				if !reflect.DeepEqual(tt.array, tt.want) {
+					t.Errorf("\nhave: %#v\nwant: %#v", tt.array, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestArrayScanBackend(t *testing.T) {
+	tests := []struct {
+		s    string
+		scan sql.Scanner
+		want any
+	}{
+		{`ARRAY[true, false]`, new(BoolArray), &BoolArray{true, false}},
+		{`ARRAY[E'\\xdead', E'\\xbeef']`, new(ByteaArray), &ByteaArray{{'\xDE', '\xAD'}, {'\xBE', '\xEF'}}},
+		{`ARRAY[1.2, 3.4]`, new(Float64Array), &Float64Array{1.2, 3.4}},
+		{`ARRAY[1, 2, 3]`, new(Int64Array), &Int64Array{1, 2, 3}},
+		{`ARRAY['a', E'\\b', 'c"', 'd,e']`, new(StringArray), &StringArray{`a`, `\b`, `c"`, `d,e`}},
+	}
+
+	db := pqtest.MustDB(t)
+	t.Parallel()
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			err := db.QueryRow(`SELECT ` + tt.s).Scan(tt.scan)
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(tt.scan, tt.want) {
+				t.Errorf("\nhave: %v\nwant %v", tt.scan, tt.want)
+			}
+		})
+	}
+}
+
+type ByteArrayValuer [1]byte
+type ByteSliceValuer []byte
+type FuncArrayValuer struct {
+	delimiter func() string
+	value     func() (driver.Value, error)
+}
+
+func (a ByteArrayValuer) Value() (driver.Value, error) { return a[:], nil }
+func (b ByteSliceValuer) Value() (driver.Value, error) { return []byte(b), nil }
+func (f FuncArrayValuer) ArrayDelimiter() string       { return f.delimiter() }
+func (f FuncArrayValuer) Value() (driver.Value, error) { return f.value() }
+
+func TestArrayValue(t *testing.T) {
+	tilde := func(v driver.Value) FuncArrayValuer {
+		return FuncArrayValuer{
+			func() string { return "~" },
+			func() (driver.Value, error) { return v, nil }}
+	}
+
+	tests := []struct {
+		array   driver.Valuer
+		want    any
+		wantErr string
+	}{
+		{new(BoolArray), nil, ``},
+		{&BoolArray{}, `{}`, ``},
+		{BoolArray{false, true, false}, `{f,t,f}`, ``},
+
+		{new(ByteaArray), nil, ``},
+		{&ByteaArray{}, `{}`, ``},
+		{ByteaArray([][]byte{{'\xDE', '\xAD', '\xBE', '\xEF'}, {'\xFE', '\xFF'}, {}}), `{"\\xdeadbeef","\\xfeff","\\x"}`, ``},
+
+		{new(StringArray), nil, ``},
+		{&StringArray{}, `{}`, ``},
+		{StringArray([]string{`a`, `\b`, `c"`, `d,e`}), `{"a","\\b","c\"","d,e"}`, ``},
+
+		{new(Int64Array), nil, ``},
+		{&Int64Array{}, `{}`, ``},
+		{Int64Array([]int64{1, 2, 3}), `{1,2,3}`, ``},
+
+		{new(Int32Array), nil, ``},
+		{&Int32Array{}, `{}`, ``},
+		{Int32Array([]int32{1, 2, 3}), `{1,2,3}`, ``},
+
+		{new(Float64Array), nil, ``},
+		{&Float64Array{}, `{}`, ``},
+		{Float64Array([]float64{1.2, 3.4, 5.6}), `{1.2,3.4,5.6}`, ``},
+
+		{new(Float32Array), nil, ``},
+		{&Float32Array{}, `{}`, ``},
+		{Float32Array([]float32{1.2, 3.4, 5.6}), `{1.2,3.4,5.6}`, ``},
+
+		{GenericArray{true}, nil, `unable to convert bool to array`},
+		{GenericArray{nil}, nil, ``},
+		{GenericArray{[]bool(nil)}, nil, ``},
+		{GenericArray{[][]int(nil)}, nil, ``},
+		{GenericArray{[]*int(nil)}, nil, ``},
+		{GenericArray{[]sql.NullString(nil)}, nil, ``},
+
+		{GenericArray{[]bool{}}, `{}`, ``},
+		{GenericArray{[]bool{true}}, `{true}`, ``},
+		{GenericArray{[]bool{true, false}}, `{true,false}`, ``},
+		{GenericArray{[2]bool{true, false}}, `{true,false}`, ``},
+		{GenericArray{[][]int{{}}}, `{}`, ``},
+		{GenericArray{[][]int{{}, {}}}, `{}`, ``},
+		{GenericArray{[][]int{{1}}}, `{{1}}`, ``},
+		{GenericArray{[][]int{{1}, {2}}}, `{{1},{2}}`, ``},
+		{GenericArray{[][]int{{1, 2}, {3, 4}}}, `{{1,2},{3,4}}`, ``},
+		{GenericArray{[2][2]int{{1, 2}, {3, 4}}}, `{{1,2},{3,4}}`, ``},
+		{GenericArray{[]string{`a`, `\b`, `c"`, `d,e`}}, `{"a","\\b","c\"","d,e"}`, ``},
+		{GenericArray{[][]byte{{'a'}, {'\\', 'b'}, {'c', '"'}, {'d', ',', 'e'}}}, `{"a","\\b","c\"","d,e"}`, ``},
+		{GenericArray{[]*int{nil}}, `{NULL}`, ``},
+		{GenericArray{[]*int{new(int), nil}}, `{0,NULL}`, ``},
+		{GenericArray{[]sql.NullString{{}}}, `{NULL}`, ``},
+		{GenericArray{[]sql.NullString{{String: `"`, Valid: true}, {}}}, `{"\"",NULL}`, ``},
+		{GenericArray{[]ByteArrayValuer{{'a'}, {'b'}}}, `{"a","b"}`, ``},
+		{GenericArray{[][]ByteArrayValuer{{{'a'}, {'b'}}, {{'c'}, {'d'}}}}, `{{"a","b"},{"c","d"}}`, ``},
+		{GenericArray{[]ByteSliceValuer{{'e'}, {'f'}}}, `{"e","f"}`, ``},
+		{GenericArray{[][]ByteSliceValuer{{{'e'}, {'f'}}, {{'g'}, {'h'}}}}, `{{"e","f"},{"g","h"}}`, ``},
+		{GenericArray{[]FuncArrayValuer{tilde(int64(1)), tilde(int64(2))}}, `{1~2}`, ``},
+		{GenericArray{[][]FuncArrayValuer{{tilde(int64(1)), tilde(int64(2))}, {tilde(int64(3)), tilde(int64(4))}}}, `{{1~2}~{3~4}}`, ``},
+		// TODO: probably shouldn't return half arrays?
+		{GenericArray{[]any{func() {}}}, `{`, `unsupported type func()`},
+		{GenericArray{[]any{nil, func() {}}}, `{NULL,`, `unsupported type func(), a func`},
+	}
+
+	t.Parallel()
+	for _, tt := range tests {
+		n := strings.TrimPrefix(strings.TrimPrefix(fmt.Sprintf("%T", tt.array), "*pq."), "pq.")
+		t.Run(n, func(t *testing.T) {
+			have, err := tt.array.Value()
+			if !pqtest.ErrorContains(err, tt.wantErr) {
+				t.Errorf("wrong error:\nhave: %s\nwant: %s", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(have, tt.want) {
+				t.Errorf("\nhave: %#v\nwant: %#v", have, tt.want)
+			}
+		})
+	}
+}
+
+func TestArrayValueBackend(t *testing.T) {
+	tests := []struct {
+		in   string
+		v    driver.Valuer
+		want string
+	}{
+		{`ARRAY[true, false]`, BoolArray{true, false}, `{t,f}`},
+		{`ARRAY[E'\\xdead', E'\\xbeef']`, ByteaArray{{'\xDE', '\xAD'}, {'\xBE', '\xEF'}}, `{"\\xdead","\\xbeef"}`},
+		{`ARRAY[1.2, 3.4]`, Float64Array{1.2, 3.4}, `{1.2,3.4}`},
+		{`ARRAY[1, 2, 3]`, Int64Array{1, 2, 3}, `{1,2,3}`},
+		{`ARRAY['a', E'\\b', 'c"', 'd,e']`, StringArray{`a`, `\b`, `c"`, `d,e`}, `{"a","\\b","c\"","d,e"}`},
+	}
+
+	db := pqtest.MustDB(t)
+	t.Parallel()
+	for _, tt := range tests {
+		var have string
+		err := db.QueryRow(`select $1::text`, tt.v).Scan(&have)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(have, tt.want) {
+			t.Errorf("\nhave: %v\nwant %v", have, tt.want)
+		}
+	}
+}
+
+func BenchmarkArray(b *testing.B) {
+	tests := []struct {
+		arr interface {
+			driver.Valuer
+			sql.Scanner
+		}
+		data []byte
+	}{
+		{&BoolArray{}, []byte(`{t,f,t,f,t,f,t,f,t,f}`)},
+		{&ByteaArray{}, []byte(`{"\\xfe","\\xff","\\xdead","\\xbeef","\\xfe","\\xff","\\xdead","\\xbeef","\\xfe","\\xff"}`)},
+		{&Float64Array{}, []byte(`{1.2,3.4,5.6,7.8,9.01,2.34,5.67,8.90,1.234,5.678}`)},
+		{&Int64Array{}, []byte(`{1,2,3,4,5,6,7,8,9,0}`)},
+		{&Float32Array{}, []byte(`{1.2,3.4,5.6,7.8,9.01,2.34,5.67,8.90,1.234,5.678}`)},
+		{&Int32Array{}, []byte(`{1,2,3,4,5,6,7,8,9,0}`)},
+		{&StringArray{}, []byte(`{a,b,c,d,e,f,g,h,i,j}`)},
+		{&StringArray{}, []byte(`{"\a","\b","\c","\d","\e","\f","\g","\h","\i","\j"}`)},
+
+		{&GenericArray{new([]sql.NullString)}, []byte(`{a,b,c,d,e,f,g,h,i,j}`)},
+		{&GenericArray{new([]sql.NullString)}, []byte(`{"\a","\b","\c","\d","\e","\f","\g","\h","\i","\j"}`)},
+	}
+
+	for _, tt := range tests {
+		b.Run(strings.TrimPrefix(fmt.Sprintf("%T", tt.arr), "*pq."), func(b *testing.B) {
+			b.Run("Scan", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_ = tt.arr.Scan(tt.data)
+				}
+			})
+			b.Run("Value", func(b *testing.B) {
+				err := tt.arr.Scan(tt.data)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, _ = tt.arr.Value()
+				}
+			})
+		})
+	}
+
+	// GenericArray doesn't support Scan() on non-Scanner arrays, so construct
+	// our own.
+	var (
+		rnd    = rand.New(rand.NewSource(1))
+		bools  = make([]bool, 10)
+		floats = make([]float64, 10)
+		ints   = make([]int64, 10)
+		byts   = make([][]byte, 10)
+		strs   = make([]string, 10)
+	)
+	for i := 0; i < len(bools); i++ {
+		bools[i] = rnd.Intn(2) == 0
+		floats[i] = rnd.NormFloat64()
+		ints[i] = rnd.Int63()
+		byts[i] = bytes.Repeat([]byte(`abc"def\ghi`), 5)
+		strs[i] = strings.Repeat(`abc"def\ghi`, 5)
+	}
+	tests2 := []struct {
+		arr driver.Valuer
+	}{
+		{GenericArray{bools}},
+		{GenericArray{floats}},
+		{GenericArray{ints}},
+		{GenericArray{byts}},
+		{GenericArray{strs}},
+	}
+	for _, tt := range tests2 {
+		b.Run(strings.TrimPrefix(fmt.Sprintf("%T", tt.arr), "pq."), func(b *testing.B) {
+			b.Run("Value", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_, _ = tt.arr.Value()
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
I was working a bit on generic array support, and some tests broke due to different error messages. These tests are all in their own function and a pain to update, so convert it all to table-driven tests. Saves about a 1,000 lines of code.