### PR TITLE
Fix typos in error messages and comments across multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,14 @@ v1.12.0 (2026-03-18)
   For example, to test if an error is a UNIQUE constraint violation:
 
       if pqErr, ok := errors.AsType[*pq.Error](err); ok && pqErr.Code == pqerror.UniqueViolation {
-          log.Fatalf("email %q already exsts", email)
+          log.Fatalf("email %q already exists", email)
       }
 
   To make this a bit more convenient, it also adds a `pq.As()` function:
 
       pqErr := pq.As(err, pqerror.UniqueViolation)
       if pqErr != nil {
-          log.Fatalf("email %q already exsts", email)
+          log.Fatalf("email %q already exists", email)
       }
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ convert an error to `pq.Error`:
 ```go
 pqErr := pq.As(err, pqerror.UniqueViolation)
 if pqErr != nil {
-  return fmt.Errorf("email %q already exsts", email)
+  return fmt.Errorf("email %q already exists", email)
 }
 ```
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -248,7 +248,7 @@ func TestExec(t *testing.T) {
 	}
 }
 
-func TestStatment(t *testing.T) {
+func TestStatement(t *testing.T) {
 	db := pqtest.MustDB(t)
 
 	stmt1 := pqtest.Prepare(t, db, "select 1")
@@ -1233,7 +1233,7 @@ func TestRowsResultTag(t *testing.T) {
 			query: "CREATE TEMP TABLE t (a int); DROP TABLE t",
 			tag:   "DROP TABLE",
 		},
-		// Ensure a rows-returning query in any position among various tags-returing
+		// Ensure a rows-returning query in any position among various tags-returning
 		// statements will prefer the rows.
 		{
 			query: "SELECT 1; CREATE TEMP TABLE t (a int); DROP TABLE t",

--- a/connector.go
+++ b/connector.go
@@ -350,7 +350,7 @@ type Config struct {
 	// newer protocol.
 	SSLMaxProtocolVersion SSLProtocolVersion `postgres:"ssl_max_protocol_version" env:"SSLPGMAXPROTOCOLVERSION"`
 
-	// Interpert sslcert and sslkey as PEM encoded data, rather than a path to a
+	// Interpret sslcert and sslkey as PEM encoded data, rather than a path to a
 	// PEM file. This is a pq extension, not supported in libpq.
 	SSLInline bool `postgres:"sslinline" env:"-"`
 

--- a/encode.go
+++ b/encode.go
@@ -317,7 +317,7 @@ func parseTS(currentLocation *time.Location, str string) (any, error) {
 // ParseTimestamp parses Postgres' text format. It returns a time.Time in
 // currentLocation iff that time's offset agrees with the offset sent from the
 // Postgres server. Otherwise, ParseTimestamp returns a time.Time with the fixed
-// offset offset provided by the Postgres server.
+// offset provided by the Postgres server.
 func ParseTimestamp(currentLocation *time.Location, str string) (time.Time, error) {
 	return pqtime.Parse(currentLocation, str)
 }

--- a/error.go
+++ b/error.go
@@ -234,7 +234,7 @@ func (e *Error) ErrorWithDetail() string {
 		if line > 1 {
 			fmt.Fprintf(b, "% 7d | %s\n", line-1, expandTab(lines[line-2]))
 		}
-		/// Expand tabs, so that the ^ is at at the correct position, but leave
+		/// Expand tabs, so that the ^ is at the correct position, but leave
 		/// "column 10-13" intact. Adjusting this to the visual column would be
 		/// better, but we don't know the tabsize of the user in their editor,
 		/// which can be 8, 4, 2, or something else. We can't know. So leaving

--- a/example_test.go
+++ b/example_test.go
@@ -351,7 +351,7 @@ func ExampleAs() {
 
 	_, err = db.Exec("insert into t (email) values ($1)", email)
 	if pqErr := pq.As(err, pqerror.UniqueViolation); pqErr != nil {
-		log.Fatalf("email %q already exsts", email)
+		log.Fatalf("email %q already exists", email)
 	}
 	if err != nil {
 		log.Fatalf("unknown error: %s", err)

--- a/internal/pqutil/path.go
+++ b/internal/pqutil/path.go
@@ -15,7 +15,7 @@ import (
 // %APPDATA%/postgresql on Windows, and $HOME/.postgresql/postgresql.crt
 // everywhere else.
 //
-// Returns an empy string if no home directory was found.
+// Returns an empty string if no home directory was found.
 //
 // Matches pqGetHomeDirectory() from PostgreSQL.
 // https://github.com/postgres/postgres/blob/2b117bb/src/interfaces/libpq/fe-connect.c#L8214

--- a/notify.go
+++ b/notify.go
@@ -533,7 +533,7 @@ func (l *Listener) Listen(channel string) error {
 
 	// The server allows you to issue a LISTEN on a channel which is already
 	// open, but it seems useful to be able to detect this case to spot for
-	// mistakes in application logic. If the application genuinely does't care,
+	// mistakes in application logic. If the application genuinely doesn't care,
 	// it can check the exported error and ignore it.
 	_, exists := l.channels[channel]
 	if exists {

--- a/notify_test.go
+++ b/notify_test.go
@@ -180,7 +180,7 @@ func TestListenerConnClose(t *testing.T) {
 	}
 }
 
-func TestListernerConnPing(t *testing.T) {
+func TestListenerConnPing(t *testing.T) {
 	t.Parallel()
 	l, _ := newTestListenerConn(t)
 	defer l.Close()

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -109,7 +109,7 @@ func TestSSLMode(t *testing.T) {
 			t.Parallel()
 
 			if tt.wantErr == "no encryption" && pqtest.Pgbouncer() {
-				// PostgreSQL repsonds with:
+				// PostgreSQL responds with:
 				//   pq: pg_hba.conf rejects connection for host "172.18.0.1", user "pqgossl", database "pqgo", no encryption (28000)
 				//
 				// But pgbouncer has a different message and code:


### PR DESCRIPTION
Fix grammar in tests, comments, and README.