### PR TITLE
Mark CopyIn() and CopyInSchema() as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 unreleased
 ----------
 
+### Deprecated features
+
+- `CopyIn()` and `CopyInToSchema()` have been marked as deprecated. These are
+  simple query builders and not needed for `COPY [..] FROM STDIN` support (which
+  is *not* deprecated).
+
+      // Old
+      tx.Prepare(CopyIn("temp", "num", "text", "blob", "nothing"))
+
+      // Replacement
+      tx.Prepare(`copy temp (num, text, blob, nothing) from stdin`)
+
 ### Features
 
 - Support protocol 3.2, and the `min_protocol_version` and

--- a/array_test.go
+++ b/array_test.go
@@ -550,7 +550,7 @@ func TestArrayValueBackend(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(have, tt.want) {
-			t.Errorf("\nhave: %v\nwant %v", have, tt.want)
+			t.Errorf("\nhave: %v\nwant: %v", have, tt.want)
 		}
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -1494,34 +1494,6 @@ func TestMultipleEmptyResult(t *testing.T) {
 	}
 }
 
-func TestCopyInStmtAffectedRows(t *testing.T) {
-	t.Parallel()
-	db := pqtest.MustDB(t)
-
-	_, err := db.Exec("CREATE TEMP TABLE temp (a int)")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	txn, err := db.BeginTx(context.TODO(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	copyStmt, err := txn.Prepare(CopyIn("temp", "a"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	res, err := copyStmt.Exec()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	res.RowsAffected()
-	res.LastInsertId()
-}
-
 func TestConnPrepareContext(t *testing.T) {
 	t.Parallel()
 

--- a/copy.go
+++ b/copy.go
@@ -1,7 +1,6 @@
 package pq
 
 import (
-	"bytes"
 	"context"
 	"database/sql/driver"
 	"encoding/binary"
@@ -19,62 +18,24 @@ var (
 	errCopyNotSupportedOutsideTxn = errors.New("pq: COPY is only allowed inside a transaction")
 )
 
-// CopyIn creates a COPY FROM statement which can be prepared with Tx.Prepare().
-// The target table should be visible in search_path.
-//
-// It copies all columns if the list of columns is empty.
-func CopyIn(table string, columns ...string) string {
-	b := bytes.NewBufferString("COPY ")
-	BufferQuoteIdentifier(table, b)
-	makeStmt(b, columns...)
-	return b.String()
-}
-
-// CopyInSchema creates a COPY FROM statement which can be prepared with
-// Tx.Prepare().
-func CopyInSchema(schema, table string, columns ...string) string {
-	b := bytes.NewBufferString("COPY ")
-	BufferQuoteIdentifier(schema, b)
-	b.WriteRune('.')
-	BufferQuoteIdentifier(table, b)
-	makeStmt(b, columns...)
-	return b.String()
-}
-
-func makeStmt(b *bytes.Buffer, columns ...string) {
-	if len(columns) == 0 {
-		b.WriteString(" FROM STDIN")
-		return
-	}
-	b.WriteString(" (")
-	for i, col := range columns {
-		if i != 0 {
-			b.WriteString(", ")
-		}
-		BufferQuoteIdentifier(col, b)
-	}
-	b.WriteString(") FROM STDIN")
-}
-
 type copyin struct {
 	cn      *conn
 	buffer  []byte
 	rowData chan []byte
 	done    chan bool
-
-	closed bool
-
-	mu struct {
+	closed  bool
+	mu      struct {
 		sync.Mutex
 		err error
 		driver.Result
 	}
 }
 
-const ciBufferSize = 64 * 1024
-
-// flush buffer before the buffer is filled up and needs reallocation
-const ciBufferFlushSize = 63 * 1024
+const (
+	ciBufferSize = 64 * 1024
+	// flush buffer before the buffer is filled up and needs reallocation
+	ciBufferFlushSize = 63 * 1024
+)
 
 func (cn *conn) prepareCopyIn(q string) (_ driver.Stmt, resErr error) {
 	if !cn.isInTransaction() {

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,11 +1,10 @@
 package pq
 
 import (
-	"bytes"
-	"database/sql"
 	"database/sql/driver"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -13,64 +12,14 @@ import (
 	"github.com/lib/pq/internal/pqtest"
 )
 
-func TestCopyInStmt(t *testing.T) {
+func TestCopyInError(t *testing.T) {
 	tests := []struct {
-		inTable string
-		inCols  []string
-		want    string
+		query   string
+		wantErr string
 	}{
-		{`table name`, nil, `COPY "table name" FROM STDIN`},
-		{"table name", []string{"column 1", "column 2"}, `COPY "table name" ("column 1", "column 2") FROM STDIN`},
-		{`table " name """`, []string{`co"lumn""`}, `COPY "table "" name """"""" ("co""lumn""""") FROM STDIN`},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run("", func(t *testing.T) {
-			t.Parallel()
-			have := CopyIn(tt.inTable, tt.inCols...)
-			if have != tt.want {
-				t.Fatalf("\nhave: %q\nwant: %q", have, tt.want)
-			}
-		})
-	}
-}
-
-func TestCopyInSchemaStmt(t *testing.T) {
-	tests := []struct {
-		inSchema string
-		inTable  string
-		inCols   []string
-		want     string
-	}{
-		{"schema name", "table name", nil,
-			`COPY "schema name"."table name" FROM STDIN`},
-
-		{"schema name", "table name", []string{"column 1", "column 2"},
-			`COPY "schema name"."table name" ("column 1", "column 2") FROM STDIN`},
-
-		{`schema " name """`, `table " name """`, []string{`co"lumn""`},
-			`COPY "schema "" name """""""."table "" name """"""" ("co""lumn""""") FROM STDIN`},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run("", func(t *testing.T) {
-			t.Parallel()
-			have := CopyInSchema(tt.inSchema, tt.inTable, tt.inCols...)
-			if have != tt.want {
-				t.Fatalf("\nhave: %q\nwant: %q", have, tt.want)
-			}
-		})
-	}
-}
-
-func TestCopyInMultipleValues(t *testing.T) {
-	tests := []struct {
-		cols []string
-	}{
-		{[]string{"a", "b"}},
-		{nil},
+		{`copy tbl (num) from stdin with binary`, `only text format supported for COPY`},
+		{"-- comment\n  /* comment */  copy tbl (num) to stdout", `COPY TO is not supported`},
+		{`copy syntax error`, `syntax error at or near "error" at column 13`},
 	}
 
 	for _, tt := range tests {
@@ -78,12 +27,96 @@ func TestCopyInMultipleValues(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 			db := pqtest.MustDB(t)
-
+			defer db.Close()
 			tx := pqtest.Begin(t, db)
-			defer tx.Rollback()
+
+			pqtest.Exec(t, tx, `create temp table tbl (num integer)`)
+
+			_, err := tx.Prepare(tt.query)
+			if !pqtest.ErrorContains(err, tt.wantErr) {
+				t.Errorf("wrong error:\nhave: %s\nwant: %s", err, tt.wantErr)
+			}
+			// Check that the protocol is in a valid state
+			err = tx.Rollback()
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCopyInErrorWrongType(t *testing.T) {
+	t.Parallel()
+	db := pqtest.MustDB(t)
+	defer db.Close()
+	tx := pqtest.Begin(t, db)
+
+	pqtest.Exec(t, tx, `create temp table tbl (num integer)`)
+
+	stmt, err := tx.Prepare(`copy tbl (num) from stdin`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = stmt.Exec("Héllö\n ☃!\r\t\\")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = stmt.Exec()
+	if !pqtest.ErrorContains(err, `(22P02)`) {
+		t.Errorf("wrong error: %v", err)
+	}
+}
+
+func TestCopyInErrorOutsideTransaction(t *testing.T) {
+	t.Parallel()
+	db := pqtest.MustDB(t)
+	defer db.Close()
+
+	_, err := db.Prepare(`copy tbl (num) from stdin`)
+	if err != errCopyNotSupportedOutsideTxn {
+		t.Errorf("wrong error: %v", err)
+	}
+}
+
+func TestCopyInQueryWhileCopy(t *testing.T) {
+	t.Parallel()
+	db := pqtest.MustDB(t)
+	defer db.Close()
+	tx := pqtest.Begin(t, db)
+
+	pqtest.Exec(t, tx, `create temp table tbl (i int primary key)`)
+
+	_, err := tx.Prepare("copy tbl (i) from stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = tx.Query(`select 1`)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCopyInMultipleValues(t *testing.T) {
+	tests := []struct {
+		query string
+	}{
+		{`copy tbl (a, b) from stdin`},
+		{`copy tbl from stdin`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			db := pqtest.MustDB(t)
+			defer db.Close()
+			tx := pqtest.Begin(t, db)
 
 			pqtest.Exec(t, tx, `create temp table tbl (a int, b varchar)`)
-			stmt := pqtest.Prepare(t, tx, CopyIn("tbl", tt.cols...))
+			stmt := pqtest.Prepare(t, tx, tt.query)
 
 			str := strings.Repeat("#", 500)
 			for i := 0; i < 500; i++ {
@@ -93,16 +126,21 @@ func TestCopyInMultipleValues(t *testing.T) {
 				}
 			}
 
-			r, err := stmt.Exec()
+			res, err := stmt.Exec()
 			if err != nil {
 				t.Fatal(err)
 			}
-			rows, err := r.RowsAffected()
+			rows, err := res.RowsAffected()
 			if err != nil {
 				t.Fatal(err)
 			}
 			if rows != 500 {
 				t.Fatalf("expected 500 rows affected, not %d", rows)
+			}
+
+			n, err := res.LastInsertId()
+			if n != 0 || err == nil || err.Error() != `LastInsertId is not supported by this driver` {
+				t.Errorf("n=%d; err=%v", n, err)
 			}
 
 			if err := stmt.Close(); err != nil {
@@ -117,6 +155,7 @@ func TestCopyInMultipleValues(t *testing.T) {
 			if num != 500 {
 				t.Fatalf("expected 500 items, not %d", num)
 			}
+
 		})
 	}
 }
@@ -124,286 +163,119 @@ func TestCopyInMultipleValues(t *testing.T) {
 func TestCopyInRaiseStmtTrigger(t *testing.T) {
 	t.Parallel()
 	db := pqtest.MustDB(t)
+	defer db.Close()
+	tx := pqtest.Begin(t, db)
 
-	txn, err := db.Begin()
+	pqtest.Exec(t, tx, `create temp table tbl (a int, b varchar)`)
+	pqtest.Exec(t, tx, `
+		create or replace function pg_temp.temptest()
+		returns trigger as
+		$BODY$ begin
+			raise notice 'Hello world';
+			return new;
+		end $BODY$
+		language plpgsql
+	`)
+	pqtest.Exec(t, tx, `
+		create trigger temptest_trigger
+		before insert on tbl
+		for each row execute procedure pg_temp.temptest()
+	`)
+
+	stmt, err := tx.Prepare(`copy tbl (a, b) from stdin`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer txn.Rollback()
-
-	_, err = txn.Exec("CREATE TEMP TABLE temp (a int, b varchar)")
+	_, err = stmt.Exec(int64(1), strings.Repeat("#", 500))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = txn.Exec(`
-			CREATE OR REPLACE FUNCTION pg_temp.temptest()
-			RETURNS trigger AS
-			$BODY$ begin
-				raise notice 'Hello world';
-				return new;
-			end $BODY$
-			LANGUAGE plpgsql`)
-	if err != nil {
+	if _, err := stmt.Exec(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stmt.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = txn.Exec(`
-			CREATE TRIGGER temptest_trigger
-			BEFORE INSERT
-			ON temp
-			FOR EACH ROW
-			EXECUTE PROCEDURE pg_temp.temptest()`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	stmt, err := txn.Prepare(CopyIn("temp", "a", "b"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	longString := strings.Repeat("#", 500)
-
-	_, err = stmt.Exec(int64(1), longString)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = stmt.Exec()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = stmt.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var num int
-	err = txn.QueryRow("SELECT COUNT(*) FROM temp").Scan(&num)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if num != 1 {
-		t.Fatalf("expected 1 items, not %d", num)
+	rows := pqtest.Query[any](t, tx, `select * from tbl`)
+	want := []map[string]any{{
+		"a": int64(1),
+		"b": strings.Repeat("#", 500),
+	}}
+	if !reflect.DeepEqual(rows, want) {
+		t.Errorf("\nhave: %#v\nwant: %#v", rows, want)
 	}
 }
 
 func TestCopyInTypes(t *testing.T) {
 	t.Parallel()
 	db := pqtest.MustDB(t)
+	defer db.Close()
+	tx := pqtest.Begin(t, db)
 
-	txn, err := db.Begin()
+	pqtest.Exec(t, tx, `create temp table tbl (num integer, text varchar, blob bytea, nothing varchar)`)
+
+	stmt, err := tx.Prepare(`copy tbl (num, text, blob, nothing) from stdin`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer txn.Rollback()
-
-	_, err = txn.Exec("CREATE TEMP TABLE temp (num INTEGER, text VARCHAR, blob BYTEA, nothing VARCHAR)")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	stmt, err := txn.Prepare(CopyIn("temp", "num", "text", "blob", "nothing"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	_, err = stmt.Exec(int64(1234567890), "Héllö\n ☃!\r\t\\", []byte{0, 255, 9, 10, 13}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = stmt.Exec()
-	if err != nil {
+	if _, err := stmt.Exec(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stmt.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	err = stmt.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var num int
-	var text string
-	var blob []byte
-	var nothing sql.NullString
-
-	err = txn.QueryRow("SELECT * FROM temp").Scan(&num, &text, &blob, &nothing)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if num != 1234567890 {
-		t.Fatal("unexpected result", num)
-	}
-	if text != "Héllö\n ☃!\r\t\\" {
-		t.Fatal("unexpected result", text)
-	}
-	if !bytes.Equal(blob, []byte{0, 255, 9, 10, 13}) {
-		t.Fatal("unexpected result", blob)
-	}
-	if nothing.Valid {
-		t.Fatal("unexpected result", nothing.String)
-	}
-}
-
-func TestCopyInWrongType(t *testing.T) {
-	t.Parallel()
-	db := pqtest.MustDB(t)
-
-	txn, err := db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer txn.Rollback()
-
-	_, err = txn.Exec("CREATE TEMP TABLE temp (num INTEGER)")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	stmt, err := txn.Prepare(CopyIn("temp", "num"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer stmt.Close()
-
-	_, err = stmt.Exec("Héllö\n ☃!\r\t\\")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = stmt.Exec()
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if pge := err.(*Error); pge.Code.Name() != "invalid_text_representation" {
-		t.Fatalf("expected 'invalid input syntax for integer' error, got %s (%+v)", pge.Code.Name(), pge)
-	}
-}
-
-func TestCopyOutsideOfTxnError(t *testing.T) {
-	t.Parallel()
-	db := pqtest.MustDB(t)
-
-	_, err := db.Prepare(CopyIn("temp", "num"))
-	if err == nil {
-		t.Fatal("COPY outside of transaction did not return an error")
-	}
-	if err != errCopyNotSupportedOutsideTxn {
-		t.Fatalf("expected %s, got %s", err, err.Error())
-	}
-}
-
-func TestCopyInBinaryError(t *testing.T) {
-	t.Parallel()
-	db := pqtest.MustDB(t)
-
-	txn, err := db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer txn.Rollback()
-
-	_, err = txn.Exec("CREATE TEMP TABLE temp (num INTEGER)")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = txn.Prepare("COPY temp (num) FROM STDIN WITH binary")
-	if err != errBinaryCopyNotSupported {
-		t.Fatalf("expected %s, got %+v", errBinaryCopyNotSupported, err)
-	}
-	// check that the protocol is in a valid state
-	err = txn.Rollback()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestCopyFromError(t *testing.T) {
-	t.Parallel()
-	db := pqtest.MustDB(t)
-
-	txn, err := db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer txn.Rollback()
-
-	_, err = txn.Exec("CREATE TEMP TABLE temp (num INTEGER)")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = txn.Prepare("-- comment\n  /* comment */  COPY temp (num) TO STDOUT")
-	if err != errCopyToNotSupported {
-		t.Fatalf("expected %s, got %+v", errCopyToNotSupported, err)
-	}
-	// check that the protocol is in a valid state
-	err = txn.Rollback()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestCopySyntaxError(t *testing.T) {
-	t.Parallel()
-	db := pqtest.MustDB(t)
-
-	txn, err := db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer txn.Rollback()
-
-	_, err = txn.Prepare("COPY ")
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if pge := err.(*Error); pge.Code.Name() != "syntax_error" {
-		t.Fatalf("expected syntax error, got %s (%+v)", pge.Code.Name(), pge)
-	}
-	// check that the protocol is in a valid state
-	err = txn.Rollback()
-	if err != nil {
-		t.Fatal(err)
+	rows := pqtest.Query[any](t, tx, `select * from tbl`)
+	want := []map[string]any{{
+		"num":     int64(1234567890),
+		"text":    "Héllö\n ☃!\r\t\\",
+		"blob":    []byte{0, 255, 9, 10, 13},
+		"nothing": nil,
+	}}
+	if !reflect.DeepEqual(rows, want) {
+		t.Errorf("\nhave: %#v\nwant: %#v", rows, want)
 	}
 }
 
 // Tests for connection errors in copyin.resploop()
-func TestCopyRespLoopConnectionError(t *testing.T) {
+func TestCopyInRespLoopConnectionError(t *testing.T) {
+	// Executes f in a backoff loop until it doesn't return an error. If this
+	// doesn't happen within duration, t.Fatal is called with the latest error.
+	retry := func(t *testing.T, duration time.Duration, f func() error) {
+		start := time.Now()
+		next := time.Millisecond * 100
+		for {
+			err := f()
+			if err == nil {
+				return
+			}
+			if time.Since(start) > duration {
+				t.Fatal(err)
+			}
+			time.Sleep(next)
+			next *= 2
+		}
+	}
+
 	t.Parallel()
 	db := pqtest.MustDB(t)
+	defer db.Close()
+	tx := pqtest.Begin(t, db)
 
-	txn, err := db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer txn.Rollback()
+	pid := pqtest.Query[int64](t, tx, `select pg_backend_pid() as pid`)
+	pqtest.Exec(t, tx, "create temp table tbl (a int)")
 
-	var pid int
-	err = txn.QueryRow("SELECT pg_backend_pid()").Scan(&pid)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = txn.Exec("CREATE TEMP TABLE temp (a int)")
+	stmt, err := tx.Prepare(`copy tbl (a) from stdin`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	stmt, err := txn.Prepare(CopyIn("temp", "a"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer stmt.Close()
-
-	_, err = db.Exec("SELECT pg_terminate_backend($1)", pid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	pqtest.Exec(t, db, `select pg_terminate_backend($1)`, pid[0]["pid"])
 
 	retry(t, time.Second*5, func() error {
 		_, err = stmt.Exec()
@@ -425,50 +297,24 @@ func TestCopyRespLoopConnectionError(t *testing.T) {
 		} else if err == errCopyInClosed {
 			// ignore
 		} else {
-			t.Fatalf("unexpected error, got %+#v", err)
+			t.Fatalf("unexpected error: %v", err)
 		}
-	}
-
-	_ = stmt.Close()
-}
-
-// retry executes f in a backoff loop until it doesn't return an error. If this
-// doesn't happen within duration, t.Fatal is called with the latest error.
-func retry(t *testing.T, duration time.Duration, f func() error) {
-	start := time.Now()
-	next := time.Millisecond * 100
-	for {
-		err := f()
-		if err == nil {
-			return
-		}
-		if time.Since(start) > duration {
-			t.Fatal(err)
-		}
-		time.Sleep(next)
-		next *= 2
 	}
 }
 
 func BenchmarkCopyIn(b *testing.B) {
 	db := pqtest.MustDB(b)
+	defer db.Close()
+	tx := pqtest.Begin(b, db)
 
-	txn, err := db.Begin()
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer txn.Rollback()
+	pqtest.Exec(b, tx, `create temp table tbl (a int, b varchar)`)
 
-	_, err = txn.Exec("CREATE TEMP TABLE temp (a int, b varchar)")
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	stmt, err := txn.Prepare(CopyIn("temp", "a", "b"))
+	stmt, err := tx.Prepare(`copy tbl (a, b) from stdin`)
 	if err != nil {
 		b.Fatal(err)
 	}
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err = stmt.Exec(int64(i), "hello world!")
 		if err != nil {
@@ -476,68 +322,15 @@ func BenchmarkCopyIn(b *testing.B) {
 		}
 	}
 
-	_, err = stmt.Exec()
-	if err != nil {
+	if _, err := stmt.Exec(); err != nil {
+		b.Fatal(err)
+	}
+	if err := stmt.Close(); err != nil {
 		b.Fatal(err)
 	}
 
-	err = stmt.Close()
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	var num int
-	err = txn.QueryRow("SELECT COUNT(*) FROM temp").Scan(&num)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	if num != b.N {
-		b.Fatalf("expected %d items, not %d", b.N, num)
-	}
-}
-
-func BenchmarkCopy(b *testing.B) {
-	bigTableColumns := []string{"ABIOGENETICALLY", "ABORIGINALITIES", "ABSORBABILITIES", "ABSORBEFACIENTS", "ABSORPTIOMETERS", "ABSTRACTIONISMS",
-		"ABSTRACTIONISTS", "ACANTHOCEPHALAN", "ACCEPTABILITIES", "ACCEPTINGNESSES", "ACCESSARINESSES", "ACCESSIBILITIES", "ACCESSORINESSES", "ACCIDENTALITIES",
-		"ACCIDENTOLOGIES", "ACCLIMATISATION", "ACCLIMATIZATION", "ACCOMMODATINGLY", "ACCOMMODATIONAL", "ACCOMPLISHMENTS", "ACCOUNTABLENESS", "ACCOUNTANTSHIPS",
-		"ACCULTURATIONAL", "ACETOPHENETIDIN", "ACETYLSALICYLIC", "ACHONDROPLASIAS", "ACHONDROPLASTIC", "ACHROMATICITIES", "ACHROMATISATION", "ACHROMATIZATION",
-		"ACIDIMETRICALLY", "ACKNOWLEDGEABLE", "ACKNOWLEDGEABLY", "ACKNOWLEDGEMENT", "ACKNOWLEDGMENTS", "ACQUIRABILITIES", "ACQUISITIVENESS", "ACRIMONIOUSNESS",
-		"ACROPARESTHESIA", "ACTINOBIOLOGIES", "ACTINOCHEMISTRY", "ACTINOTHERAPIES", "ADAPTABLENESSES", "ADDITIONALITIES", "ADENOCARCINOMAS", "ADENOHYPOPHYSES",
-		"ADENOHYPOPHYSIS", "ADENOIDECTOMIES", "ADIATHERMANCIES", "ADJUSTABILITIES", "ADMINISTRATIONS", "ADMIRABLENESSES", "ADMISSIBILITIES", "ADRENALECTOMIES",
-		"ADSORBABILITIES", "ADVENTUROUSNESS", "ADVERSARINESSES", "ADVISABLENESSES", "AERODYNAMICALLY", "AERODYNAMICISTS", "AEROELASTICIANS", "AEROHYDROPLANES",
-		"AEROLITHOLOGIES", "AEROSOLISATIONS", "AEROSOLIZATIONS", "AFFECTABILITIES", "AFFECTIVENESSES", "AFFORDABILITIES", "AFFRANCHISEMENT", "AFTERSENSATIONS",
-		"AGGLUTINABILITY", "AGGRANDISEMENTS", "AGGRANDIZEMENTS", "AGGREGATENESSES", "AGRANULOCYTOSES", "AGRANULOCYTOSIS", "AGREEABLENESSES", "AGRIBUSINESSMAN",
-		"AGRIBUSINESSMEN", "AGRICULTURALIST", "AIRWORTHINESSES", "ALCOHOLISATIONS", "ALCOHOLIZATIONS", "ALCOHOLOMETRIES", "ALEXIPHARMAKONS", "ALGORITHMICALLY",
-		"ALKALINISATIONS", "ALKALINIZATIONS", "ALLEGORICALNESS", "ALLEGORISATIONS", "ALLEGORIZATIONS", "ALLELOMORPHISMS", "ALLERGENICITIES", "ALLOTETRAPLOIDS",
-		"ALLOTETRAPLOIDY", "ALLOTRIOMORPHIC", "ALLOWABLENESSES", "ALPHABETISATION", "ALPHABETIZATION", "ALTERNATIVENESS", "ALTITUDINARIANS", "ALUMINOSILICATE",
-		"ALUMINOTHERMIES", "AMARYLLIDACEOUS", "AMBASSADORSHIPS", "AMBIDEXTERITIES", "AMBIGUOUSNESSES", "AMBISEXUALITIES", "AMBITIOUSNESSES", "AMINOPEPTIDASES",
-		"AMINOPHENAZONES", "AMMONIFICATIONS", "AMORPHOUSNESSES", "AMPHIDIPLOIDIES", "AMPHITHEATRICAL", "ANACOLUTHICALLY", "ANACREONTICALLY", "ANAESTHESIOLOGY",
-		"ANAESTHETICALLY", "ANAGRAMMATISING", "ANAGRAMMATIZING", "ANALOGOUSNESSES", "ANALYZABILITIES", "ANAMORPHOSCOPES", "ANCYLOSTOMIASES", "ANCYLOSTOMIASIS",
-		"ANDROGYNOPHORES", "ANDROMEDOTOXINS", "ANDROMONOECIOUS", "ANDROMONOECISMS", "ANESTHETIZATION", "ANFRACTUOSITIES", "ANGUSTIROSTRATE", "ANIMATRONICALLY",
-		"ANISOTROPICALLY", "ANKYLOSTOMIASES", "ANKYLOSTOMIASIS", "ANNIHILATIONISM", "ANOMALISTICALLY", "ANOMALOUSNESSES", "ANONYMOUSNESSES", "ANSWERABILITIES",
-		"ANTAGONISATIONS", "ANTAGONIZATIONS", "ANTAPHRODISIACS", "ANTEPENULTIMATE", "ANTHROPOBIOLOGY", "ANTHROPOCENTRIC", "ANTHROPOGENESES", "ANTHROPOGENESIS",
-		"ANTHROPOGENETIC", "ANTHROPOLATRIES", "ANTHROPOLOGICAL", "ANTHROPOLOGISTS", "ANTHROPOMETRIES", "ANTHROPOMETRIST", "ANTHROPOMORPHIC", "ANTHROPOPATHIES",
-		"ANTHROPOPATHISM", "ANTHROPOPHAGIES", "ANTHROPOPHAGITE", "ANTHROPOPHAGOUS", "ANTHROPOPHOBIAS", "ANTHROPOPHOBICS", "ANTHROPOPHUISMS", "ANTHROPOPSYCHIC",
-		"ANTHROPOSOPHIES", "ANTHROPOSOPHIST", "ANTIABORTIONIST", "ANTIALCOHOLISMS", "ANTIAPHRODISIAC", "ANTIARRHYTHMICS", "ANTICAPITALISMS", "ANTICAPITALISTS",
-		"ANTICARCINOGENS", "ANTICHOLESTEROL", "ANTICHOLINERGIC", "ANTICHRISTIANLY", "ANTICLERICALISM", "ANTICLIMACTICAL", "ANTICOINCIDENCE", "ANTICOLONIALISM",
-		"ANTICOLONIALIST", "ANTICOMPETITIVE", "ANTICONVULSANTS", "ANTICONVULSIVES", "ANTIDEPRESSANTS", "ANTIDERIVATIVES", "ANTIDEVELOPMENT", "ANTIEDUCATIONAL",
-		"ANTIEGALITARIAN", "ANTIFASHIONABLE", "ANTIFEDERALISTS", "ANTIFERROMAGNET", "ANTIFORECLOSURE", "ANTIHELMINTHICS", "ANTIHISTAMINICS", "ANTILIBERALISMS",
-		"ANTILIBERTARIAN", "ANTILOGARITHMIC", "ANTIMATERIALISM", "ANTIMATERIALIST", "ANTIMETABOLITES", "ANTIMILITARISMS", "ANTIMILITARISTS", "ANTIMONARCHICAL",
-		"ANTIMONARCHISTS", "ANTIMONOPOLISTS", "ANTINATIONALIST", "ANTINUCLEARISTS", "ANTIODONTALGICS", "ANTIPERISTALSES", "ANTIPERISTALSIS", "ANTIPERISTALTIC",
-		"ANTIPERSPIRANTS", "ANTIPHLOGISTICS", "ANTIPORNOGRAPHY", "ANTIPROGRESSIVE", "ANTIQUARIANISMS", "ANTIRADICALISMS", "ANTIRATIONALISM", "ANTIRATIONALIST",
-		"ANTIRATIONALITY", "ANTIREPUBLICANS", "ANTIROMANTICISM", "ANTISEGREGATION", "ANTISENTIMENTAL", "ANTISEPARATISTS", "ANTISEPTICISING", "ANTISEPTICIZING",
-		"ANTISEXUALITIES", "ANTISHOPLIFTING", "ANTISOCIALITIES", "ANTISPECULATION", "ANTISPECULATIVE", "ANTISYPHILITICS", "ANTITHEORETICAL", "ANTITHROMBOTICS",
-		"ANTITRADITIONAL", "ANTITRANSPIRANT", "ANTITRINITARIAN", "ANTITUBERCULOUS", "ANTIVIVISECTION", "APHELIOTROPISMS", "APOCALYPTICALLY", "APOCALYPTICISMS",
-		"APOLIPOPROTEINS", "APOLITICALITIES", "APOPHTHEGMATISE", "APOPHTHEGMATIST", "APOPHTHEGMATIZE", "APOTHEGMATISING", "APOTHEGMATIZING", "APPEALABILITIES",
-		"APPEALINGNESSES", "APPENDICULARIAN", "APPLICABILITIES", "APPRENTICEHOODS", "APPRENTICEMENTS", "APPRENTICESHIPS", "APPROACHABILITY", "APPROPINQUATING",
-		"APPROPINQUATION", "APPROPINQUITIES", "APPROPRIATENESS", "ARACHNOIDITISES", "ARBITRARINESSES", "ARBORICULTURIST", "ARCHAEBACTERIUM", "ARCHAEOBOTANIES",
-		"ARCHAEOBOTANIST", "ARCHAEOMETRISTS", "ARCHAEOPTERYXES", "ARCHAEZOOLOGIES", "ARCHEOASTRONOMY", "ARCHEOBOTANISTS", "ARCHEOLOGICALLY", "ARCHEOMAGNETISM",
-		"ARCHEOZOOLOGIES", "ARCHEOZOOLOGIST", "ARCHGENETHLIACS", "ARCHIDIACONATES", "ARCHIEPISCOPACY", "ARCHIEPISCOPATE", "ARCHITECTURALLY", "ARCHPRIESTHOODS",
-		"ARCHPRIESTSHIPS", "ARGUMENTATIVELY", "ARIBOFLAVINOSES", "ARIBOFLAVINOSIS", "AROMATHERAPISTS", "ARRONDISSEMENTS", "ARTERIALISATION", "ARTERIALIZATION",
-		"ARTERIOGRAPHIES", "ARTIFICIALISING", "ARTIFICIALITIES", "ARTIFICIALIZING", "ASCLEPIADACEOUS", "ASSENTIVENESSES"}
-
-	for i := 0; i < b.N; i++ {
-		_ = CopyIn("temp", bigTableColumns...)
+	rows := pqtest.Query[int](b, tx, `select count(*) from tbl`)
+	if rows[0]["count"] != b.N {
+		b.Fatalf("expected %d items, not %d", b.N, rows[0]["count"])
 	}
 }

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,6 +1,9 @@
 package pq
 
-import "database/sql"
+import (
+	"bytes"
+	"database/sql"
+)
 
 // PGError is an interface used by previous versions of pq.
 //
@@ -64,3 +67,48 @@ func ParseURL(url string) (string, error) { return convertURL(url) }
 //
 // Deprecated: this is an alias for [sql.NullTime].
 type NullTime = sql.NullTime
+
+// CopyIn creates a COPY FROM statement which can be prepared with Tx.Prepare().
+// The target table should be visible in search_path.
+//
+// It copies all columns if the list of columns is empty.
+//
+// Deprecated: there is no need to use this query builder, you can use:
+//
+//	tx.Prepare("copy tbl (col1, col2) from stdin")
+func CopyIn(table string, columns ...string) string {
+	b := bytes.NewBufferString("COPY ")
+	BufferQuoteIdentifier(table, b)
+	makeStmt(b, columns...)
+	return b.String()
+}
+
+// CopyInSchema creates a COPY FROM statement which can be prepared with
+// Tx.Prepare().
+//
+// Deprecated: there is no need to use this query builder, you can use:
+//
+//	tx.Prepare("copy schema.tbl (col1, col2) from stdin")
+func CopyInSchema(schema, table string, columns ...string) string {
+	b := bytes.NewBufferString("COPY ")
+	BufferQuoteIdentifier(schema, b)
+	b.WriteRune('.')
+	BufferQuoteIdentifier(table, b)
+	makeStmt(b, columns...)
+	return b.String()
+}
+
+func makeStmt(b *bytes.Buffer, columns ...string) {
+	if len(columns) == 0 {
+		b.WriteString(" FROM STDIN")
+		return
+	}
+	b.WriteString(" (")
+	for i, col := range columns {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		BufferQuoteIdentifier(col, b)
+	}
+	b.WriteString(") FROM STDIN")
+}

--- a/deprecated_test.go
+++ b/deprecated_test.go
@@ -1,0 +1,55 @@
+package pq
+
+import "testing"
+
+func TestCopyInStmt(t *testing.T) {
+	tests := []struct {
+		inTable string
+		inCols  []string
+		want    string
+	}{
+		{`table name`, nil, `COPY "table name" FROM STDIN`},
+		{"table name", []string{"column 1", "column 2"}, `COPY "table name" ("column 1", "column 2") FROM STDIN`},
+		{`table " name """`, []string{`co"lumn""`}, `COPY "table "" name """"""" ("co""lumn""""") FROM STDIN`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			have := CopyIn(tt.inTable, tt.inCols...)
+			if have != tt.want {
+				t.Fatalf("\nhave: %q\nwant: %q", have, tt.want)
+			}
+		})
+	}
+}
+
+func TestCopyInSchemaStmt(t *testing.T) {
+	tests := []struct {
+		inSchema string
+		inTable  string
+		inCols   []string
+		want     string
+	}{
+		{"schema name", "table name", nil,
+			`COPY "schema name"."table name" FROM STDIN`},
+
+		{"schema name", "table name", []string{"column 1", "column 2"},
+			`COPY "schema name"."table name" ("column 1", "column 2") FROM STDIN`},
+
+		{`schema " name """`, `table " name """`, []string{`co"lumn""`},
+			`COPY "schema "" name """""""."table "" name """"""" ("co""lumn""""") FROM STDIN`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			have := CopyInSchema(tt.inSchema, tt.inTable, tt.inCols...)
+			if have != tt.want {
+				t.Fatalf("\nhave: %q\nwant: %q", have, tt.want)
+			}
+		})
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -78,17 +78,15 @@ pq may return errors of type [*pq.Error] which contain error details:
 
 # Bulk imports
 
-You can perform bulk imports by preparing a statement returned by [CopyIn] (or
-[CopyInSchema]) in an explicit transaction ([sql.Tx]). The returned statement
-handle can then be repeatedly "executed" to copy data into the target table.
-After all data has been processed you should call Exec() once with no arguments
-to flush all buffered data. Any call to Exec() might return an error which
-should be handled appropriately, but because of the internal buffering an error
-returned by Exec() might not be related to the data passed in the call that
-failed.
+You can perform bulk imports by preparing a "COPY [..] FROM STDIN" statement in
+a transaction ([sql.Tx]). The returned [sql.Stmt] handle can then be repeatedly
+"executed" to copy data into the target table. After all data has been processed
+you should call Exec() once with no arguments to flush all buffered data. Any
+call to Exec() might return an error which should be handled appropriately, but
+because of the internal buffering an error returned by Exec() might not be
+related to the data passed in the call that failed.
 
-CopyIn uses COPY FROM internally. It is not possible to COPY outside of an
-explicit transaction in pq.
+It is not possible to COPY outside of an explicit transaction in pq.
 
 # Notifications
 

--- a/example_test.go
+++ b/example_test.go
@@ -111,7 +111,7 @@ func ExampleRegisterTLSConfig() {
 	// Output:
 }
 
-func ExampleCopyIn() {
+func Example_copyFromStdin() {
 	// Connect and create table.
 	db, err := sql.Open("postgres", "")
 	if err != nil {
@@ -127,7 +127,7 @@ func ExampleCopyIn() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	stmt, err := tx.Prepare(pq.CopyIn("users", "name", "age"))
+	stmt, err := tx.Prepare(`copy users (name, age) from stdin`)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/issues_test.go
+++ b/issues_test.go
@@ -10,29 +10,10 @@ import (
 	"github.com/lib/pq/internal/pqtest"
 )
 
-func TestIssue494(t *testing.T) {
-	db := pqtest.MustDB(t)
-
-	query := `CREATE TEMP TABLE t (i INT PRIMARY KEY)`
-	if _, err := db.Exec(query); err != nil {
-		t.Fatal(err)
-	}
-
-	txn := pqtest.Begin(t, db)
-
-	if _, err := txn.Prepare(CopyIn("t", "i")); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := txn.Query("SELECT 1"); err == nil {
-		t.Fatal("expected error")
-	}
-}
-
 func TestIssue1046(t *testing.T) {
 	t.Parallel()
-
 	db := pqtest.MustDB(t)
+	defer db.Close()
 
 	ctxTimeout := time.Second * 2
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
@@ -63,6 +44,7 @@ func TestIssue1062(t *testing.T) {
 		t.Parallel()
 	}
 	db := pqtest.MustDB(t)
+	defer db.Close()
 
 	// Ensure that cancelling a QueryRowContext does not result in an ErrBadConn.
 
@@ -105,6 +87,7 @@ func connIsValid(t *testing.T, db *sql.DB) {
 
 func TestQueryCancelRace(t *testing.T) {
 	db := pqtest.MustDB(t)
+	defer db.Close()
 
 	// cancel a query while executing on Postgres: must return the cancelled error code
 	ctx, cancel := context.WithCancel(context.Background())
@@ -127,6 +110,7 @@ func TestQueryCancelRace(t *testing.T) {
 func TestQueryCancelledReused(t *testing.T) {
 	t.Parallel()
 	db := pqtest.MustDB(t)
+	defer db.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// run a query that returns a lot of data


### PR DESCRIPTION
These are just simple string-concat query builders, and don't really do anything special. These two are identical:

	tx.Prepare(CopyIn("temp", "num", "text", "blob", "nothing"))

	tx.Prepare(`copy temp (num, text, blob, nothing) from stdin`)

IMO having a (fairly incomplete) query builder doesn't really add much.

Closes #688