### PR TITLE
fix: treat io.ErrUnexpectedEOF as driver.ErrBadConn to prevent connection pool poisoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+unreleased
+----------
+
+- Treat io.ErrUnexpectedEOF as driver.ErrBadConn so database/sql discards the
+  connection. Since v1.12.0 this could result in permanently broken connections,
+  especially with CockroachDB which frequently sends partial messages ([#1299]).
+
+[#1299]: https://github.com/lib/pq/pull/1299
+
 v1.12.1 (2026-03-30)
 --------------------
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -507,7 +508,7 @@ func TestErrorDuringStartupClosesConn(t *testing.T) {
 
 func TestBadConn(t *testing.T) {
 	t.Parallel()
-	for _, tt := range []error{io.EOF, &Error{Severity: pqerror.SeverityFatal}} {
+	for _, tt := range []error{io.EOF, &Error{Severity: pqerror.SeverityFatal}, io.ErrUnexpectedEOF} {
 		t.Run(fmt.Sprintf("%s", tt), func(t *testing.T) {
 			var cn conn
 			err := cn.handleError(tt)
@@ -519,6 +520,63 @@ func TestBadConn(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnexpectedEOF(t *testing.T) {
+	t.Parallel()
+
+	// On the first "select truncate" it sends a correct RowDescription followed
+	// by a truncated DataRow (header declares 96 body bytes, only 5 are sent)
+	// and then close the connection. database/sql should discard the connection
+	// and retry, and subsequent queries succeed.
+	var failed atomic.Bool
+	f := pqtest.NewFake(t, func(f pqtest.Fake, cn net.Conn) {
+		f.Startup(cn, nil)
+		for {
+			code, q, ok := f.ReadMsg(cn)
+			if !ok {
+				return
+			}
+			switch code {
+			case proto.Terminate:
+				cn.Close()
+				return
+			case proto.Query:
+				switch q := string(q[:bytes.IndexByte(q, 0)]); {
+				case q == ";": // Ping()
+					f.WriteMsg(cn, proto.EmptyQueryResponse, "")
+					f.WriteMsg(cn, proto.ReadyForQuery, "I")
+				case q == "select truncate" && !failed.Swap(true):
+					f.WriteMsg(cn, proto.RowDescription, "\x00\x01truncate\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x19\xff\xff\xff\xff\xff\xff\x00\x00")
+					cn.Write([]byte("D\x00\x00\x00\x64short"))
+					cn.Close()
+					return
+				case q == "select truncate":
+					f.SimpleQuery(cn, "SELECT", "truncate", "1")
+					f.WriteMsg(cn, proto.ReadyForQuery, "I")
+				case q == "select okay":
+					f.SimpleQuery(cn, "SELECT", "okay", "1")
+					f.WriteMsg(cn, proto.ReadyForQuery, "I")
+				default:
+					panic(fmt.Sprintf("unexpected query: %q", q))
+				}
+			}
+		}
+	})
+	defer f.Close()
+
+	db := pqtest.MustDB(t, f.DSN())
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	// This should work as database/sql retries for us.
+	pqtest.QueryRow[int](t, db, `select truncate`)
+	if !failed.Load() {
+		t.Fatal("select truncate never failed")
+	}
+
+	// Make sure it doesn't break the connection.
+	pqtest.QueryRow[int](t, db, `select okay`)
 }
 
 func TestConnClose(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -307,7 +307,7 @@ func (cn *conn) handleError(reported error, query ...string) error {
 			reported = driver.ErrBadConn
 		}
 	case error:
-		if err == io.EOF || err.Error() == "remote error: handshake failure" {
+		if err == io.EOF || err == io.ErrUnexpectedEOF || err.Error() == "remote error: handshake failure" {
 			reported = driver.ErrBadConn
 		}
 	default:


### PR DESCRIPTION
Fixes #1298

When a TCP read is interrupted mid-message (partial DataRow), pq's `recvMessage` returns `io.ErrUnexpectedEOF`. Prior to this fix, `handleError` did not classify this as `driver.ErrBadConn`, so:

1. `cn.err` was never set, and `IsValid()` returned true
2. The `inProgress` atomic flag remained stuck at true (since ReadyForQuery
   never arrived)
3. `database/sql` kept handing out the broken connection
4. The CompareAndSwap guard rejected every subsequent query with
   "there is already a query being processed on this connection"

This is especially impactful with CockroachDB, where node drains and rebalances routinely produce partial reads.

Two changes:
 1. `error.go`: Treat `io.ErrUnexpectedEOF` the same as `io.EOF` in `handleError` - both indicate a dead connection.
 2. `conn.go`: Wrap `errQueryInProgress` with `driver.ErrBadConn` so `database/sql` evicts the connection instead of recycling it. This acts as defense for any future code path that leaves `inProgress` stuck.

Includes unit test for `handleError` and integration test using a TCP fault-injection proxy that truncates a DataRow mid-body to reproduce the exact failure mode.