### PR TITLE
fix scram count

### DIFF
--- a/scram/scram.go
+++ b/scram/scram.go
@@ -161,7 +161,7 @@ func (c *Client) step2(in []byte) error {
 	if !bytes.HasPrefix(fields[1], []byte("s=")) || len(fields[1]) < 6 {
 		return fmt.Errorf("server sent an invalid SCRAM-SHA-256 salt: %q", fields[1])
 	}
-	if !bytes.HasPrefix(fields[2], []byte("i=")) || len(fields[2]) < 6 {
+	if !bytes.HasPrefix(fields[2], []byte("i=")) || len(fields[2]) < 3 {
 		return fmt.Errorf("server sent an invalid SCRAM-SHA-256 iteration count: %q", fields[2])
 	}
 


### PR DESCRIPTION
## Fix SCRAM-SHA-256 iteration count validation for low iteration values

### Problem
The SCRAM-SHA-256 authentication fails with the error:
```
pq: SCRAM-SHA-256 error: server sent an invalid SCRAM-SHA-256 iteration count: "i=256"
```

This occurs when connecting to servers (e.g., AWS RDS) that use iteration counts below 1000.

### Root Cause
The length validation check `len(fields[2]) < 6` requires the iteration field to have at least 6 characters (e.g., `i=1000`). This incorrectly rejects valid iteration counts with fewer than 4 digits, such as `i=256` (5 characters).

### Fix
Changed the minimum length check from `< 6` to `< 3`, which only requires `i=` plus at least one digit. The actual integer validation is still performed by `strconv.Atoi` on the subsequent line.

### Changed Files
- `scram/scram.go`: Line 164
