### PR TITLE
Route trailing readReadyForQuery error through handleError on extended-protocol cleanup

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1760,7 +1760,7 @@ func (cn *conn) readParseResponse() error {
 		return nil
 	case proto.ErrorResponse:
 		err := parseError(r, "")
-		_ = cn.readReadyForQuery()
+		_ = cn.handleError(cn.readReadyForQuery())
 		return err
 	default:
 		cn.err.set(driver.ErrBadConn)
@@ -1788,7 +1788,7 @@ func (cn *conn) readStatementDescribeResponse() (paramTyps []oid.Oid, colNames [
 			return paramTyps, colNames, colTyps, nil
 		case proto.ErrorResponse:
 			err := parseError(r, "")
-			_ = cn.readReadyForQuery()
+			_ = cn.handleError(cn.readReadyForQuery())
 			return nil, nil, nil, err
 		default:
 			cn.err.set(driver.ErrBadConn)
@@ -1809,7 +1809,7 @@ func (cn *conn) readPortalDescribeResponse() (rowsHeader, error) {
 		return rowsHeader{}, nil
 	case proto.ErrorResponse:
 		err := parseError(r, "")
-		_ = cn.readReadyForQuery()
+		_ = cn.handleError(cn.readReadyForQuery())
 		return rowsHeader{}, err
 	default:
 		cn.err.set(driver.ErrBadConn)
@@ -1827,7 +1827,7 @@ func (cn *conn) readBindResponse() error {
 		return nil
 	case proto.ErrorResponse:
 		err := parseError(r, "")
-		_ = cn.readReadyForQuery()
+		_ = cn.handleError(cn.readReadyForQuery())
 		return err
 	default:
 		cn.err.set(driver.ErrBadConn)
@@ -1853,7 +1853,7 @@ func (cn *conn) postExecuteWorkaround() error {
 		switch t {
 		case proto.ErrorResponse:
 			err := parseError(r, "")
-			_ = cn.readReadyForQuery()
+			_ = cn.handleError(cn.readReadyForQuery())
 			return err
 		case proto.CommandComplete, proto.DataRow, proto.EmptyQueryResponse:
 			// the query didn't fail, but we can't process this message

--- a/conn_test.go
+++ b/conn_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -576,6 +577,71 @@ func TestUnexpectedEOF(t *testing.T) {
 
 	// Make sure it doesn't break the connection.
 	pqtest.QueryRow[int](t, db, `select okay`)
+}
+
+func TestPoolerErrorResponseWithoutReadyForQuery(t *testing.T) {
+	t.Parallel()
+
+	// On any Parse the fake emits a non-fatal ErrorResponse and closes the
+	// connection without sending a trailing ReadyForQuery — the byte sequence
+	// pgbouncer emits via disconnect_server(false, ...) -> send_pooler_error
+	// (severity ERROR, SQLSTATE 08P01, no RFQ).
+	//
+	// Inside readParseResponse, the trailing readReadyForQuery() returns
+	// io.EOF; that EOF must be routed through handleError so cn.err is set
+	// to driver.ErrBadConn. Otherwise the broken conn re-enters the *sql.DB
+	// pool with inProgress stuck at true, and the next call on it short-
+	// circuits to errQueryInProgress instead of running the query.
+	var triggered atomic.Bool
+	f := pqtest.NewFake(t, func(f pqtest.Fake, cn net.Conn) {
+		f.Startup(cn, nil)
+		for {
+			code, _, ok := f.ReadMsg(cn)
+			if !ok {
+				return
+			}
+			switch code {
+			case proto.Terminate:
+				cn.Close()
+				return
+			case proto.Query:
+				// Ping(): empty simple query.
+				f.WriteMsg(cn, proto.EmptyQueryResponse, "")
+				f.WriteMsg(cn, proto.ReadyForQuery, "I")
+			case proto.Parse:
+				triggered.Store(true)
+				f.WriteMsg(cn, proto.ErrorResponse,
+					"SERROR\x00C08P01\x00Mserver conn crashed?\x00\x00")
+				cn.Close()
+				return
+			}
+		}
+	})
+	defer f.Close()
+
+	db := pqtest.MustDB(t, f.DSN())
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	if _, err := db.Exec("select $1::int", 1); err == nil {
+		t.Fatal("first Exec: want non-nil error from pooler fault, got nil")
+	}
+	if !triggered.Load() {
+		t.Fatal("server-side fault was never triggered")
+	}
+
+	// The next Exec must not short-circuit to errQueryInProgress. Without the
+	// fix the poisoned conn stays in the pool with inProgress=true and is
+	// reused here; with the fix it was evicted, *sql.DB opens a fresh conn
+	// and we get a proper *pq.Error from the new fault — not the "there is
+	// already a query being processed" guard.
+	_, err := db.Exec("select $1::int", 1)
+	if err == nil {
+		t.Fatal("second Exec: want non-nil error, got nil")
+	}
+	if errors.Is(err, errQueryInProgress) {
+		t.Fatalf("second Exec: poisoned conn was reused from pool: %v", err)
+	}
 }
 
 func TestConnClose(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -580,7 +580,7 @@ func TestUnexpectedEOF(t *testing.T) {
 }
 
 // #1320
-func TestCloseWithoutReadyForQuery(t *testing.T) {
+func TestUnexpectedClose(t *testing.T) {
 	t.Parallel()
 
 	// Emit non-fatal ErrorResponse and close the connection on any Parse.

--- a/conn_test.go
+++ b/conn_test.go
@@ -579,19 +579,13 @@ func TestUnexpectedEOF(t *testing.T) {
 	pqtest.QueryRow[int](t, db, `select okay`)
 }
 
-func TestPoolerErrorResponseWithoutReadyForQuery(t *testing.T) {
+// #1320
+func TestCloseWithoutReadyForQuery(t *testing.T) {
 	t.Parallel()
 
-	// On any Parse the fake emits a non-fatal ErrorResponse and closes the
-	// connection without sending a trailing ReadyForQuery — the byte sequence
-	// pgbouncer emits via disconnect_server(false, ...) -> send_pooler_error
-	// (severity ERROR, SQLSTATE 08P01, no RFQ).
-	//
-	// Inside readParseResponse, the trailing readReadyForQuery() returns
-	// io.EOF; that EOF must be routed through handleError so cn.err is set
-	// to driver.ErrBadConn. Otherwise the broken conn re-enters the *sql.DB
-	// pool with inProgress stuck at true, and the next call on it short-
-	// circuits to errQueryInProgress instead of running the query.
+	// Emit non-fatal ErrorResponse and close the connection on any Parse.
+	// Previously this would cause conn.inProgress to remain "stuck" on true
+	// because cn.err was never set and no ReadyForQuery was received.
 	var triggered atomic.Bool
 	f := pqtest.NewFake(t, func(f pqtest.Fake, cn net.Conn) {
 		f.Startup(cn, nil)
@@ -604,38 +598,35 @@ func TestPoolerErrorResponseWithoutReadyForQuery(t *testing.T) {
 			case proto.Terminate:
 				cn.Close()
 				return
-			case proto.Query:
-				// Ping(): empty simple query.
+			case proto.Query: // Ping(): empty simple query.
 				f.WriteMsg(cn, proto.EmptyQueryResponse, "")
 				f.WriteMsg(cn, proto.ReadyForQuery, "I")
 			case proto.Parse:
 				triggered.Store(true)
-				f.WriteMsg(cn, proto.ErrorResponse,
-					"SERROR\x00C08P01\x00Mserver conn crashed?\x00\x00")
+				f.WriteMsg(cn, proto.ErrorResponse, "SERROR\x00C08P01\x00Mserver conn crashed?\x00\x00")
 				cn.Close()
 				return
 			}
 		}
 	})
 	defer f.Close()
-
 	db := pqtest.MustDB(t, f.DSN())
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 
-	if _, err := db.Exec("select $1::int", 1); err == nil {
+	_, err := db.Exec("select $1::int", 1)
+	if err == nil {
 		t.Fatal("first Exec: want non-nil error from pooler fault, got nil")
 	}
 	if !triggered.Load() {
 		t.Fatal("server-side fault was never triggered")
 	}
 
-	// The next Exec must not short-circuit to errQueryInProgress. Without the
-	// fix the poisoned conn stays in the pool with inProgress=true and is
-	// reused here; with the fix it was evicted, *sql.DB opens a fresh conn
-	// and we get a proper *pq.Error from the new fault — not the "there is
-	// already a query being processed" guard.
-	_, err := db.Exec("select $1::int", 1)
+	// Must not short-circuit to errQueryInProgress and have the poisoned conn
+	// stays in the pool with inProgress=true. database/sql should open a new
+	// connection we get a proper *pq.Error from the new fault, not the "there
+	// is already a query being processed" guard.
+	_, err = db.Exec("select $1::int", 1)
 	if err == nil {
 		t.Fatal("second Exec: want non-nil error, got nil")
 	}


### PR DESCRIPTION
Fixes #1320 

When a transparent pooler (e.g. pgbouncer's `disconnect_server(false, ...) -> send_pooler_error`) emits a synthetic `ErrorResponse` mid-extended-protocol and closes the socket before sending a trailing `ReadyForQuery`, the trailing `readReadyForQuery()` inside `conn.go`'s five extended-protocol cleanup sites returns `io.EOF` — and that error is silently dropped by `_ =`. Prior to this fix, this means:

1. `cn.err` was never set (the EOF never reached `handleError`), and `IsValid()` returned true
2. The `inProgress` atomic flag remained stuck at true (since `ReadyForQuery` never arrived to clear it in `recvMessage`)
3. `database/sql` kept handing out the broken connection from the pool
4. The CompareAndSwap guard rejected every subsequent query with `pq: there is already a query being processed on this connection`

This is the same end-state as #1298, but reached through a different bug-path that the merge of #1299 ([commit 6d77ced41719616090c9e7eec2c313a18640bc3f](https://github.com/lib/pq/commit/6d77ced41719616090c9e7eec2c313a18640bc3f)) does not close. The merged change classifies `io.ErrUnexpectedEOF` in `handleError`, but for this path the EOF is dropped *before* `handleError` ever sees it. The defensive `errQueryInProgress -> driver.ErrBadConn` wrap from that PR was rejected in review and is not in upstream, so `(*DB).retry` does not silently retry either. The path is fully open in current `master`.

This is especially impactful in production behind pgbouncer ≥1.15: the byte sequence is severity ERROR (not FATAL) followed by a TCP close with no `ReadyForQuery`. The non-FATAL severity also means the parsed `*pq.Error` is not classified as `driver.ErrBadConn` by `handleError`, so the only remaining signal — the EOF on the trailing `ReadyForQuery` read — was the one that needed to propagate.

One change:

1. `conn.go`: route the result of `cn.readReadyForQuery()` through `cn.handleError` at the five extended-protocol cleanup sites (`readParseResponse`, `readStatementDescribeResponse`, `readPortalDescribeResponse`, `readBindResponse`, `postExecuteWorkaround`). `handleError(nil)` is a no-op so the happy path is unaffected; for `io.EOF`, `io.ErrUnexpectedEOF`, and `*net.OpError` the existing `cn.err.set(driver.ErrBadConn)` side effect runs even though the return value is still discarded by `_ =`. `*sql.DB.putConn -> dc.IsValid()` then returns false and the conn is closed instead of being returned to `freeConn`.

```diff
 case proto.ErrorResponse:
     err := parseError(r, "")
-    _ = cn.readReadyForQuery()
+    _ = cn.handleError(cn.readReadyForQuery())
     return err
```

Includes integration test using `pqtest.Fake` that emits a non-fatal `ErrorResponse` (SQLSTATE `08P01`) and closes the connection without `ReadyForQuery`, then asserts that a subsequent `db.Exec` does **not** short-circuit to `errQueryInProgress` — i.e. the poisoned conn was actually evicted from the pool rather than merely flagged. The test reproduces the exact production failure mode reported in #1320.
