### PR TITLE
feat: adds the possibility of using Postgres 19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: ['14', '15', '16', '17', '18']
+        pg: ['14', '15', '16', '17', '18', '19']
         go: ['1.23', '1.26']
     steps:
     - uses: 'actions/checkout@v6'

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,18 @@ services:
     command:     ['start-single-node', '--accept-sql-without-tls', '--certs-dir=/ssl2']
     healthcheck: {test: ['CMD-SHELL', '/cockroach/cockroach node status --insecure --user=pqgo'], start_period: '30s', start_interval: '1s'}
 
+  pg19:
+    profiles:    ['pg19']
+    image:       'postgres:19beta2'
+    ports:       ['127.0.0.1:5432:5432']
+    entrypoint:  '/init/entry.sh'
+    volumes:     ['./testdata/postgres:/init', './testdata/ssl:/ssl']
+    shm_size:    '128mb'
+    healthcheck: {test: ['CMD-SHELL', 'pg_isready -U pqgo -d pqgo'], start_period: '30s', start_interval: '1s'}
+    environment:
+      'POSTGRES_DATABASE': 'pqgo'
+      'POSTGRES_USER':     'pqgo'
+      'POSTGRES_PASSWORD': 'unused'
   pg18:
     image:       'postgres:18'
     ports:       ['127.0.0.1:5432:5432']


### PR DESCRIPTION
## Summary

Add opt-in support for PostgreSQL 19 (currently beta) in Compose and CI, while keeping PostgreSQL 18 as the default.

```bash
docker compose up -d pg19

go test ./...