### PR TITLE
docs: use https for PostgreSQL and IETF documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ connections asynchronously so it doesn't use the context from QueryContext(),
 PingContext(), etc. The default is to wait indefinitely.
 
 [Config struct]: https://pkg.go.dev/github.com/lib/pq#Config
-[run-time parameter]: http://www.postgresql.org/docs/current/static/runtime-config.html
+[run-time parameter]: https://www.postgresql.org/docs/current/static/runtime-config.html
 
 Errors
 ------
@@ -153,7 +153,7 @@ users) don't have to add unnecessary dependencies.
 
 Reading a [password file] (pgpass) is also supported.
 
-[password file]: http://www.postgresql.org/docs/current/static/libpq-pgpass.html
+[password file]: https://www.postgresql.org/docs/current/static/libpq-pgpass.html
 
 ### Bulk imports with `COPY [..] FROM STDIN`
 You can perform bulk imports by preparing a `COPY [..] FROM STDIN` statement

--- a/array.go
+++ b/array.go
@@ -718,7 +718,7 @@ func appendArray(b []byte, rv reflect.Value, n int) ([]byte, string, error) {
 // using driver.DefaultParameterConverter and the resulting []byte or string
 // is double-quoted.
 //
-// See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+// See https://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
 func appendArrayElement(b []byte, rv reflect.Value) ([]byte, string, error) {
 	if k := rv.Kind(); k == reflect.Array || k == reflect.Slice {
 		if t := rv.Type(); t != typeByteSlice && !t.Implements(typeDriverValuer) {
@@ -785,7 +785,7 @@ func appendValue(b []byte, v driver.Value) ([]byte, error) {
 // Notably, whitespace around brackets and delimiters is significant, and NULL
 // is case-sensitive.
 //
-// See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+// See https://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
 func parseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
 	var depth, i int
 

--- a/connector.go
+++ b/connector.go
@@ -329,7 +329,7 @@ type Config struct {
 
 	// Path to [pgpass] file to store passwords; overrides Password.
 	//
-	// [pgpass]: http://www.postgresql.org/docs/current/static/libpq-pgpass.html
+	// [pgpass]: https://www.postgresql.org/docs/current/static/libpq-pgpass.html
 	Passfile string `postgres:"passfile" env:"PGPASSFILE"`
 
 	// Commandline options to send to the server at connection start.
@@ -568,8 +568,8 @@ type ConfigMultihost struct {
 // support are set. Environment variables have a lower precedence than
 // explicitly provided connection parameters.
 //
-// [PostgreSQL environment variables]: http://www.postgresql.org/docs/current/static/libpq-envars.html
-// [run-time parameter]: http://www.postgresql.org/docs/current/static/runtime-config.html
+// [PostgreSQL environment variables]: https://www.postgresql.org/docs/current/static/libpq-envars.html
+// [run-time parameter]: https://www.postgresql.org/docs/current/static/runtime-config.html
 func NewConfig(dsn string) (Config, error) {
 	return newConfig(dsn, os.Environ())
 }

--- a/doc.go
+++ b/doc.go
@@ -131,7 +131,7 @@ package:
 This package is in a separate module so that users who don't need Kerberos don't
 have to add unnecessary dependencies.
 
-[identifier]: http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
-[NOTIFY]: http://www.postgresql.org/docs/current/static/sql-notify.html
+[identifier]: https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+[NOTIFY]: https://www.postgresql.org/docs/current/static/sql-notify.html
 */
 package pq

--- a/scram/scram.go
+++ b/scram/scram.go
@@ -24,7 +24,7 @@
 
 // Package scram implements a SCRAM-{SHA-1,etc} client per RFC5802.
 //
-// http://tools.ietf.org/html/rfc5802
+// https://tools.ietf.org/html/rfc5802
 package scram
 
 import (

--- a/ssl.go
+++ b/ssl.go
@@ -86,7 +86,7 @@ func ssl(cfg Config, mode SSLMode) (func(net.Conn) (net.Conn, error), error) {
 		// Skip TLS's own verification since it requires full verification.
 		tlsConf.InsecureSkipVerify = true
 
-		// From http://www.postgresql.org/docs/current/static/libpq-ssl.html:
+		// From https://www.postgresql.org/docs/current/static/libpq-ssl.html:
 		//
 		// For backwards compatibility with earlier versions of PostgreSQL, if a
 		// root CA file exists, the behavior of sslmode=require will be the same


### PR DESCRIPTION
## Summary

Updates documentation / godoc links from \`http://\` to \`https://\` for:

- \`www.postgresql.org\` (README, doc.go, connector.go, ssl.go, array.go)
- \`tools.ietf.org\` (scram package comment for RFC 5802)

Docs-only; no runtime behavior change.

## Test plan

- [x] Grep confirms no remaining \`http://www.postgresql.org\` / \`http://tools.ietf.org\` links
- [x] Links resolve over HTTPS