### PR TITLE
Return an error for unknown column format codes

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -58,7 +58,7 @@ func decode(ps *parameterStatus, s []byte, typ oid.Oid, f format) (any, error) {
 	case formatText:
 		return textDecode(ps, s, typ)
 	default:
-		panic("unreachable")
+		return nil, fmt.Errorf("pq: unknown column format code %d", f)
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -303,6 +303,8 @@ func TestDecode(t *testing.T) {
 		{oid.T_text, formatText, []byte("hello world"), "hello world", ``},
 
 		{oid.T_uuid, formatBinary, []byte{0x12, 0x34}, ([]byte)(nil), `pq: unable to decode uuid; bad length: 2`},
+
+		{oid.T_text, format(2), []byte("x"), nil, `pq: unknown column format code 2`},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
`decode` used `panic("unreachable")` for unknown column format codes. That can be reached when a server (or test double) sends a format code other than text/binary. Return an error from the decode path instead.

Fixes #1328

## Test plan
- [x] Extended `TestDecode` with format code 2
- [x] `go test -run '^TestDecode$' .` (unit cases pass; package TestMain needs a live Postgres for a full exit 0)
