### PR TITLE
Split off scram/ package to internal/scram/

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--- Files in scram/ and internal/scram/ based on https://github.com/go-mgo/mgo/tree/v2/internal/scram ---
+
+Copyright (c) 2014 - Gustavo Niemeyer <gustavo@niemeyer.net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/conn.go
+++ b/conn.go
@@ -25,8 +25,8 @@ import (
 	"github.com/lib/pq/internal/pqsql"
 	"github.com/lib/pq/internal/pqutil"
 	"github.com/lib/pq/internal/proto"
+	"github.com/lib/pq/internal/scram"
 	"github.com/lib/pq/oid"
-	"github.com/lib/pq/scram"
 )
 
 // Common error types

--- a/internal/scram/scram.go
+++ b/internal/scram/scram.go
@@ -1,7 +1,6 @@
-// Package scram implements a SCRAM client per RFC5802.
+// Package scram implements a SCRAM-{SHA-1,etc} client per RFC5802.
 //
-// Deprecated: never intended to be exported. This package is frozen and not
-// used by pq.
+// http://tools.ietf.org/html/rfc5802
 package scram
 
 import (
@@ -15,19 +14,39 @@ import (
 	"strings"
 )
 
+// Client implements a SCRAM-* client (SCRAM-SHA-1, SCRAM-SHA-256, etc).
+//
+// A Client may be used within a SASL conversation with logic resembling:
+//
+//	var in []byte
+//	var client = scram.NewClient(sha1.New, user, pass)
+//	for client.Step(in) {
+//	        out := client.Out()
+//	        // send out to server
+//	        in := serverOut
+//	}
+//	if client.Err() != nil {
+//	        // auth failed
+//	}
 type Client struct {
-	newHash     func() hash.Hash
-	user        string
-	pass        string
-	step        int
-	out         bytes.Buffer
-	err         error
+	newHash func() hash.Hash
+	user    string
+	pass    string
+	step    int
+	out     bytes.Buffer
+	err     error
+
 	clientNonce []byte
 	serverNonce []byte
 	saltedPass  []byte
 	authMsg     bytes.Buffer
 }
 
+// NewClient returns a new SCRAM-* client with the provided hash algorithm.
+//
+// For SCRAM-SHA-256, for example, use:
+//
+//	client := scram.NewClient(sha256.New, user, pass)
 func NewClient(newHash func() hash.Hash, user, pass string) *Client {
 	c := &Client{newHash: newHash, user: user, pass: pass}
 	c.out.Grow(256)
@@ -35,6 +54,10 @@ func NewClient(newHash func() hash.Hash, user, pass string) *Client {
 	return c
 }
 
+// Set client nonce for tests.
+func (c *Client) setNonce(nonce []byte) { c.clientNonce = nonce }
+
+// Out returns the data to be sent to the server in the current step.
 func (c *Client) Out() []byte {
 	if c.out.Len() == 0 {
 		return nil
@@ -42,12 +65,15 @@ func (c *Client) Out() []byte {
 	return c.out.Bytes()
 }
 
+// Err returns the error that occurred, or nil if there were no errors.
 func (c *Client) Err() error { return c.err }
-
-func (c *Client) SetNonce(nonce []byte) { c.clientNonce = nonce }
 
 var escaper = strings.NewReplacer("=", "=3D", ",", "=2C")
 
+// Step processes the incoming data from the server and makes the
+// next round of data for the server available via Client.Out.
+// Step returns false if there are no errors and more data is
+// still expected.
 func (c *Client) Step(in []byte) bool {
 	c.out.Reset()
 	if c.step > 2 || c.err != nil {
@@ -56,39 +82,38 @@ func (c *Client) Step(in []byte) bool {
 	c.step++
 	switch c.step {
 	case 1:
-		c.err = c.step1(in)
+		c.err = c.stepClientFirst(in)
 	case 2:
-		c.err = c.step2(in)
+		c.err = c.stepServerFirst(in)
 	case 3:
-		c.err = c.step3(in)
+		c.err = c.stepServerFinal(in)
 	}
 	return c.step > 2 || c.err != nil
 }
 
-func (c *Client) step1(in []byte) error {
+func (c *Client) stepClientFirst(in []byte) error {
 	if len(c.clientNonce) == 0 {
 		const nonceLen = 16
-		buf := make([]byte, nonceLen+b64.EncodedLen(nonceLen))
-		if _, err := rand.Read(buf[:nonceLen]); err != nil {
-			return fmt.Errorf("cannot read random SCRAM-SHA-256 nonce from operating system: %w", err)
-		}
+		buf := make([]byte, nonceLen+base64.StdEncoding.EncodedLen(nonceLen))
+		rand.Read(buf[:nonceLen]) // Never returns error.
 		c.clientNonce = buf[nonceLen:]
-		b64.Encode(c.clientNonce, buf[:nonceLen])
+		base64.StdEncoding.Encode(c.clientNonce, buf[:nonceLen])
 	}
 	c.authMsg.WriteString("n=")
 	escaper.WriteString(&c.authMsg, c.user)
 	c.authMsg.WriteString(",r=")
 	c.authMsg.Write(c.clientNonce)
+
 	c.out.WriteString("n,,")
 	c.out.Write(c.authMsg.Bytes())
 	return nil
 }
 
-var b64 = base64.StdEncoding
-
-func (c *Client) step2(in []byte) error {
+// Also writes client-final message
+func (c *Client) stepServerFirst(in []byte) error {
 	c.authMsg.WriteByte(',')
 	c.authMsg.Write(in)
+
 	fields := bytes.Split(in, []byte(","))
 	if len(fields) != 3 {
 		return fmt.Errorf("expected 3 fields in first SCRAM-SHA-256 server message, got %d: %q", len(fields), in)
@@ -102,12 +127,14 @@ func (c *Client) step2(in []byte) error {
 	if !bytes.HasPrefix(fields[2], []byte("i=")) || len(fields[2]) < 6 {
 		return fmt.Errorf("server sent an invalid SCRAM-SHA-256 iteration count: %q", fields[2])
 	}
+
 	c.serverNonce = fields[0][2:]
 	if !bytes.HasPrefix(c.serverNonce, c.clientNonce) {
 		return fmt.Errorf("server SCRAM-SHA-256 nonce is not prefixed by client nonce: got %q, want %q+\"...\"", c.serverNonce, c.clientNonce)
 	}
-	salt := make([]byte, b64.DecodedLen(len(fields[1][2:])))
-	n, err := b64.Decode(salt, fields[1][2:])
+
+	salt := make([]byte, base64.StdEncoding.DecodedLen(len(fields[1][2:])))
+	n, err := base64.StdEncoding.Decode(salt, fields[1][2:])
 	if err != nil {
 		return fmt.Errorf("cannot decode SCRAM-SHA-256 salt sent by server: %q", fields[1])
 	}
@@ -117,6 +144,8 @@ func (c *Client) step2(in []byte) error {
 		return fmt.Errorf("server sent an invalid SCRAM-SHA-256 iteration count: %q", fields[2])
 	}
 	c.saltPassword(salt, iterCount)
+
+	// Write client-final message.
 	c.authMsg.WriteString(",c=biws,r=")
 	c.authMsg.Write(c.serverNonce)
 	c.out.WriteString("c=biws,r=")
@@ -126,7 +155,7 @@ func (c *Client) step2(in []byte) error {
 	return nil
 }
 
-func (c *Client) step3(in []byte) error {
+func (c *Client) stepServerFinal(in []byte) error {
 	var isv, ise bool
 	var fields = bytes.Split(in, []byte(","))
 	if len(fields) == 1 {
@@ -175,8 +204,8 @@ func (c *Client) clientProof() []byte {
 	for i, b := range clientKey {
 		clientProof[i] ^= b
 	}
-	clientProof64 := make([]byte, b64.EncodedLen(len(clientProof)))
-	b64.Encode(clientProof64, clientProof)
+	clientProof64 := make([]byte, base64.StdEncoding.EncodedLen(len(clientProof)))
+	base64.StdEncoding.Encode(clientProof64, clientProof)
 	return clientProof64
 }
 
@@ -184,10 +213,12 @@ func (c *Client) serverSignature() []byte {
 	mac := hmac.New(c.newHash, c.saltedPass)
 	mac.Write([]byte("Server Key"))
 	serverKey := mac.Sum(nil)
+
 	mac = hmac.New(c.newHash, serverKey)
 	mac.Write(c.authMsg.Bytes())
 	serverSignature := mac.Sum(nil)
-	encoded := make([]byte, b64.EncodedLen(len(serverSignature)))
-	b64.Encode(encoded, serverSignature)
+
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(serverSignature)))
+	base64.StdEncoding.Encode(encoded, serverSignature)
 	return encoded
 }

--- a/internal/scram/scram_test.go
+++ b/internal/scram/scram_test.go
@@ -1,0 +1,67 @@
+package scram
+
+import (
+	"crypto/sha1"
+	"strings"
+	"testing"
+)
+
+func TestExamples(t *testing.T) {
+	tests := [][]string{
+		{
+			"U: user pencil",
+			"N: fyko+d2lbbFgONRv9qkxdawL",
+			"C: n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL",
+			"S: r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096",
+			"C: c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=",
+			"S: v=rmF9pqV8S7suAoZWja4dJRkFsKQ=",
+		},
+		{
+			"U: root fe8c89e308ec08763df36333cbf5d3a2",
+			"N: OTcxNDk5NjM2MzE5",
+			"C: n,,n=root,r=OTcxNDk5NjM2MzE5",
+			"S: r=OTcxNDk5NjM2MzE581Ra3provgG0iDsMkDiIAlrh4532dDLp,s=XRDkVrFC9JuL7/F4tG0acQ==,i=10000",
+			"C: c=biws,r=OTcxNDk5NjM2MzE581Ra3provgG0iDsMkDiIAlrh4532dDLp,p=6y1jp9R7ETyouTXS9fW9k5UHdBc=",
+			"S: v=LBnd9dUJRxdqZiEq91NKP3z/bHA=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			auth := strings.Fields(tt[0][3:])
+			client := NewClient(sha1.New, auth[0], auth[1])
+			first, done := true, false
+			for _, step := range tt[1:] {
+				switch step[:3] {
+				case "N: ":
+					client.setNonce([]byte(step[3:]))
+				case "C: ":
+					if first {
+						first = false
+						done = client.Step(nil)
+					}
+					if done {
+						t.Fatal()
+					}
+					if client.Err() != nil {
+						t.Fatal(client.Err())
+					}
+					if have := client.Out(); string(have) != string(step[3:]) {
+						t.Fatalf("\nhave: %q\nwant: %q", have, step[3:])
+					}
+				case "S: ":
+					first = false
+					done = client.Step([]byte(step[3:]))
+				default:
+					t.Fatalf("invalid test line: %q", step)
+				}
+			}
+			if !done {
+				t.Fatal()
+			}
+			if client.Err() != nil {
+				t.Fatal(client.Err())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This never should have been exported, but people can and do import this.

Mark scram/ as deprecated and frozen, and copy to internal/scram/. This way this can be worked on without worrying about compatibility.

Also add test case from upstream here.