### PR TITLE
Use time.UTC if the server's timezone is set to a UTC alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ unreleased
 - Send intermediate CAs with client certificates, so they can be signed by an
   intermediate CA ([#1267]).
 
+- Use `time.UTC` for UTC alises such as `Etc/UTC` ([#1282]).
+
 [#1258]: https://github.com/lib/pq/pull/1258
 [#1265]: https://github.com/lib/pq/pull/1265
 [#1267]: https://github.com/lib/pq/pull/1267
@@ -46,6 +48,7 @@ unreleased
 [#1278]: https://github.com/lib/pq/pull/1278
 [#1280]: https://github.com/lib/pq/pull/1280
 [#1281]: https://github.com/lib/pq/pull/1281
+[#1283]: https://github.com/lib/pq/pull/1283
 
 v1.11.2 (2026-02-10)
 --------------------

--- a/conn.go
+++ b/conn.go
@@ -1561,10 +1561,15 @@ func (cn *conn) processParameterStatus(r *readBuf) {
 			cn.parameterStatus.serverVersion = major1*10000 + major2*100
 		}
 	case "TimeZone":
-		var err error
-		cn.parameterStatus.currentLocation, err = time.LoadLocation(r.string())
-		if err != nil {
-			cn.parameterStatus.currentLocation = nil
+		switch tz := r.string(); tz {
+		case "UTC", "Etc/UTC", "Etc/Universal", "Etc/Zulu", "Etc/UCT":
+			cn.parameterStatus.currentLocation = time.UTC
+		default:
+			var err error
+			cn.parameterStatus.currentLocation, err = time.LoadLocation(tz)
+			if err != nil {
+				cn.parameterStatus.currentLocation = nil
+			}
 		}
 	// Use sql.NullBool so we can distinguish between false and not sent. If
 	// it's not sent we use a query to get the value – I don't know when these

--- a/encode_test.go
+++ b/encode_test.go
@@ -38,6 +38,10 @@ func TestTimeScan(t *testing.T) {
 		{"timestamp", "2020-03-04 24:00:00", time.Date(2020, 3, 5, 0, 0, 0, 0, time.FixedZone("", 0))},
 		{"timestamptz", "2020-03-04 24:00:00+02", time.Date(2020, 3, 4, 22, 0, 0, 0, time.UTC)},
 		{"timestamptz", "2020-03-04 24:00:00-02", time.Date(2020, 3, 5, 2, 0, 0, 0, time.UTC)},
+
+		{"timestamptz", "2001-02-03T12:13:14 UTC", time.Date(2001, 2, 3, 12, 13, 14, 0, time.UTC)},
+		{"timestamptz", "2001-02-03T12:13:14 Etc/UTC", time.Date(2001, 2, 3, 12, 13, 14, 0, time.UTC)},
+		{"timestamptz", "2001-02-03T12:13:14 Asia/Makassar", time.Date(2001, 2, 3, 04, 13, 14, 0, time.UTC)},
 	}
 
 	db := pqtest.MustDB(t)
@@ -92,6 +96,18 @@ func TestTimeWithZone(t *testing.T) {
 			}
 		}
 	}
+
+	t.Run("UTC aliases", func(t *testing.T) {
+		for _, z := range []string{"UTC", "Etc/UTC", "Etc/Universal", "Etc/Zulu", "Etc/UCT"} {
+			t.Run(z, func(t *testing.T) {
+				have := pqtest.Query[time.Time](t, pqtest.MustDB(t, "timezone="+z),
+					`select '2001-02-03 12:13:14Z'::timestamptz`)[0]["timestamptz"]
+				if l := have.Location(); l != time.UTC {
+					t.Errorf("%s", l)
+				}
+			})
+		}
+	})
 }
 
 func TestTimeWithoutZone(t *testing.T) {


### PR DESCRIPTION
These are all aliases of "UTC" in the timezone database. They would scan to the correct offset, but with the original name and comparing to time.UTC would be false.

In most cases this doesn't really matter, but it comes up in tests. e.g. PostgreSQL Docker has Etc/UTC as the default.