### PR TITLE
conn: mark connection bad if readReadyForQuery fails after ErrorResponse

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1760,7 +1760,9 @@ func (cn *conn) readParseResponse() error {
 		return nil
 	case proto.ErrorResponse:
 		err := parseError(r, "")
-		_ = cn.readReadyForQuery()
+		if rfqErr := cn.readReadyForQuery(); rfqErr != nil {
+			cn.err.set(driver.ErrBadConn)
+		}
 		return err
 	default:
 		cn.err.set(driver.ErrBadConn)
@@ -1788,7 +1790,9 @@ func (cn *conn) readStatementDescribeResponse() (paramTyps []oid.Oid, colNames [
 			return paramTyps, colNames, colTyps, nil
 		case proto.ErrorResponse:
 			err := parseError(r, "")
-			_ = cn.readReadyForQuery()
+			if rfqErr := cn.readReadyForQuery(); rfqErr != nil {
+				cn.err.set(driver.ErrBadConn)
+			}
 			return nil, nil, nil, err
 		default:
 			cn.err.set(driver.ErrBadConn)
@@ -1809,7 +1813,9 @@ func (cn *conn) readPortalDescribeResponse() (rowsHeader, error) {
 		return rowsHeader{}, nil
 	case proto.ErrorResponse:
 		err := parseError(r, "")
-		_ = cn.readReadyForQuery()
+		if rfqErr := cn.readReadyForQuery(); rfqErr != nil {
+			cn.err.set(driver.ErrBadConn)
+		}
 		return rowsHeader{}, err
 	default:
 		cn.err.set(driver.ErrBadConn)
@@ -1827,7 +1833,9 @@ func (cn *conn) readBindResponse() error {
 		return nil
 	case proto.ErrorResponse:
 		err := parseError(r, "")
-		_ = cn.readReadyForQuery()
+		if rfqErr := cn.readReadyForQuery(); rfqErr != nil {
+			cn.err.set(driver.ErrBadConn)
+		}
 		return err
 	default:
 		cn.err.set(driver.ErrBadConn)
@@ -1853,7 +1861,9 @@ func (cn *conn) postExecuteWorkaround() error {
 		switch t {
 		case proto.ErrorResponse:
 			err := parseError(r, "")
-			_ = cn.readReadyForQuery()
+			if rfqErr := cn.readReadyForQuery(); rfqErr != nil {
+				cn.err.set(driver.ErrBadConn)
+			}
 			return err
 		case proto.CommandComplete, proto.DataRow, proto.EmptyQueryResponse:
 			// the query didn't fail, but we can't process this message


### PR DESCRIPTION
Closes #1320.

The five mid-extended-protocol error handlers (`readParseResponse`, `readStatementDescribeResponse`, `readPortalDescribeResponse`, `readBindResponse`, `postExecuteWorkaround`) drain the trailing `ReadyForQuery` and silently discard its result. When the peer closes the connection at that moment, `readReadyForQuery` returns `io.EOF`, the error is dropped, `cn.err` stays clean, and `database/sql` keeps treating the connection as healthy. The `CompareAndSwap` that guards `inProgress` then rejects every subsequent query with *there is already a query being processed*.

Set `driver.ErrBadConn` when the drain fails so `database/sql` evicts the poisoned connection from the pool.