### PR TITLE
Revert "Clearer error starting a query when already processing a query"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ unreleased
 
 ### Fixes
 
+- Revert "clearer error when starting a new query while pq is still processing
+  another query ([#1272])" as the mechanism proved to be fragile ([#1327]).
+
 - The limit on error responses added in v1.11.0 ([#1248]) should only apply on
   errors during the connection phase ([#1326]).
 
@@ -27,6 +30,7 @@ unreleased
 [#1310]: https://github.com/lib/pq/pull/1310
 [#1317]: https://github.com/lib/pq/pull/1317
 [#1326]: https://github.com/lib/pq/pull/1326
+[#1327]: https://github.com/lib/pq/pull/1327
 
 
 v1.12.3 (2026-04-03)

--- a/conn.go
+++ b/conn.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/lib/pq/internal/pgpass"
@@ -39,7 +38,6 @@ var (
 	ErrSSLKeyUnknownOwnership    = pqutil.ErrSSLKeyUnknownOwnership
 	ErrSSLKeyHasWorldPermissions = pqutil.ErrSSLKeyHasWorldPermissions
 
-	errQueryInProgress = errors.New("pq: there is already a query being processed on this connection")
 	errUnexpectedReady = errors.New("unexpected ReadyForQuery")
 	errNoRowsAffected  = errors.New("no RowsAffected available after the empty statement")
 	errNoLastInsertID  = errors.New("no LastInsertId available after the empty statement")
@@ -189,7 +187,6 @@ type conn struct {
 
 	secretKey           []byte              // Cancellation key for CancelRequest messages.
 	pid                 int                 // Cancellation PID.
-	inProgress          atomic.Bool         // This connection is in the middle of a processing a request.
 	noticeHandler       func(*Error)        // If not nil, notices will be synchronously sent here
 	notificationHandler func(*Notification) // If not nil, notifications will be synchronously sent here
 	gss                 GSS                 // GSSAPI context
@@ -835,9 +832,6 @@ func (cn *conn) PrepareContext(ctx context.Context, q string) (driver.Stmt, erro
 
 	if pqsql.StartsWithCopy(q) {
 		s, err := cn.prepareCopyIn(q)
-		if err == nil {
-			cn.inProgress.Store(true)
-		}
 		return s, cn.handleError(err, q)
 	}
 	s, err := cn.prepareTo(q, cn.gname())
@@ -927,9 +921,6 @@ func (cn *conn) query(query string, args []driver.NamedValue) (*rows, error) {
 	if err := cn.err.get(); err != nil {
 		return nil, err
 	}
-	if !cn.inProgress.CompareAndSwap(false, true) {
-		return nil, errQueryInProgress
-	}
 
 	// Check to see if we can use the "simpleQuery" interface, which is
 	// *much* faster than going through prepare/exec
@@ -982,9 +973,6 @@ func (cn *conn) ExecContext(ctx context.Context, query string, args []driver.Nam
 	defer cn.watchCancel(ctx, false)()
 	if err := cn.err.get(); err != nil {
 		return nil, err
-	}
-	if !cn.inProgress.CompareAndSwap(false, true) {
-		return nil, errQueryInProgress
 	}
 
 	// simpleExec is *much* faster than going through prepare/exec.
@@ -1119,10 +1107,6 @@ func (cn *conn) recvMessage(r *readBuf) (proto.ResponseCode, error) {
 	// Read the type and length of the message that follows.
 	t := proto.ResponseCode(x[0])
 	n := int(binary.BigEndian.Uint32(x[1:])) - 4
-
-	if proto.ResponseCode(t) == proto.ReadyForQuery {
-		cn.inProgress.Store(false)
-	}
 
 	// When PostgreSQL cannot start a backend (e.g., an external process limit),
 	// it sends plain text like "Ecould not fork new process [..]", which

--- a/copy.go
+++ b/copy.go
@@ -328,7 +328,6 @@ func (ci *copyin) Close() error {
 	}
 
 	<-ci.done
-	ci.cn.inProgress.Store(false)
 
 	if err := ci.err(); err != nil {
 		return err

--- a/copy_test.go
+++ b/copy_test.go
@@ -2,7 +2,6 @@ package pq
 
 import (
 	"database/sql/driver"
-	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -61,19 +60,6 @@ func TestCopyInErrorOutsideTransaction(t *testing.T) {
 	_, err := db.Prepare(`copy tbl (num) from stdin`)
 	if err != errCopyNotSupportedOutsideTxn {
 		t.Errorf("wrong error: %v", err)
-	}
-}
-
-func TestCopyInQueryWhileCopy(t *testing.T) {
-	t.Parallel()
-	db := pqtest.MustDB(t)
-	tx := pqtest.Begin(t, db)
-	pqtest.Exec(t, tx, `create temp table tbl (i int primary key)`)
-
-	pqtest.Prepare(t, tx, "copy tbl (i) from stdin", db)
-	_, err := tx.Query(`select 1`)
-	if !errors.Is(err, errQueryInProgress) {
-		t.Errorf("wrong error:\nhave: %s\nwant: %s", err, errQueryInProgress)
 	}
 }
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -2,10 +2,8 @@ package pq
 
 import (
 	"database/sql"
-	"errors"
 	"math"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/lib/pq/internal/pqtest"
@@ -276,80 +274,4 @@ func TestRowsClose(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-}
-
-func TestRowsConcurrentUse(t *testing.T) {
-	t.Parallel()
-	db := pqtest.MustDB(t, "")
-
-	var wg sync.WaitGroup
-	for range 20 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			tx := pqtest.Begin(t, db)
-			defer tx.Rollback()
-
-			rows, err := tx.Query(`select unnest('{1,2,3}'::int[])`)
-			if err != nil {
-				t.Error(err)
-				return
-			}
-
-			all := make([]int, 0, 3)
-			for rows.Next() {
-				var n int
-				err := rows.Scan(&n)
-				if err != nil {
-					t.Error(err)
-					return
-				}
-				all = append(all, n)
-
-				_, err = tx.Query("select 99")
-				if !errors.Is(err, errQueryInProgress) {
-					t.Errorf("wrong error for query: %v", err)
-				}
-				_, err = tx.Exec("select pg_sleep(0.01)")
-				if !errors.Is(err, errQueryInProgress) {
-					t.Errorf("wrong error for exec: %v", err)
-				}
-			}
-			if !reflect.DeepEqual(all, []int{1, 2, 3}) {
-				t.Error(all)
-			}
-
-			var n int
-			err = tx.QueryRow("select 42").Scan(&n)
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			if n != 42 {
-				t.Error(n)
-			}
-			_, err = tx.Exec("select pg_sleep(0.01)")
-			if err != nil {
-				t.Error(err)
-				return
-			}
-
-			// Calling Close() early rows
-			rows, err = tx.Query(`select unnest('{1,2,3}'::int[])`)
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			rows.Close()
-			err = tx.QueryRow("select 43").Scan(&n)
-			if err != nil {
-				t.Error(err)
-			}
-			if n != 43 {
-				t.Error(n)
-			}
-		}()
-	}
-	wg.Wait()
 }


### PR DESCRIPTION
This reverts #1272 as there are too many subtle errors with keeping a flag on the connection: #1299, #1320, and possibly more. When I added this I thought this should be fairly safe to do because it adapted a long-existing mechanism, but it seems I was wrong about that – I guess that was always a bit buggy but no one noticed because it's used fairly infrequently.

I find it too complex to follow, and it doesn't really fix anything: it just gives a nicer error message on wrong usage. That's nice, but not critical. Correct behaviour is.

So just revert it for now. Can come back to this at some point, but I don't really have the time for it now. Also stop tracking it for COPY, as that wasn't entirely correct either.

Fixes #1320
Closes #1321