### PR TITLE
Add TCP keepalive support for long queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ unreleased
 
 ### Features
 
+- Implement TCP keepalive connection parameters (`keepalives`,
+  `keepalives_idle`, `keepalives_interval`, `keepalives_count`), matching libpq
+  ([#360]).
+
 - Implement `require_auth` connection parameter ([#1310]).
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -90,8 +90,25 @@ It's recommended to add `connect_timeout` to the DSN – database/sql may open n
 connections asynchronously so it doesn't use the context from QueryContext(),
 PingContext(), etc. The default is to wait indefinitely.
 
+For long-running queries, TCP keepalives help detect dead connections (for
+example behind NATs or load balancers). pq accepts the same libpq parameters:
+
+- `keepalives` – enable (`1`) or disable (`0`) client-side TCP keepalives
+- `keepalives_idle` – seconds idle before the first keepalive probe
+- `keepalives_interval` – seconds between unacknowledged probes
+- `keepalives_count` – number of failed probes before the connection is dead
+
+Example:
+
+    sql.Open("postgres", "dbname=pqgo keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=5")
+
+When unset, the dialer's defaults are left alone ([net.Dialer] enables keepalives
+by default). Settings apply only to TCP connections (`*net.TCPConn`); Unix
+sockets ignore them. They can also be set on [Config].
+
 [Config struct]: https://pkg.go.dev/github.com/lib/pq#Config
 [run-time parameter]: http://www.postgresql.org/docs/current/static/runtime-config.html
+[net.Dialer]: https://pkg.go.dev/net#Dialer
 
 Errors
 ------

--- a/conn.go
+++ b/conn.go
@@ -442,17 +442,17 @@ func (cn *conn) checkTSA(tsa TargetSessionAttrs) error {
 func dial(ctx context.Context, d Dialer, cfg Config) (net.Conn, error) {
 	network, address := cfg.network()
 
+	var (
+		conn net.Conn
+		err  error
+	)
 	// Zero or not specified means wait indefinitely.
 	if cfg.ConnectTimeout > 0 {
 		// connect_timeout should apply to the entire connection establishment
 		// procedure, so we both use a timeout for the TCP connection
 		// establishment and set a deadline for doing the initial handshake. The
 		// deadline is then reset after startup() is done.
-		var (
-			deadline = time.Now().Add(cfg.ConnectTimeout)
-			conn     net.Conn
-			err      error
-		)
+		deadline := time.Now().Add(cfg.ConnectTimeout)
 		if dctx, ok := d.(DialerContext); ok {
 			ctx, cancel := context.WithTimeout(ctx, cfg.ConnectTimeout)
 			defer cancel()
@@ -463,13 +463,84 @@ func dial(ctx context.Context, d Dialer, cfg Config) (net.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		err = conn.SetDeadline(deadline)
-		return conn, err
+		if err = conn.SetDeadline(deadline); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+	} else if dctx, ok := d.(DialerContext); ok {
+		conn, err = dctx.DialContext(ctx, network, address)
+	} else {
+		conn, err = d.Dial(network, address)
 	}
-	if dctx, ok := d.(DialerContext); ok {
-		return dctx.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
 	}
-	return d.Dial(network, address)
+
+	if err = setTCPKeepalives(conn, cfg); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// setTCPKeepalives applies client-side TCP keepalive options from cfg to conn
+// when the connection is a [*net.TCPConn] (or unwraps to one) and at least one
+// keepalive parameter is configured. Unix-domain sockets and other connection
+// types are left unchanged.
+//
+// Parameters match libpq: keepalives, keepalives_idle, keepalives_interval,
+// and keepalives_count. [net.TCPConn.SetKeepAliveConfig] is used so idle,
+// interval, and count can be set independently.
+func setTCPKeepalives(conn net.Conn, cfg Config) error {
+	if !cfg.hasKeepaliveSettings() {
+		return nil
+	}
+	tc, ok := asTCPConn(conn)
+	if !ok {
+		return nil
+	}
+
+	// keepalives=0 disables client-side TCP keepalives.
+	// keepalives_idle/interval/count alone leave keepalives enabled (libpq).
+	if cfg.isset("keepalives") && !cfg.Keepalives {
+		return tc.SetKeepAlive(false)
+	}
+
+	// Zero Idle/Interval/Count leave Go/OS defaults (see [net.KeepAliveConfig]).
+	return tc.SetKeepAliveConfig(net.KeepAliveConfig{
+		Enable:   true,
+		Idle:     cfg.KeepalivesIdle,
+		Interval: cfg.KeepalivesInterval,
+		Count:    cfg.KeepalivesCount,
+	})
+}
+
+// hasKeepaliveSettings reports whether any TCP keepalive option was configured
+// (via DSN parsing or non-zero/true fields on [Config]).
+func (cfg Config) hasKeepaliveSettings() bool {
+	if cfg.isset("keepalives") || cfg.isset("keepalives_idle") ||
+		cfg.isset("keepalives_interval") || cfg.isset("keepalives_count") {
+		return true
+	}
+	return cfg.Keepalives || cfg.KeepalivesIdle != 0 || cfg.KeepalivesInterval != 0 || cfg.KeepalivesCount != 0
+}
+
+// asTCPConn returns the underlying *net.TCPConn if conn is one or unwraps to
+// one (e.g. via NetConn() as on [*tls.Conn]).
+func asTCPConn(conn net.Conn) (*net.TCPConn, bool) {
+	for conn != nil {
+		if tc, ok := conn.(*net.TCPConn); ok {
+			return tc, true
+		}
+		// *tls.Conn and similar wrappers.
+		type netConner interface{ NetConn() net.Conn }
+		if nc, ok := conn.(netConner); ok {
+			conn = nc.NetConn()
+			continue
+		}
+		return nil, false
+	}
+	return nil, false
 }
 
 func (cn *conn) isInTransaction() bool {

--- a/conn_test.go
+++ b/conn_test.go
@@ -505,6 +505,163 @@ func TestErrorDuringStartupClosesConn(t *testing.T) {
 	}
 }
 
+func TestSetTCPKeepalives(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Accept in background so Dial can complete.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		// Hold the connection open until the test finishes with it.
+		io.Copy(io.Discard, c)
+	}()
+
+	raw, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+
+	tc, ok := raw.(*net.TCPConn)
+	if !ok {
+		t.Fatalf("Dial returned %T, want *net.TCPConn", raw)
+	}
+
+	t.Run("noop when unset", func(t *testing.T) {
+		if err := setTCPKeepalives(tc, Config{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("enable with tuning", func(t *testing.T) {
+		cfg, err := newConfig("keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=4", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := setTCPKeepalives(tc, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("disable", func(t *testing.T) {
+		cfg, err := newConfig("keepalives=0", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := setTCPKeepalives(tc, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("idle alone enables", func(t *testing.T) {
+		cfg, err := newConfig("keepalives_idle=15", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := setTCPKeepalives(tc, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("config fields without isset", func(t *testing.T) {
+		cfg := Config{
+			Keepalives:         true,
+			KeepalivesIdle:     20 * time.Second,
+			KeepalivesInterval: 5 * time.Second,
+			KeepalivesCount:    3,
+		}
+		if err := setTCPKeepalives(tc, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("non-TCP is ignored", func(t *testing.T) {
+		cfg, err := newConfig("keepalives=1", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Unix-style pipe is not *net.TCPConn.
+		c1, c2 := net.Pipe()
+		defer c1.Close()
+		defer c2.Close()
+		if err := setTCPKeepalives(c1, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("asTCPConn unwraps NetConn", func(t *testing.T) {
+		type wrap struct {
+			net.Conn
+		}
+		// Plain embedding does not implement NetConn; asTCPConn should fail.
+		if _, ok := asTCPConn(wrap{Conn: tc}); ok {
+			t.Fatal("expected unwrap failure for plain embedding")
+		}
+
+		w := netConnerWrap{inner: tc}
+		got, ok := asTCPConn(w)
+		if !ok || got != tc {
+			t.Fatalf("asTCPConn unwrap: ok=%v got=%v want=%v", ok, got, tc)
+		}
+	})
+
+	raw.Close()
+	<-done
+}
+
+// netConnerWrap is a test double for connections that expose NetConn()
+// (as *tls.Conn does).
+type netConnerWrap struct {
+	inner net.Conn
+}
+
+func (w netConnerWrap) Read(b []byte) (int, error)         { return w.inner.Read(b) }
+func (w netConnerWrap) Write(b []byte) (int, error)        { return w.inner.Write(b) }
+func (w netConnerWrap) Close() error                       { return w.inner.Close() }
+func (w netConnerWrap) LocalAddr() net.Addr                { return w.inner.LocalAddr() }
+func (w netConnerWrap) RemoteAddr() net.Addr               { return w.inner.RemoteAddr() }
+func (w netConnerWrap) SetDeadline(t time.Time) error      { return w.inner.SetDeadline(t) }
+func (w netConnerWrap) SetReadDeadline(t time.Time) error  { return w.inner.SetReadDeadline(t) }
+func (w netConnerWrap) SetWriteDeadline(t time.Time) error { return w.inner.SetWriteDeadline(t) }
+func (w netConnerWrap) NetConn() net.Conn                  { return w.inner }
+
+func TestHasKeepaliveSettings(t *testing.T) {
+	t.Parallel()
+	if (Config{}).hasKeepaliveSettings() {
+		t.Error("empty Config should not report keepalive settings")
+	}
+	if !(Config{Keepalives: true}).hasKeepaliveSettings() {
+		t.Error("Keepalives true should report settings")
+	}
+	if !(Config{KeepalivesIdle: time.Second}).hasKeepaliveSettings() {
+		t.Error("KeepalivesIdle should report settings")
+	}
+	if !(Config{KeepalivesInterval: time.Second}).hasKeepaliveSettings() {
+		t.Error("KeepalivesInterval should report settings")
+	}
+	if !(Config{KeepalivesCount: 1}).hasKeepaliveSettings() {
+		t.Error("KeepalivesCount should report settings")
+	}
+	cfg, err := newConfig("keepalives=0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.hasKeepaliveSettings() {
+		t.Error("keepalives=0 should report settings (to disable)")
+	}
+}
+
 func TestBadConn(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []error{io.EOF, &Error{Severity: pqerror.SeverityFatal}, io.ErrUnexpectedEOF} {

--- a/connector.go
+++ b/connector.go
@@ -408,6 +408,30 @@ type Config struct {
 	// specified means wait indefinitely
 	ConnectTimeout time.Duration `postgres:"connect_timeout" env:"PGCONNECT_TIMEOUT"`
 
+	// Controls whether client-side TCP keepalives are used. The default is to
+	// leave the dialer's keepalive settings unchanged (Go's [net.Dialer] enables
+	// keepalives by default). Set to true to enable with optional
+	// KeepalivesIdle/Interval/Count, or false to disable. Ignored for
+	// Unix-domain sockets and non-TCP connections.
+	//
+	// Matches libpq's keepalives parameter (1=on, 0=off).
+	Keepalives bool `postgres:"keepalives" env:"-"`
+
+	// Seconds of inactivity after which TCP sends a keepalive probe. Zero uses
+	// the system/Go default. Ignored for Unix-domain sockets or when keepalives
+	// are disabled. Matches libpq's keepalives_idle.
+	KeepalivesIdle time.Duration `postgres:"keepalives_idle" env:"-"`
+
+	// Seconds between keepalive retransmissions when a probe is not
+	// acknowledged. Zero uses the system/Go default. Matches libpq's
+	// keepalives_interval.
+	KeepalivesInterval time.Duration `postgres:"keepalives_interval" env:"-"`
+
+	// Number of unacknowledged keepalive probes before the connection is
+	// considered dead. Zero uses the system/Go default. Matches libpq's
+	// keepalives_count.
+	KeepalivesCount int `postgres:"keepalives_count" env:"-"`
+
 	// Whether to always send []byte parameters over as binary. Enables single
 	// round-trip mode for non-prepared Query calls. This is a pq extension, not
 	// supported in libpq.
@@ -885,6 +909,8 @@ func (cfg *Config) setFromTag(o map[string]string, tag string, service bool) err
 			rv                    = values.Field(i)
 			k                     = rt.Tag.Get(tag)
 			connectTimeout        = (tag == "postgres" && k == "connect_timeout") || (tag == "env" && k == "PGCONNECT_TIMEOUT")
+			keepalivesIdle        = tag == "postgres" && k == "keepalives_idle"
+			keepalivesInterval    = tag == "postgres" && k == "keepalives_interval"
 			host                  = (tag == "postgres" && k == "host") || (tag == "env" && k == "PGHOST")
 			hostaddr              = (tag == "postgres" && k == "hostaddr") || (tag == "env" && k == "PGHOSTADDR")
 			port                  = (tag == "postgres" && k == "port") || (tag == "env" && k == "PGPORT")
@@ -897,6 +923,7 @@ func (cfg *Config) setFromTag(o map[string]string, tag string, service bool) err
 			sslminprotocolversion = (tag == "postgres" && k == "ssl_min_protocol_version") || (tag == "env" && k == "PGSSLMINPROTOCOLVERSION")
 			sslmaxprotocolversion = (tag == "postgres" && k == "ssl_max_protocol_version") || (tag == "env" && k == "PGSSLMAXPROTOCOLVERSION")
 			requireauth           = (tag == "postgres" && k == "require_auth") || (tag == "env" && k == "PGREQUIREAUTH")
+			durationSeconds       = connectTimeout || keepalivesIdle || keepalivesInterval
 		)
 		if k == "" || k == "-" {
 			continue
@@ -995,12 +1022,12 @@ func (cfg *Config) setFromTag(o map[string]string, tag string, service bool) err
 					}
 					rv.Set(reflect.ValueOf(s))
 				}
-			case reflect.Int64:
+			case reflect.Int, reflect.Int64:
 				n, err := strconv.ParseInt(v, 10, 64)
 				if err != nil {
 					return fmt.Errorf(f+"%w", k, err)
 				}
-				if connectTimeout {
+				if durationSeconds {
 					n = int64(time.Duration(n) * time.Second)
 				}
 				rv.SetInt(n)
@@ -1087,9 +1114,10 @@ func (cfg Config) tomap() map[string]string {
 			case reflect.Uint16:
 				n := rv.Uint()
 				o[k] = strconv.FormatUint(n, 10)
-			case reflect.Int64:
+			case reflect.Int, reflect.Int64:
 				n := rv.Int()
-				if k == "connect_timeout" {
+				switch k {
+				case "connect_timeout", "keepalives_idle", "keepalives_interval":
 					n = int64(time.Duration(n) / time.Second)
 				}
 				o[k] = strconv.FormatInt(n, 10)

--- a/connector_test.go
+++ b/connector_test.go
@@ -444,6 +444,23 @@ func TestNewConfig(t *testing.T) {
 		{"require_auth=!md5,!scram-sha-256", nil, "require_auth=!md5,!scram-sha-256", ""},
 		{"require_auth=md5,!password", nil, "", `negative require_auth method "!password" cannot be mixed with non-negative methods`},
 		{"require_auth=!md5,password", nil, "", `require_auth method "password" cannot be mixed with negative methods`},
+
+		// TCP keepalives (libpq)
+		{"keepalives=1", nil, "keepalives=yes", ""},
+		{"keepalives=0", nil, "keepalives=no", ""},
+		{"keepalives=yes", nil, "keepalives=yes", ""},
+		{"keepalives=off", nil, "keepalives=no", ""},
+		{"keepalives=maybe", nil, "", `pq: wrong value for "keepalives": strconv.ParseBool: parsing "maybe": invalid syntax`},
+		{"keepalives_idle=30", nil, "keepalives_idle=30", ""},
+		{"keepalives_interval=10", nil, "keepalives_interval=10", ""},
+		{"keepalives_count=5", nil, "keepalives_count=5", ""},
+		{"keepalives=1 keepalives_idle=60 keepalives_interval=10 keepalives_count=3", nil,
+			"keepalives=yes keepalives_count=3 keepalives_idle=60 keepalives_interval=10", ""},
+		{"keepalives_idle=abc", nil, "", `pq: wrong value for "keepalives_idle": strconv.ParseInt: parsing "abc": invalid syntax`},
+		{"keepalives_count=1.5", nil, "", `pq: wrong value for "keepalives_count": strconv.ParseInt: parsing "1.5": invalid syntax`},
+		// Must not leak into runtime parameters.
+		{"keepalives=1 keepalives_idle=1 search_path=public", nil,
+			"keepalives=yes keepalives_idle=1 search_path=public", ""},
 	}
 
 	t.Parallel()
@@ -478,6 +495,32 @@ func TestNewConfig(t *testing.T) {
 			if have.ConnectTimeout != 4*time.Second {
 				t.Errorf("\nhave: %q\nwant: %q", have.ConnectTimeout, 4*time.Second)
 			}
+		}
+	})
+
+	// Keepalive durations are seconds; keepalives_count is an int.
+	t.Run("keepalives", func(t *testing.T) {
+		have, err := newConfig("keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=5", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !have.Keepalives {
+			t.Error("Keepalives: want true")
+		}
+		if have.KeepalivesIdle != 30*time.Second {
+			t.Errorf("KeepalivesIdle: have %v want %v", have.KeepalivesIdle, 30*time.Second)
+		}
+		if have.KeepalivesInterval != 10*time.Second {
+			t.Errorf("KeepalivesInterval: have %v want %v", have.KeepalivesInterval, 10*time.Second)
+		}
+		if have.KeepalivesCount != 5 {
+			t.Errorf("KeepalivesCount: have %d want 5", have.KeepalivesCount)
+		}
+		if _, ok := have.Runtime["keepalives"]; ok {
+			t.Error("keepalives must not be a runtime parameter")
+		}
+		if _, ok := have.Runtime["keepalives_idle"]; ok {
+			t.Error("keepalives_idle must not be a runtime parameter")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Implements client-side TCP keepalive support for long-running queries (e.g. behind NATs, load balancers, or Redshift), addressing #360.

This supersedes the stale approach in #999 (2020). That PR wired `net.Dialer.KeepAlive` only (idle and interval forced to the same value, no count). This implementation:

- Uses libpq connection parameter names: `keepalives`, `keepalives_idle`, `keepalives_interval`, `keepalives_count`
- Applies settings after dial on `*net.TCPConn` via `SetKeepAlive` / `SetKeepAliveConfig` (Go 1.23+), so idle, interval, and count can be set independently
- Works with any dialer that returns a TCP connection (or a `NetConn()` wrapper such as `*tls.Conn`)
- Leaves dialer defaults alone when parameters are omitted; ignores Unix sockets / non-TCP
- Does not send keepalive keys as startup runtime parameters

Example:

```
postgres://…?keepalives=1&keepalives_idle=30&keepalives_interval=10&keepalives_count=5
```

Fields are also available on `pq.Config`.

## Test plan

- [x] Unit tests for DSN parsing (seconds → duration, count as int, invalid values, not leaked into `Runtime`)
- [x] Unit tests for `setTCPKeepalives` against a real local TCP listener (enable/disable/tuning/non-TCP/no-op/NetConn unwrap)
- [ ] CI against lib/pq

Fixes #360