### PR TITLE
Set ALPN for direct SSL connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ unreleased
 
 ### Fixes
 
+- `sslnegotiation=direct` didn't work due to missing ALPN protocol [[#1332]).
+
 - Revert "clearer error when starting a new query while pq is still processing
   another query ([#1272])" as the mechanism proved to be fragile ([#1327]).
 
@@ -31,6 +33,7 @@ unreleased
 [#1317]: https://github.com/lib/pq/pull/1317
 [#1326]: https://github.com/lib/pq/pull/1326
 [#1327]: https://github.com/lib/pq/pull/1327
+[#1332]: https://github.com/lib/pq/pull/1327
 
 
 v1.12.3 (2026-04-03)

--- a/internal/pqtest/pqtest.go
+++ b/internal/pqtest/pqtest.go
@@ -35,6 +35,16 @@ func SkipCockroach(t testing.TB) {
 	}
 }
 
+// SkipBeforeVersion skips the test unless the connected server reports at least
+// the given major version (e.g. 16, 17, etc.)
+func SkipBeforeVersion(t testing.TB, want int) {
+	t.Helper()
+	have := QueryRow[int](t, MustDB(t), `show server_version_num`)["server_version_num"] / 10000
+	if want > have {
+		t.Skipf("skipped for PostgreSQL %d (want %d)", have, want)
+	}
+}
+
 func ForceBinaryParameters() bool {
 	v, ok := os.LookupEnv("PQTEST_BINARY_PARAMETERS")
 	if !ok {

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -14,6 +14,7 @@ const (
 	CancelRequestCode = (1234 << 16) | 5678
 	NegotiateSSLCode  = (1234 << 16) | 5679
 	NegotiateGSSCode  = (1234 << 16) | 5680
+	ALPNProtocol      = "postgresql"
 )
 
 // Constants from fe-protocol3.c

--- a/ssl.go
+++ b/ssl.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/lib/pq/internal/pqutil"
+	"github.com/lib/pq/internal/proto"
 )
 
 // Registry for custom tls.Configs
@@ -120,6 +121,12 @@ func ssl(cfg Config, mode SSLMode) (func(net.Conn) (net.Conn, error), error) {
 
 	tlsConf.MinVersion = cfg.SSLMinProtocolVersion.tlsconf()
 	tlsConf.MaxVersion = cfg.SSLMaxProtocolVersion.tlsconf()
+
+	// ALPN is mandatory with direct SSL connections; PostgreSQL only supports
+	// one protocol.
+	if cfg.SSLNegotiation == SSLNegotiationDirect {
+		tlsConf.NextProtos = []string{proto.ALPNProtocol}
+	}
 
 	// RFC 6066 asks to not set SNI if the host is a literal IP address (IPv4 or
 	// IPv6). This check is coded already crypto.tls.hostnameInSNI, so just

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -92,7 +93,9 @@ func TestSSLMode(t *testing.T) {
 		// sslmode=disable
 		{"sslmode=disable user=pqgossl", "or:no encryption|login rejected (08P01)|authentication rejected by configuration (28000)"},
 
-		// sslnegotiation=direct should fail if ssl isn't required, like libpq:
+		// sslnegotiation=direct
+		{"sslmode=require sslnegotiation=direct", ""},
+		// should fail if ssl isn't required, like libpq:
 		// psql: error: weak sslmode "allow" may not be used with sslnegotiation=direct (use "require", "verify-ca", or "verify-full")
 		{"sslmode=disable sslnegotiation=direct", "weak sslmode"},
 		{"sslmode=allow sslnegotiation=direct", "weak sslmode"},
@@ -102,6 +105,10 @@ func TestSSLMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
+
+			if strings.Contains(tt.connect, "sslnegotiation=direct") {
+				pqtest.SkipBeforeVersion(t, 17) // Only supported on PostgreSQL≥17.
+			}
 
 			_, err := pqtest.DB(t, tt.connect)
 			switch {


### PR DESCRIPTION
When `sslnegotiation=direct` is set, clients receive `EOF`. This happens because Postgres expects the ALPN `postgresql` to be set but the client's TLS configuration doesn't specify it. With this commit we explicitly set the expected ALPN, allowing connections to succeed.

Closes #1331