### PR TITLE
Use correct location for default ~/.pgpass location

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -800,10 +799,7 @@ func (cfg *Config) fromService() error {
 	}
 
 	if !cfg.isset("PGSERVICEFILE") {
-		if home := pqutil.Home(); home != "" {
-			if runtime.GOOS != "windows" {
-				home = filepath.Dir(home) // Unlike other files this uses ~/ and not ~/.postgresql
-			}
+		if home := pqutil.Home(false); home != "" {
 			cfg.ServiceFile = filepath.Join(home, ".pg_service.conf")
 		}
 	}

--- a/internal/pqtest/pqtest.go
+++ b/internal/pqtest/pqtest.go
@@ -89,10 +89,10 @@ func DSN(conninfo string) string {
 func Home(t *testing.T) string {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
-	if err := os.MkdirAll(pqutil.Home(), 0o777); err != nil {
+	if err := os.MkdirAll(pqutil.Home(true), 0o777); err != nil {
 		t.Fatal(err)
 	}
-	return pqutil.Home()
+	return pqutil.Home(true)
 }
 
 // DB connects to the test database and returns the Ping error. The connection

--- a/internal/pqutil/path.go
+++ b/internal/pqutil/path.go
@@ -19,7 +19,7 @@ import (
 //
 // Matches pqGetHomeDirectory() from PostgreSQL.
 // https://github.com/postgres/postgres/blob/2b117bb/src/interfaces/libpq/fe-connect.c#L8214
-func Home() string {
+func Home(subdir bool) string {
 	if runtime.GOOS == "windows" {
 		// pq uses SHGetFolderPath(), which is deprecated but x/sys/windows has
 		// KnownFolderPath(). We don't really want to pull that in though, so
@@ -40,7 +40,12 @@ func Home() string {
 		}
 		home = u.HomeDir
 	}
-	return filepath.Join(home, ".postgresql")
+	// libpq reads some files from ~/ and some from ~/.postgresql – on Windows
+	// it always uses %APPDATA%/postgresql.
+	if subdir {
+		home = filepath.Join(home, ".postgresql")
+	}
+	return home
 }
 
 // ErrNotExists reports if err is a "path doesn't exist" type error.
@@ -62,7 +67,7 @@ var WarnFD io.Writer = os.Stderr
 func Pgpass(passfile string) string {
 	// Get passfile from the options.
 	if passfile == "" {
-		home := Home()
+		home := Home(false)
 		if home == "" {
 			return ""
 		}

--- a/ssl.go
+++ b/ssl.go
@@ -65,7 +65,7 @@ func getTLSConfigClone(key string) *tls.Config {
 // in case of sslmode=allow or prefer.
 func ssl(cfg Config, mode SSLMode) (func(net.Conn) (net.Conn, error), error) {
 	var (
-		home = pqutil.Home()
+		home = pqutil.Home(true)
 		// Don't set defaults here, because tlsConf may be overwritten if a
 		// custom one was registered. Set it after the sslmode switch.
 		tlsConf = &tls.Config{}

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -374,14 +374,14 @@ func TestSSLDefaults(t *testing.T) {
 		t.Run(tt.file, func(t *testing.T) {
 			pqtest.Home(t)
 
-			pqtest.Write(t, []byte("invalid data"), pqutil.Home(), tt.file)
+			pqtest.Write(t, []byte("invalid data"), pqutil.Home(true), tt.file)
 			if tt.file == "postgresql.crt" {
-				pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.key"), pqutil.Home(), "postgresql.key")
-				pqtest.Chmod(t, 0o600, pqutil.Home(), "postgresql.key")
+				pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.key"), pqutil.Home(true), "postgresql.key")
+				pqtest.Chmod(t, 0o600, pqutil.Home(true), "postgresql.key")
 			}
 			if tt.file == "postgresql.key" {
-				pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.crt"), pqutil.Home(), "postgresql.crt")
-				pqtest.Chmod(t, 0o600, pqutil.Home(), "postgresql.key")
+				pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.crt"), pqutil.Home(true), "postgresql.crt")
+				pqtest.Chmod(t, 0o600, pqutil.Home(true), "postgresql.key")
 			}
 
 			_, err := pqtest.DB(t, "user=pqgossl sslmode=require")
@@ -393,10 +393,10 @@ func TestSSLDefaults(t *testing.T) {
 
 	t.Run("work with default paths", func(t *testing.T) {
 		pqtest.Home(t)
-		pqtest.Write(t, pqtest.Read(t, "testdata/init/root.crt"), pqutil.Home(), "root.crt")
-		pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.crt"), pqutil.Home(), "postgresql.crt")
-		pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.key"), pqutil.Home(), "postgresql.key")
-		pqtest.Chmod(t, 0o600, pqutil.Home(), "postgresql.key")
+		pqtest.Write(t, pqtest.Read(t, "testdata/init/root.crt"), pqutil.Home(true), "root.crt")
+		pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.crt"), pqutil.Home(true), "postgresql.crt")
+		pqtest.Write(t, pqtest.Read(t, "testdata/init/postgresql.key"), pqutil.Home(true), "postgresql.key")
+		pqtest.Chmod(t, 0o600, pqutil.Home(true), "postgresql.key")
 		_ = pqtest.MustDB(t, "host=postgres user=pqgosslcert sslmode=verify-ca")
 	})
 }


### PR DESCRIPTION
Broke with 5e55bb7.

Fixes #1294
Closes #1295