### PR TITLE
Implement connection service file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ unreleased
 
 - Support `ssl_min_protocol_version` and `ssl_max_protocol_version` ([#1277]).
 
+- Support connection service file to load connection details ([#1285]).
+
 - Support `sslrootcert=system` and use `~/.postgresql/root.crt` as the default
   value of sslrootcert ([#1280], [#1281]).
 
@@ -53,6 +55,7 @@ unreleased
 [#1281]: https://github.com/lib/pq/pull/1281
 [#1282]: https://github.com/lib/pq/pull/1282
 [#1283]: https://github.com/lib/pq/pull/1283
+[#1285]: https://github.com/lib/pq/pull/1285
 
 v1.11.2 (2026-02-10)
 --------------------

--- a/connector.go
+++ b/connector.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -19,6 +20,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/lib/pq/internal/pgservice"
 	"github.com/lib/pq/internal/pqutil"
 	"github.com/lib/pq/internal/proto"
 )
@@ -412,6 +414,23 @@ type Config struct {
 	// Maximum PostgreSQL protocol version to request from the server. Defaults to "3.0".
 	MaxProtocolVersion ProtocolVersion `postgres:"max_protocol_version" env:"PGMAXPROTOCOLVERSION"`
 
+	// Load connection parameters from the service file at ~/.pg_service.conf
+	// (which can be configured with PGSERVICEFILE).
+	//
+	// The service file is a INI-like file to configure connection parameters:
+	//
+	//   [servicename]
+	//   # Comment
+	//   dbname=foo
+	//
+	// Unlike libpq, this does not look at the system-wide service file, as the
+	// location of this is a compile-time value that is not easy for pq to
+	// retrieve.
+	Service string `postgres:"service" env:"PGSERVICE"`
+
+	// Path to connection service file. Defaults to ~/.pg_service.conf.
+	ServiceFile string `postgres:"-" env:"PGSERVICEFILE"`
+
 	// Runtime parameters: any unrecognized parameter in the DSN will be added
 	// to this and sent to PostgreSQL during startup.
 	Runtime map[string]string `postgres:"-" env:"-"`
@@ -440,7 +459,10 @@ type ConfigMultihost struct {
 	Port     uint16
 }
 
-// NewConfig creates a new [Config] from the defaults, environment, and DSN.
+// NewConfig creates a new [Config] from the defaults, environment, service
+// file, and DSN, in that order. That is: a service overrides any value from the
+// environment, which in turn gets overridden by the same parameter in the
+// connection string.
 //
 // Most connection parameters supported by PostgreSQL are supported; see the
 // [Config] struct for supported parameters. pq also lets you specify any
@@ -532,6 +554,9 @@ func newConfig(dsn string, env []string) (Config, error) {
 		return Config{}, err
 	}
 	if err := cfg.fromDSN(dsn); err != nil {
+		return Config{}, err
+	}
+	if err := cfg.fromService(); err != nil {
 		return Config{}, err
 	}
 
@@ -650,7 +675,7 @@ func (cfg *Config) fromEnv(env []string) error {
 		switch k {
 		case "PGREQUIRESSL", "PGSSLCOMPRESSION", // Deprecated.
 			"PGREALM", "PGGSSENCMODE", "PGGSSDELEGATION", "PGGSSLIB", // krb stuff
-			"PGREQUIREAUTH", "PGCHANNELBINDING", "PGSERVICE", "PGSERVICEFILE",
+			"PGREQUIREAUTH", "PGCHANNELBINDING",
 			"PGSSLCERTMODE", "PGSSLCRL", "PGSSLCRLDIR", "PGREQUIREPEER":
 			return fmt.Errorf("pq: environment variable $%s is not supported", k)
 		case "PGKRBSRVNAME":
@@ -660,7 +685,7 @@ func (cfg *Config) fromEnv(env []string) error {
 		}
 		e[k] = v
 	}
-	return cfg.setFromTag(e, "env")
+	return cfg.setFromTag(e, "env", false)
 }
 
 // parseOpts parses the options from name and adds them to the values.
@@ -766,10 +791,31 @@ func (cfg *Config) fromDSN(dsn string) error {
 		opt[string(keyRunes)] = string(valRunes)
 	}
 
-	return cfg.setFromTag(opt, "postgres")
+	return cfg.setFromTag(opt, "postgres", false)
 }
 
-func (cfg *Config) setFromTag(o map[string]string, tag string) error {
+func (cfg *Config) fromService() error {
+	if cfg.Service == "" {
+		return nil
+	}
+
+	if !cfg.isset("PGSERVICEFILE") {
+		if home := pqutil.Home(); home != "" {
+			if runtime.GOOS != "windows" {
+				home = filepath.Dir(home) // Unlike other files this uses ~/ and not ~/.postgresql
+			}
+			cfg.ServiceFile = filepath.Join(home, ".pg_service.conf")
+		}
+	}
+
+	opts, err := pgservice.FindService(cfg.ServiceFile, cfg.Service)
+	if err != nil {
+		return fmt.Errorf("pq: %w", err)
+	}
+	return cfg.setFromTag(opts, "postgres", true)
+}
+
+func (cfg *Config) setFromTag(o map[string]string, tag string, service bool) error {
 	f := "pq: wrong value for %q: "
 	if tag == "env" {
 		f = "pq: wrong value for $%s: "
@@ -803,7 +849,11 @@ func (cfg *Config) setFromTag(o map[string]string, tag string) error {
 		v, ok := o[k]
 		delete(o, k)
 		if ok {
-			if t, ok := rt.Tag.Lookup("postgres"); ok && t != "" && t != "-" {
+			t, ok := rt.Tag.Lookup("postgres")
+			if !ok || t == "" || t == "-" { // For PGSERVICEFILE, which can only be from env
+				t, ok = rt.Tag.Lookup("env")
+			}
+			if ok && t != "" && t != "-" {
 				cfg.set = append(cfg.set, t)
 			}
 			switch rt.Type.Kind() {
@@ -903,8 +953,18 @@ func (cfg *Config) setFromTag(o map[string]string, tag string) error {
 		}
 	}
 
+	if service && len(o) > 0 {
+		// TODO(go1.23): use maps.Keys once we require Go 1.23.
+		var key string
+		for k := range o {
+			key = k
+			break
+		}
+		return fmt.Errorf("pq: unknown setting %q in service file for service %q", key, cfg.Service)
+	}
+
 	// Set run-time; we delete map keys as they're set in the struct.
-	if tag == "postgres" {
+	if !service && tag == "postgres" {
 		// Make sure database= sets dbname=, as that previously worked (kind of
 		// by accident).
 		// TODO(v2): remove

--- a/connector_test.go
+++ b/connector_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -845,6 +847,84 @@ func TestProtocolVersion(t *testing.T) {
 			}
 			if tt.wantErr == "" && !reflect.DeepEqual(*have, tt.wantKey) {
 				t.Fatalf("wrong keydata\nhave: %v\nwant: %v", *have, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestService(t *testing.T) {
+	h := pqtest.Home(t)
+	if runtime.GOOS != "windows" {
+		h = filepath.Dir(h)
+	}
+
+	// Test without ~/.pg_service.conf existing
+	t.Run("default file doesn't exist", func(t *testing.T) {
+		cfg, err := NewConfig("service=svc1")
+		if wantErr := fmt.Sprintf(`pq: service file "%s/.pg_service.conf" not found`, h); !pqtest.ErrorContains(err, wantErr) {
+			t.Fatalf("wrong error\nhave: %v\nwant: %v", err, wantErr)
+		}
+		if have := cfg.string(); have != "" {
+			t.Errorf("\nhave: %q\nwant: %q", have, "")
+		}
+	})
+
+	tests := []struct {
+		connect string
+		env     map[string]string
+		want    string
+		wantErr string
+	}{
+		{"service=doesntexist", nil, ``, `definition of service "doesntexist" not found`},
+		{"service=svc1", nil, `connect_timeout=20 dbname=xyz host=firsthost port=1234 service=svc1 sslmode=disable user=pqgo`, ``},
+		{"service=svc2", nil, `connect_timeout=20 dbname='with space' host=localhost service=svc2 sslmode=disable user=''`, ``},
+		{"service=svc3", nil, ``, `pq: unknown setting "unknown" in service file for service "svc3"`},
+		{"service=svc4", nil, `connect_timeout=20 dbname=pqgo host=localhost service=svc4 sslmode=disable user=pqgo`, ``},
+		{"service=svc5", nil, `connect_timeout=20 dbname=pqgo host=localhost service=svc5 sslmode=disable user=pqgo`, ``},
+
+		{"service=svc5", map[string]string{"PGSERVICEFILE": "none"}, ``, `service file "none" not found`},
+		{"service=svc1", map[string]string{"PGSERVICEFILE": filepath.Join(h, "other")}, ``, `definition of service "svc1" not found`},
+		{"service=other", map[string]string{"PGSERVICEFILE": filepath.Join(h, "other")},
+			`connect_timeout=20 dbname=other host=localhost service=other sslmode=disable user=pqgo`, ``},
+	}
+
+	pqtest.Write(t, []byte("[other]\ndbname=other"), h, "other")
+	pqtest.Write(t, []byte(`
+		[svc1]
+		# Connect to this instead.
+		host=firsthost
+		dbname = xyz
+		port=1234
+
+		[svc2]
+		user=
+		dbname=with space
+
+		[svc3]
+		unknown=wut
+
+		# Empty
+		[svc4]
+		[svc5]
+	`), h, ".pg_service.conf")
+
+	// pgbouncer sets PGPORT; not really used to just unset.
+	// TODO: might want to add pqtest.Clearenv() or the like.
+	t.Setenv("PGPORT", "")
+	os.Unsetenv("PGPORT")
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			cfg, err := NewConfig(tt.connect)
+			if !pqtest.ErrorContains(err, tt.wantErr) {
+				t.Fatalf("wrong error\nhave: %v\nwant: %v", err, tt.wantErr)
+			}
+			if have := cfg.string(); have != tt.want {
+				t.Errorf("\nhave: %q\nwant: %q", have, tt.want)
 			}
 		})
 	}

--- a/internal/pgservice/pgservice.go
+++ b/internal/pgservice/pgservice.go
@@ -1,0 +1,70 @@
+package pgservice
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/lib/pq/internal/pqutil"
+)
+
+func FindService(path string, service string) (map[string]string, error) {
+	fp, err := os.Open(path)
+	if err != nil {
+		if pqutil.ErrNotExists(err) {
+			// libpq just returns "definition of service not found" if the
+			// default file doesn't exist, but IMO that's confusing.
+			return nil, fmt.Errorf("service file %q not found", path)
+		}
+		return nil, err
+	}
+	defer fp.Close()
+
+	var (
+		scan = bufio.NewScanner(fp)
+		i    int
+	)
+	for scan.Scan() {
+		i++
+		line := strings.TrimSpace(scan.Text())
+		if line == "" || line[0] == '#' {
+			continue
+		}
+
+		// [service] header that we want.
+		if line[0] == '[' && line[len(line)-1] == ']' && strings.TrimSpace(line[1:len(line)-1]) == service {
+			opts := make(map[string]string)
+			for scan.Scan() {
+				i++
+				line := strings.TrimSpace(scan.Text())
+				if line == "" || line[0] == '#' {
+					continue
+				}
+				// Next header: our work here is done.
+				if line[0] == '[' && line[len(line)-1] == ']' {
+					return opts, nil
+				}
+
+				k, v, ok := strings.Cut(line, "=")
+				if !ok {
+					return nil, fmt.Errorf("line %d: missing '=' in %q", i, line)
+				}
+				k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+				if k == "" {
+					return nil, fmt.Errorf("line %d: no value before '=' in %q", i, line)
+				}
+				opts[k] = v
+			}
+			if scan.Err() != nil {
+				return nil, scan.Err()
+			}
+			return opts, nil
+		}
+	}
+	if scan.Err() != nil {
+		return nil, scan.Err()
+	}
+
+	return nil, fmt.Errorf("definition of service %q not found", service)
+}

--- a/internal/pqtest/pqtest.go
+++ b/internal/pqtest/pqtest.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/lib/pq/internal/pqutil"
 )
 
 func Pgbouncer() bool { return os.Getenv("PGPORT") == "6432" }
@@ -53,7 +55,7 @@ func InvalidCertificate(err error) bool {
 
 // Ptr gets a pointer to any value.
 //
-// TODO: replace with new(..) once pq requires Go 1.26.
+// TODO(go1.26): replace with new(..) once pq requires Go 1.26.
 func Ptr[T any](t T) *T {
 	return &t
 }
@@ -80,6 +82,17 @@ func DSN(conninfo string) string {
 		conninfo += " binary_parameters=yes"
 	}
 	return conninfo
+}
+
+// Home sets the HOME directory to a temporary directly and makes sure the
+// .postgresql directory exists.
+func Home(t *testing.T) string {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(pqutil.Home(), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	return pqutil.Home()
 }
 
 // DB connects to the test database and returns the Ping error. The connection

--- a/internal/pqutil/perm.go
+++ b/internal/pqutil/perm.go
@@ -29,10 +29,10 @@ func SSLKeyPermissions(sslkey string) error {
 		return err
 	}
 
-	return checkPermissions(fi)
+	return CheckPermissions(fi)
 }
 
-func checkPermissions(fi os.FileInfo) error {
+func CheckPermissions(fi os.FileInfo) error {
 	// The maximum permissions that a private key file owned by a regular user
 	// is allowed to have. This translates to u=rw. Regardless of if we're
 	// running as root or not, 0600 is acceptable, so we return if no bits

--- a/internal/pqutil/perm_test.go
+++ b/internal/pqutil/perm_test.go
@@ -1,6 +1,6 @@
 //go:build !windows && !plan9
 
-package pqutil
+package pqutil_test
 
 import (
 	"os"
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/lib/pq/internal/pqtest"
+	. "github.com/lib/pq/internal/pqutil"
 )
 
 type statWrapper struct{ stat syscall.Stat_t }
@@ -54,7 +55,7 @@ func TestSSLKeyPermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			have := checkPermissions(&statWrapper{stat: tt.stat})
+			have := CheckPermissions(&statWrapper{stat: tt.stat})
 			if !pqtest.ErrorContains(have, tt.wantErr) {
 				t.Errorf("\nhave: %s\nwant: %s", have, tt.wantErr)
 			}

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -372,10 +372,7 @@ func TestSSLDefaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.file, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
-			if err := os.MkdirAll(pqutil.Home(), 0o777); err != nil {
-				t.Fatal(err)
-			}
+			pqtest.Home(t)
 
 			pqtest.Write(t, []byte("invalid data"), pqutil.Home(), tt.file)
 			if tt.file == "postgresql.crt" {
@@ -395,11 +392,7 @@ func TestSSLDefaults(t *testing.T) {
 	}
 
 	t.Run("work with default paths", func(t *testing.T) {
-		t.Setenv("HOME", t.TempDir())
-		if err := os.MkdirAll(pqutil.Home(), 0o777); err != nil {
-			t.Fatal(err)
-		}
-
+		pqtest.Home(t)
 		pqtest.Write(t, pqtest.Read(t, "testdata/init/root.crt"), pqutil.Home(), "root.crt")
 		pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.crt"), pqutil.Home(), "postgresql.crt")
 		pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.key"), pqutil.Home(), "postgresql.key")


### PR DESCRIPTION
Allow reading connection from a service file if "service=name" is used.

Based on https://github.com/lib/pq/pull/868

Co-authored-by: Feike Steenbergen <feikesteenbergen@gmail.com>

Fixes #538
Closes #868