### PR TITLE
Don't clear password if directly set on pq.Config

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -268,7 +268,7 @@ restartAll:
 		cfg.SSLMode = mode
 		cn := &conn{cfg: cfg, dialer: c.dialer}
 		cn.cfg.Password = pgpass.PasswordFromPgpass(cn.cfg.Passfile, cn.cfg.User, cn.cfg.Password,
-			cn.cfg.Host, strconv.Itoa(int(cn.cfg.Port)), cn.cfg.Database, cn.cfg.isset("password"))
+			cn.cfg.Host, strconv.Itoa(int(cn.cfg.Port)), cn.cfg.Database)
 
 		var err error
 		cn.c, err = dial(ctx, c.dialer, cn.cfg)
@@ -1315,13 +1315,13 @@ func (cn *conn) auth(r *readBuf, cfg Config) error {
 		}
 
 		var token []byte
-		if cfg.isset("krbspn") {
-			// Use the supplied SPN if provided..
+		if cfg.KrbSpn != "" {
+			// Use the supplied SPN if provided.
 			token, err = cli.GetInitTokenFromSpn(cfg.KrbSpn)
 		} else {
-			// Allow the kerberos service name to be overridden
+			// Allow the kerberos service name to be overridden.
 			service := "postgres"
-			if cfg.isset("krbsrvname") {
+			if cfg.KrbSrvname != "" {
 				service = cfg.KrbSrvname
 			}
 			token, err = cli.GetInitToken(cfg.Host, service)

--- a/conn_test.go
+++ b/conn_test.go
@@ -116,8 +116,7 @@ func TestPgpass(t *testing.T) {
 		for k, v := range extra {
 			o[k] = v
 		}
-		_, pwd := o["password"]
-		have := pgpass.PasswordFromPgpass(o["passfile"], o["user"], o["password"], o["host"], o["port"], o["dbname"], pwd)
+		have := pgpass.PasswordFromPgpass(o["passfile"], o["user"], o["password"], o["host"], o["port"], o["dbname"])
 		if have != want {
 			t.Fatalf("wrong password\nhave: %q\nwant: %q", have, want)
 		}

--- a/connector.go
+++ b/connector.go
@@ -974,6 +974,8 @@ func (cfg *Config) setFromTag(o map[string]string, tag string, service bool) err
 	return nil
 }
 
+// Should generally only be used from newConfig(), as it will never be set if
+// people go outside that.
 func (cfg Config) isset(name string) bool {
 	return slices.Contains(cfg.set, name)
 }

--- a/internal/pgpass/pgpass.go
+++ b/internal/pgpass/pgpass.go
@@ -9,9 +9,8 @@ import (
 	"github.com/lib/pq/internal/pqutil"
 )
 
-func PasswordFromPgpass(passfile, user, password, host, port, dbname string, passwordSet bool) string {
-	// Do not process .pgpass if a password was supplied.
-	if passwordSet {
+func PasswordFromPgpass(passfile, user, password, host, port, dbname string) string {
+	if password != "" { // Do not process .pgpass if a password was supplied.
 		return password
 	}
 


### PR DESCRIPTION
cfg.isset() depends on the logic in newConfig(), so if that was set outside of PGPASSWORD or password= it would never be set.

PostgreSQL does not accept empty passwords:

	(0)=# alter user pqgopassword with password '';
	NOTICE:  empty string is not a valid password, clearing password
	Time: 10.785 ms

So okay to just test for != ""

Also do the same for krbspn and krbsrvname.

Fixes #1301